### PR TITLE
Use observation buffering w/ new quant. esti.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.matttproud.quantile</groupId>
             <artifactId>quantile</artifactId>
-            <version>0.0.1</version>
+            <version>0.0.2</version>
         </dependency>
         <!-- Test Dependencies Follow -->
         <dependency>


### PR DESCRIPTION
This commit minimizes the concurrency control overhead that Flavio
reported while exercising a instrumented request handler in a tight
loop in synthetic load test.  This is achieved by the following:
1. Increasing the default quantile estimator buffer size to minimize
    the frequency of its internal compaction.  The estimator itself is
    not thread safe, so it requires coarse locking around it.  The less
    frequently it internally compacts and requires sample value
    producers to wait for it to perform this, the better.
2. Supporting buffering of samples on the client library side in a
    low-overhead way that decouples the quantile estimator compaction
    from most of the sample value producers.

Providing exact figures from microbenchmarks seems like a specious
enterprise, but it seems likely that this will reduce lock overhead
by minimally 95 percent.  I leave that as an exercise for the user.
