### PR TITLE
avoid blocking on partials creation

### DIFF
--- a/client/src/main/java/io/prometheus/client/metrics/Metric.java
+++ b/client/src/main/java/io/prometheus/client/metrics/Metric.java
@@ -635,11 +635,12 @@ public abstract class Metric<M extends Metric, C extends Metric.Child, P extends
 
     C baseApply() {
       final TreeMap<String, String> t = new TreeMap<String, String>(validate());
-      final C v = children.putIfAbsent(t, newChild());
-      if (v != null) {
-        return v;
+      C child = children.get(t);
+      if(child == null) { 
+    	  child = newChild();
+    	  children.put(t, child);
       }
-      return children.get(t);
+      return child;
     }
 
     @Override


### PR DESCRIPTION
On Java 8, the method ConcurrentHashMap.putIfAbsent uses a lock on the Node instance that is the representation of the map key, even if the element is already existent. This PR uses the get method to avoid blocking operations.

cc/ @juliusv @matttproud @grandbora @herval
