### PR TITLE
Include JCIP annotations for fundamentals types.

### DIFF
--- a/client/src/main/java/io/prometheus/client/AtomicDoubleSerializer.java
+++ b/client/src/main/java/io/prometheus/client/AtomicDoubleSerializer.java
@@ -20,6 +20,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.lang.reflect.Type;
 
 /**
@@ -30,6 +31,7 @@ import java.lang.reflect.Type;
  *
  * @author matt.proud@gmail.com (Matt T. Proud)
  */
+@ThreadSafe
 class AtomicDoubleSerializer implements JsonSerializer<AtomicDouble> {
   @Override
   public JsonElement serialize(final AtomicDouble src, final Type typeOfSrc,

--- a/client/src/main/java/io/prometheus/client/Prometheus.java
+++ b/client/src/main/java/io/prometheus/client/Prometheus.java
@@ -29,6 +29,7 @@ import org.reflections.scanners.FieldAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
@@ -63,6 +64,7 @@ import java.util.logging.Logger;
  * @see io.prometheus.client.metrics.Metric
  * @author matt.proud@gmail.com (Matt T. Proud)
  */
+@ThreadSafe
 public class Prometheus {
   private static final Logger log = Logger.getLogger(Prometheus.class.getName());
 

--- a/client/src/main/java/io/prometheus/client/metrics/Counter.java
+++ b/client/src/main/java/io/prometheus/client/metrics/Counter.java
@@ -20,6 +20,7 @@ import com.google.gson.*;
 import io.prometheus.client.Metrics;
 import io.prometheus.client.utility.labels.Reserved;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 import java.lang.reflect.Type;
 import java.util.List;
@@ -158,6 +159,7 @@ public class Counter extends Metric<Counter, Counter.Child, Counter.Partial> {
    * For all other behaviors, see {@link Metric.BaseBuilder}.
    * </p>
    */
+  @ThreadSafe
   public static class Builder implements Metric.Builder<Builder, Counter> {
     private static final Double DEFAULT_VALUE = Double.valueOf(0);
 
@@ -249,6 +251,7 @@ public class Counter extends Metric<Counter, Counter.Child, Counter.Partial> {
    *
    * @see Metric.Partial
    */
+  @NotThreadSafe
   public class Partial extends Metric.Partial {
     /**
      * <p>
@@ -289,6 +292,7 @@ public class Counter extends Metric<Counter, Counter.Child, Counter.Partial> {
    *
    * @see Metric.Child
    */
+  @ThreadSafe
   public class Child implements Metric.Child {
     final AtomicDouble value = new AtomicDouble();
 

--- a/client/src/main/java/io/prometheus/client/metrics/Gauge.java
+++ b/client/src/main/java/io/prometheus/client/metrics/Gauge.java
@@ -20,6 +20,7 @@ import com.google.gson.*;
 import io.prometheus.client.Metrics;
 import io.prometheus.client.utility.labels.Reserved;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 import java.lang.reflect.Type;
 import java.util.List;
@@ -168,6 +169,7 @@ public class Gauge extends Metric<Gauge, Gauge.Child, Gauge.Partial> {
    * For all other behaviors, see {@link Metric.BaseBuilder}.
    * </p>
    */
+  @ThreadSafe
   public static class Builder implements Metric.Builder<Builder, Gauge> {
     private static final Double DEFAULT_VALUE = Double.valueOf(0);
 
@@ -254,6 +256,7 @@ public class Gauge extends Metric<Gauge, Gauge.Child, Gauge.Partial> {
    *
    * @see Metric.Partial
    */
+  @NotThreadSafe
   public class Partial extends Metric.Partial {
     /**
      * <p>
@@ -296,6 +299,7 @@ public class Gauge extends Metric<Gauge, Gauge.Child, Gauge.Partial> {
    *
    * @see Metric.Child
    */
+  @ThreadSafe
   public class Child implements Metric.Child {
     final AtomicDouble value = new AtomicDouble();
 

--- a/client/src/main/java/io/prometheus/client/metrics/Summary.java
+++ b/client/src/main/java/io/prometheus/client/metrics/Summary.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 
 import com.google.common.base.Optional;
@@ -196,6 +197,7 @@ public class Summary extends Metric<Summary, Summary.Child, Summary.Partial> {
     return new Builder();
   }
 
+  @ThreadSafe
   public static class Builder implements Metric.Builder<Builder, Summary> {
     private static final Long DEFAULT_PURGE_INTERVAL = TimeUnit.MINUTES.toMillis(15);
     private static final ImmutableMap<Double, Double> DEFAULT_TARGETS = ImmutableMap.of(0.5, 0.05,
@@ -307,6 +309,7 @@ public class Summary extends Metric<Summary, Summary.Child, Summary.Partial> {
     }
   }
 
+  @NotThreadSafe
   public class Partial extends Metric.Partial {
     /**
      * <p>
@@ -334,6 +337,7 @@ public class Summary extends Metric<Summary, Summary.Child, Summary.Partial> {
     }
   }
 
+  @ThreadSafe
   public class Child implements Metric.Child {
     private final AtomicDouble sum = new AtomicDouble();
     private final AtomicLong count = new AtomicLong();


### PR DESCRIPTION
For some of the base metric types, we already had Java Concurrency in
Practice annotations, but they were not comprehensively canvassed.  In
the interests of promoting Javadoc documentation that is completely
self-contained, they should continue to be used.
