### PR TITLE
Include success of Javadoc gen. in test outcome.

### DIFF
--- a/Makefile.TRAVIS
+++ b/Makefile.TRAVIS
@@ -13,5 +13,6 @@ utility: client
 
 test: build
 	mvn test
+	mvn javadoc:aggregate
 
 .PHONY: build client examples test utility


### PR DESCRIPTION
Documentation is important; so if the Javadoc generator barfs for a
serious reason, which I know it will for JDK 8, we want to know.
