### PR TITLE
Fix broken API contract for metric cloning.

### DIFF
--- a/client/src/main/java/io/prometheus/client/metrics/Counter.java
+++ b/client/src/main/java/io/prometheus/client/metrics/Counter.java
@@ -263,6 +263,11 @@ public class Counter extends Metric<Counter, Counter.Child, Counter.Partial> {
     }
 
     @Override
+    public Partial clone() {
+      return (Partial) super.clone();
+    }
+
+    @Override
     protected Counter.Child newChild() {
       return new Child();
     }

--- a/client/src/main/java/io/prometheus/client/metrics/Gauge.java
+++ b/client/src/main/java/io/prometheus/client/metrics/Gauge.java
@@ -271,6 +271,11 @@ public class Gauge extends Metric<Gauge, Gauge.Child, Gauge.Partial> {
     }
 
     @Override
+    public Partial clone() {
+      return (Partial) super.clone();
+    }
+
+    @Override
     protected Gauge.Child newChild() {
       return new Child();
     }

--- a/client/src/main/java/io/prometheus/client/metrics/Summary.java
+++ b/client/src/main/java/io/prometheus/client/metrics/Summary.java
@@ -324,6 +324,11 @@ public class Summary extends Metric<Summary, Summary.Child, Summary.Partial> {
     }
 
     @Override
+    public Partial clone() {
+      return (Partial) super.clone();
+    }
+
+    @Override
     protected Summary.Child newChild() {
       return new Child(targets);
     }


### PR DESCRIPTION
The `Metric` primitives support cloning of their mutation objects
by means of a call to `Metric.Child#clone`.  This has been an code path that
has seldom been used but was explicitly asked for by prospective users.
Unfortunately it was not tested thoroughly until recently, when it was
discovered that the exposed protocol to API consumers results in

```
Counter.Child#clone()  // yields Metric.Child
Gauge.Child#clone()    // yields Metric.Child
Summary.Child#clone()  // yields Metric.Child
```

and not

```
Counter.Child#clone()  // yields Counter.Child
Gauge.Child#clone()    // yields Gauge.Child
Summary.Child#clone()  // yields Summary.Child
```

This commit adds elementary workflow cases to ensure the promise of the
API.
