### PR TITLE
Internalize the internal telemetry for Prometheus.

### DIFF
--- a/client/src/main/java/io/prometheus/client/Telemetry.java
+++ b/client/src/main/java/io/prometheus/client/Telemetry.java
@@ -25,7 +25,7 @@ import io.prometheus.client.metrics.Summary;
  *
  * @author matt.proud@gmail.com (Matt T. Proud)
  */
-public class Telemetry {
+class Telemetry {
   @Register
   static final Gauge initializeTime = Gauge.newBuilder()
           .namespace("telemetry")


### PR DESCRIPTION
The class that defines the internal telemetry for Prometheus ought to
have remained invisible to outside users---namely the case of Javadoc
readers.  It has been turned to package private ("default access") to
support this use case.
