### PR TITLE
Improve the user documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,21 @@ It supports Java, Clojure, Scala, JRuby, and anything else that runs on the JVM.
 If you use Maven, you can simply reference the following
 assets:
 
-  * The Client
+  * [The Client](http://mvnrepository.com/artifact/io.prometheus/client)
     * groupId: _io.prometheus_
     * artifactId: _client_
-    * version: _0.0.2-SNAPSHOT_
-  * Hotspot VM Metrics
+    * version: _0.0.2_
+  * [Hotspot VM Metrics](http://mvnrepository.com/artifact/io.prometheus.client.utility/hotspot)
     * groupId: _io.prometheus.client.utility_
     * artifactId: _hotspot_
-    * version: _0.0.2-SNAPSHOT_
-  * Exposition Servlet - Transferring Metrics to Prometheus Servers
+    * version: _0.0.2_
+  * [Exposition Servlet](http://mvnrepository.com/artifact/io.prometheus.client.utility/servlet) - Transferring Metrics to Prometheus Servers
     * groupId: _io.prometheus.client.utility_
     * artifactId: _servlet_
-    * version: _0.0.2-SNAPSHOT_
+    * version: _0.0.2_
 
 ### Getting Started
 There are canonical examples defined in the class definition Javadoc headers in the _io.prometheus.client.metrics_ package.
-
-## Building
-
-    $ mvn compile
-
-## Testing
-
-    $ mvn test
 
 ## Documentation
 The client is canonically documented with Javadoc.  Running the following will produce output local documentation
@@ -38,6 +30,71 @@ in _apidocs_ directories for you to read.
 
 If you use the Mavenized version of the Prometheus client, you can also instruct Maven to download the Javadoc and
 source artifacts.
+
+<strong>Alternatively</strong>, you can also look at the generated [Java Client
+Github Project Page](http://prometheus.github.io/client_java), but the raw
+Javadoc in Java source in version control should be treated as the canonical
+form of documentation.
+
+## Maintenance of this Library
+This suite is built and managed by [Maven](http://maven.apache.org), and the
+artifacts are hosted on the [Sonatype OSS Asset Repository](https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide).
+
+### Building
+
+    $ mvn compile
+
+### Testing
+
+    $ mvn test
+
+Please note that tests on Travis may be unreliable due to the absence of
+installed Maven artifacts.  Ensure that the current snapshot version is
+deployed to Sonatype OSS Repository.
+
+###  Deployment
+These steps below are only useful if you are in a release engineering capacity
+and want to publicize these changes for external users.  You will also need to
+have your local Maven setup correctly along with valid and public GPG key and
+adequate authorization on the Sonatype OSS Repository to submit new artifacts,
+be they _staging_ or _release_ ones.
+
+#### Staging
+    $  mvn clean deploy -DperformRelease=true
+
+#### Release
+    $ mvn release:clean -DperformRelease=true
+    $ mvn release:prepare -DperformRelease=true
+    $ mvn release:perform -DperformRelease=true
+
+#### Documentation
+Documentation can also be released to the public via the Github Pages subproduct
+through the magic _gh-pages_ branch for a Github project.  Documentation is
+generated via the following command:
+
+    $ mvn javadoc:aggregate
+
+It will need to be automatically merged into the _gh-pages_ branch, but that is
+as simple as this:
+
+    $ git checkout master
+    $ mvn javadoc:aggregate
+    $ git checkout gh-pages
+    $ mv target/site/apidocs/ ./
+    $ git status
+    $ # Amend the branch as necessary.
+    $ git commit
+    $ git push
+
+There is a Maven plugin to perform this work, but it is broken.  The
+javadoc:aggregate step will emit documentation into
+_target/site/apidocs_.  The reason that we use this aggregate step instead
+of bare javadoc is that we want one comprehensive Javadoc emission that includes
+all Maven submodules versus trying to manually concatenate this together.
+
+Output documentation lives in the [Java Client Github Project
+Page](http://prometheus.github.io/client_java).
+
 
 ## Contact
   * All of the core developers are accessible via the [Prometheus Developers Mailinglist](https://groups.google.com/forum/?fromgroups#!forum/prometheus-developers).

--- a/client/src/main/java/io/prometheus/client/metrics/Metric.java
+++ b/client/src/main/java/io/prometheus/client/metrics/Metric.java
@@ -396,7 +396,7 @@ public abstract class Metric<M extends Metric, C extends Metric.Child, P extends
   /**
    * <p>
    * {@link Partial} is an <em>incomplete incarnation</em> of a
-   * {@link Metric.Child} that you add label value pair registerStatic to with
+   * {@link Metric.Child} that you add label value pair to with
    * {@link #labelPair(String, String)}. They are used to provide measurements
    * in a trace-like fashion where the outcomes are not known a priori, and the
    * outcomes affect what label pairs the metric shall have.
@@ -413,12 +413,12 @@ public abstract class Metric<M extends Metric, C extends Metric.Child, P extends
    *       Summary
    *           .newBuilder()
    *           .name(&quot;request_latency_ms&quot;)
-   *           // There are three distinct registerStatic we care about:
+   *           // There are three distinct labelNames we care about:
    *           // - operation: What type of operation are we handling?
    *           // - result: What was its outcome?
    *           // - shard: What remote storage shard was used in answering this
    *           // request?
-   *           .registerStatic(&quot;operation&quot;, &quot;result&quot;, &quot;shard&quot;)
+   *           .labelNames(&quot;operation&quot;, &quot;result&quot;, &quot;shard&quot;)
    *           .documentation(
    *               &quot;Latency quantiles for requests partitioned by 'operation' type, 'result' disposition, and storage 'shard' name.&quot;)
    *           .build();
@@ -441,21 +441,21 @@ public abstract class Metric<M extends Metric, C extends Metric.Child, P extends
    *
    *   private void doCreate(CreateReq r, Summary.Partial t) throws StorageException {
    *     String shard = shardMap.getForReq(r);
-   *     op.registerStatic(&quot;shard&quot;, shard);
+   *     op.labelNames(&quot;shard&quot;, shard);
    *     // Do our work: Create the entity in the remote shard.
    *   }
    *
    *   public void handleDelete(DeleteReq r) {
-   *     Summary.Partial op = latencies.newPartial().registerStatic(&quot;operation&quot;, &quot;delete&quot;);
+   *     Summary.Partial op = latencies.newPartial().labelNames(&quot;operation&quot;, &quot;delete&quot;);
    *     long start = System.currentTimeMillis();
    *
    *     try {
    *       doDelete(shard, r);
-   *       op.registerStatic(&quot;result&quot;, &quot;success&quot;);
+   *       op.labelName(&quot;result&quot;, &quot;success&quot;);
    *     } catch (StorageException e) {
-   *       op.registerStatic(&quot;result&quot;, &quot;storage_failure&quot;);
+   *       op.labelNames(&quot;result&quot;, &quot;storage_failure&quot;);
    *     } catch (RuntimeException e) {
-   *       op.registerStatic(&quot;result&quot;, &quot;unknown_error&quot;);
+   *       op.labelNames(&quot;result&quot;, &quot;unknown_error&quot;);
    *     } finally {
    *       op.apply().observe(System.currentTimeMillis() - start);
    *     }
@@ -463,7 +463,7 @@ public abstract class Metric<M extends Metric, C extends Metric.Child, P extends
    *
    *   private void doDelete(deleteReq r, Summary.Partial t) throws StorageException {
    *     String shard = shardMap.getForReq(r);
-   *     op.registerStatic(&quot;shard&quot;, shard);
+   *     op.labelNames(&quot;shard&quot;, shard);
    *     // Do our work: delete the entity in the remote shard.
    *   }
    *
@@ -545,7 +545,7 @@ public abstract class Metric<M extends Metric, C extends Metric.Child, P extends
    * <li>
    * If there is a mismatch between the number of labels that have been
    * accumulated with {@link #labelPair(String, String)} and those defined in
-   * the underlying {@code Builder#registerStatic}, a runtime exception will
+   * the underlying {@code Builder#labelNames}, a runtime exception will
    * occur, signifying illegal use.</li>
    * </ul>
    * </p>
@@ -680,7 +680,7 @@ public abstract class Metric<M extends Metric, C extends Metric.Child, P extends
 
   @Override
   public String toString() {
-    return String.format("Metric{name='%s', registerStatic=%s}", name, labelNames);
+    return String.format("Metric{name='%s', labelNames=%s}", name, labelNames);
   }
 
   /**


### PR DESCRIPTION
This commit fixes a couple of typos in the Javadoc, which resulted
from an automatic refactor process done in IntelliJ.  Documentation
should be more straightforward for users now!

Secondarily, the base README now includes notes about how to perform
releases and documentation updates if the engineer is somewhat
unfamiliar with Maven.
