### PR TITLE
Include Maven artifacts in .gitignore blacklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 .idea
 *.iml
+
+target/


### PR DESCRIPTION
The Maven output should never distract us.
