### PR TITLE
Enhance clarity in notes about metric export.

### DIFF
--- a/client/src/main/java/io/prometheus/client/Register.java
+++ b/client/src/main/java/io/prometheus/client/Register.java
@@ -21,19 +21,26 @@ import java.lang.annotation.Target;
 
 /**
  * <p>
- * Register {@link Metric} and their derivatives with the {@link Prometheus}
- * registrar across all runtime libraries and their dependencies.
+ * Register {@link io.prometheus.client.metrics.Metric} and their derivatives with the
+ * {@link Prometheus} registrar across all runtime libraries and their dependencies and the
+ * <em>class path</em>.
  * </p>
  *
  * <p>
- * The purpose of this <em>runtime</em> annotation is to provide a common
- * fragment to search for across an entire server's classpath for metrics to
- * export. Due to nuances in the underlying Java Virtual Machine
- * implementations, not every class referenced in an application's transitive
- * closure will be loaded.
- * <em>This can prevent telemetry from being found and registered!</em> Each
- * {@link Metric} decorated with {@link Metric} will be found and registered for
- * exposition across all libraries your server depends on.
+ * The purpose of this <em>runtime</em> annotation is to provide a common fragment to search for
+ * across an entire server's classpath for metrics to export.  Due to nuances in the underlying
+ * Java Virtual Machine implementations and behaviors around both class loading and initialization
+ * (i.e., behaviors outside of Prometheus' and your direct control), not every class referenced in
+ * an application's transitive closure and its classpath will be loaded and initialized, unless it
+ * is referenced by a dependent type, which is itself referenced by a root type in the
+ * application.</p>
+ *
+ * <p><strong>Not using this <em>optional</em> annotation may prevent expected telemetry from being
+ * found and registered</strong>!  This is to say, metric consumers may not find the metrics they
+ * want without it.  Each {@link io.prometheus.client.metrics.Metric} decorated with
+ * {@link Register} will be found and registered for exposition across all libraries your server
+ * depends on.  <strong>This registration property can be beneficial for authors of shared
+ * infrastructure libraries that are used by multiple teams</strong>!
  * </p>
  *
  * @author matt.proud@gmail.com (Matt T. Proud)

--- a/examples/random/src/main/java/io/prometheus/client/examples/random/Main.java
+++ b/examples/random/src/main/java/io/prometheus/client/examples/random/Main.java
@@ -30,14 +30,12 @@ import java.util.concurrent.TimeUnit;
  * @author matt.proud@gmail.com (Matt T. Proud)
  */
 public class Main {
-  @Register
   private static final Counter rpcCalls = Counter.newBuilder()
           .namespace("rpc")
           .name("calls_total")
           .documentation("The total number of RPC calls partitioned by RPC service.")
           .build();
 
-  @Register
   private static final Summary rpcLatency = Summary.newBuilder()
           .namespace("rpc")
           .name("latency_microseconds")


### PR DESCRIPTION
The original Metric export documentation was a little ambiguous in
parts.  This commit strengthens the optionalness of the use of the
runtime annotations but notes the legitimate use cases of it whereby
the Virtual Machine Specification will fall short and neither load nor
initialize classes of interest that may have metrics defined that an
application's consumer may care about.

This is likely to be a corner case that most users of Prometheus will
hopefully never encounter.  One cannot be too sure, though, with how
some of dynamic languages built on top of the Java Virtual Machine
generate their output classes, so this mechanism is offered as a
fallback.

In short, using this annotation is a good and safe practice.  Not
using it is fine in most cases but can put you at the perils of the
VMS and its loader behaviors.
