### PR TITLE
Initial version of new java client for prometheus.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,37 @@ It supports Java, Clojure, Scala, JRuby, and anything else that runs on the JVM.
 If you use Maven, you can simply reference the following
 assets:
 
-  * [The Client](http://mvnrepository.com/artifact/io.prometheus/client)
-    * groupId: _io.prometheus_
-    * artifactId: _client_
-    * version: _0.0.4_
-  * [Hotspot 'jvmstat/perfdata' Metrics](http://mvnrepository.com/artifact/io.prometheus.client.utility/jvmstat)
-    * groupId: _io.prometheus.client.utility_
-    * artifactId: _jvmstat_
-    * version: _0.0.4_
-  * [Hotspot VM Metrics](http://mvnrepository.com/artifact/io.prometheus.client.utility/hotspot)
-    * groupId: _io.prometheus.client.utility_
-    * artifactId: _hotspot_
-    * version: _0.0.4_
-  * [Exposition Servlet](http://mvnrepository.com/artifact/io.prometheus.client.utility/servlet) - Transferring Metrics to Prometheus Servers
-    * groupId: _io.prometheus.client.utility_
-    * artifactId: _servlet_
-    * version: _0.0.4_
+  * Original Client
+    * [The Client](http://mvnrepository.com/artifact/io.prometheus/client)
+      * groupId: _io.prometheus_
+      * artifactId: _client_
+      * version: _0.0.4_
+    * [Hotspot 'jvmstat/perfdata' Metrics](http://mvnrepository.com/artifact/io.prometheus.client.utility/jvmstat)
+      * groupId: _io.prometheus.client.utility_
+      * artifactId: _jvmstat_
+      * version: _0.0.4_
+    * [Hotspot VM Metrics](http://mvnrepository.com/artifact/io.prometheus.client.utility/hotspot)
+      * groupId: _io.prometheus.client.utility_
+      * artifactId: _hotspot_
+      * version: _0.0.4_
+    * [Exposition Servlet](http://mvnrepository.com/artifact/io.prometheus.client.utility/servlet) - Transferring Metrics to Prometheus Servers
+      * groupId: _io.prometheus.client.utility_
+      * artifactId: _servlet_
+      * version: _0.0.4_
+  * Simple Client
+    * [The Client](http://mvnrepository.com/artifact/io.prometheus/simpleclient)
+      * groupId: _io.prometheus_
+      * artifactId: _simpleclient_
+      * version: _0.0.2_
+    * [Exposition Servlet](http://mvnrepository.com/artifact/io.prometheus.client.utility/servlet)
+      * groupId: _io.prometheus_
+      * artifactId: _simpleclient_servlet_
+      * version: _0.0.2_
 
 ### Getting Started
-There are canonical examples defined in the class definition Javadoc headers in the _io.prometheus.client.metrics_ package.
+There are canonical examples defined in the class definition Javadoc of the client packages.
+
+See [the wiki](https://github.com/prometheus/client_java/wiki) for more information.
 
 ## Documentation
 The client is canonically documented with Javadoc.  Running the following will produce output local documentation

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
         <module>client</module>
         <module>examples</module>
         <module>utility</module>
+        <module>simpleclient</module>
+        <module>simpleclient_servlet</module>
     </modules>
 
     <build>

--- a/simpleclient/pom.xml
+++ b/simpleclient/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.5-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.prometheus</groupId>
+    <artifactId>simpleclient</artifactId>
+    <version>0.0.2</version>
+
+    <name>Prometheus Java Client Metrics</name>
+    <description>
+        Prometheus Java Client Metrics, Next Generation
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>brian-brazil</id>
+            <name>Brian Brazil</name>
+            <email>brian.brazil@boxever.com</email>
+        </developer>
+    </developers>
+
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- The simpleclient has no dependencies by design, so that
+             it can be included into any other project without having
+             to worry about conflicts. -->
+        <!-- Test Dependencies Follow -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -1,0 +1,127 @@
+
+package io.prometheus.client;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+
+/**
+ * A collector for a set of metrics.
+ * <p>
+ * Normal users should use {@link Gauge}, {@link Counter} and {@link Summary}.
+ * Subclasssing Collector is for advanced uses, such as proxying metrics from another monitoring system.
+ */
+abstract public class Collector {
+  /**
+   * Return all of the metrics of this Collector.
+   */
+  abstract public MetricFamilySamples[] collect();
+  public static enum Type {
+    COUNTER,
+    GAUGE,
+    SUMMARY
+  }
+
+  /**
+   * A metric, and all of it's samples.
+   */
+  static public class MetricFamilySamples {
+    public final String name;
+    public final Type type;
+    public final String help;
+    public final Vector<Sample> samples;
+
+    public MetricFamilySamples(String name, Type type, String help, Vector<Sample> samples) {
+      this.name = name;
+      this.type = type;
+      this.help = help;
+      this.samples = samples;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == null || !(obj instanceof MetricFamilySamples)) {
+        return false;
+      }
+      MetricFamilySamples other = (MetricFamilySamples) obj;
+      
+      return other.name.equals(name) && other.type.equals(type)
+        && other.help.equals(help) && other.samples.equals(samples) ;
+    }
+
+    @Override
+    public int hashCode() {
+      int hash = 1;
+      hash = 37 * hash + name.hashCode();
+      hash = 37 * hash + type.hashCode();
+      hash = 37 * hash + help.hashCode();
+      hash = 37 * hash + samples.hashCode();
+      return hash;
+    }
+
+    @Override
+    public String toString() {
+      return "Name: " + name + " Type: " + type + " Help: " + help + 
+        " Samples: " + samples;
+    }
+
+  /**
+   * A single Sample, with a unique name and set of labels.
+   */
+    public static class Sample {
+      public final String name;
+      public final String[] labelNames;
+      public final List<String> labelValues;  // Must have same length as labelNames.
+      public final double value;
+
+      public Sample(String name, String[] labelNames, List<String> labelValues, double value) {
+        this.name = name;
+        this.labelNames = labelNames;
+        this.labelValues = labelValues;
+        this.value = value;
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof Sample)) {
+          return false;
+        }
+        Sample other = (Sample) obj;
+        return other.name.equals(name) && Arrays.equals(other.labelNames, labelNames)
+          && other.labelValues.equals(labelValues) && other.value == value;
+      }
+
+      @Override
+      public int hashCode() {
+        int hash = 1;
+        hash = 37 * hash + name.hashCode();
+        hash = 37 * hash + labelNames.hashCode();
+        hash = 37 * hash + labelValues.hashCode();
+        long d = Double.doubleToLongBits(value);
+        hash = 37 * hash + (int)(d ^ (d >>> 32));
+        return hash;
+      }
+
+      @Override
+      public String toString() {
+        return "Name: " + name + " LabelNames: " + Arrays.asList(labelNames) + " labelValues: " + labelValues + 
+          " Value: " + value;
+      }
+    }
+  }
+
+  /**
+   * Register the Collector with the default registry.
+   */
+  public Collector register() {
+    return register(CollectorRegistry.defaultRegistry);
+  }
+
+  /**
+   * Register the Collector with the given registry.
+   */
+  public Collector register(CollectorRegistry registry) {
+    registry.register(this);
+    return this;
+  }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -1,0 +1,118 @@
+package io.prometheus.client;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * A registry of Collectors.
+ * <p>
+ * The majority of users should use the {@link #defaultRegistry}, rather than instantiating their own.
+ * <p>
+ * Creating a registry other than the default is primarily useful for unittests, or
+ * pushing a subset of metrics to the <a href="https://github.com/prometheus/pushgateway">Pushgateway</a>
+ * from batch jobs.
+ */
+public class CollectorRegistry {
+  /**
+   * The default registry.
+   */
+  public static final CollectorRegistry defaultRegistry = new CollectorRegistry();
+
+  private final Set<Collector> collectors = 
+      Collections.newSetFromMap(new ConcurrentHashMap<Collector, Boolean>());
+
+  /**
+   * Register a Collector.
+   * </p>
+   * A collector can be registered to multiple CollectorRegistries.
+   */
+  public void register(Collector m) {
+    collectors.add(m);
+  }
+  
+  /**
+   * Unregister a Collector.
+   */
+  public void unregister(Collector m) {
+    collectors.remove(m);
+  }
+  /**
+   * Unregister all Collectors.
+   */
+  public void clear() {
+    collectors.clear();
+  }
+ 
+  /**
+   * Enumeration of metrics of all registered collectors.
+   */
+  public Enumeration<Collector.MetricFamilySamples> metricFamilySamples() {
+    return new MetricFamilySamplesEnumeration();
+  }
+  class MetricFamilySamplesEnumeration implements Enumeration<Collector.MetricFamilySamples> {
+
+    private final Iterator<Collector> collectorIter = collectors.iterator();
+    private Collector.MetricFamilySamples[] metricFamilySamples;
+    private int metricFamilySamplesIndex;
+    private Collector.MetricFamilySamples next;
+
+    MetricFamilySamplesEnumeration() {
+      findNextElement();
+    }
+    
+    private void findNextElement() {
+      if (metricFamilySamples != null && metricFamilySamplesIndex < metricFamilySamples.length) {
+        next = metricFamilySamples[metricFamilySamplesIndex];
+        metricFamilySamplesIndex++;
+      } else {
+        while (collectorIter.hasNext()) {
+          metricFamilySamplesIndex = 0;
+          metricFamilySamples = collectorIter.next().collect();
+          if (metricFamilySamples.length > 0) {
+            next = metricFamilySamples[metricFamilySamplesIndex];
+            metricFamilySamplesIndex++;
+            return;
+          }
+        }
+        next = null;
+      }
+    }
+
+    public Collector.MetricFamilySamples nextElement() {
+      Collector.MetricFamilySamples current = next;
+      if (current == null) {
+        throw new NoSuchElementException();
+      }
+      findNextElement();
+      return current;
+    }
+    
+    public boolean hasMoreElements() {
+      return next != null;
+    }
+  }
+
+  /**
+   * Returns the given value, or null if it doesn't exist.
+   * </p>
+   * This is inefficient, and intended only for use in unittests.
+   */
+  public Double getSampleValue(String name, String[] labelNames, String[] labelValues) {
+    for (Collector.MetricFamilySamples metricFamilySamples: Collections.list(metricFamilySamples())) {
+      for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
+        if (sample.name.equals(name)
+            && Arrays.equals(sample.labelNames, labelNames)
+            && Arrays.equals(sample.labelValues.toArray(), labelValues)) {
+          return new Double(sample.value);
+        }
+      }
+    }
+    return null;
+  }
+
+}

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -1,0 +1,154 @@
+package io.prometheus.client;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+/**
+ * Counter metric, to track counts of events or running totals.
+ * <p>
+ * Example of Counters include:
+ * <ul>
+ *  <li>Number of requests processed</li>
+ *  <li>Number of items that were inserted into a queue</li>
+ *  <li>Total amount of data a system has processed</li>
+ * </ul>
+ *
+ * Counters can only go up (and be reset), if your use case can go down you should use a {@link Gauge} instead.
+ * Use the <code>rate()</code> function in Prometheus to calculate the rate of increase of a Counter.
+ * By convention, the names of Counters are suffixed by <code>_total</code>.
+ *
+ * <p>
+ * An example Counter:
+ * <pre>
+ * {@code
+ *   class YourClass {
+ *     static final Counter requests = (Counter) Counter.build()
+ *         .name("requests_total").help("Total requests.").register();
+ *     static final Counter failedRequests = (Counter) Counter.build()
+ *         .name("requests_failed_total").help("Total failed requests.").register();
+ *
+ *     void processRequest() {
+ *        requests.inc();
+ *        try {
+ *          // Your code here.
+ *        } catch (Exception e) {
+ *          failedRequests.inc();
+ *          throw e;
+ *        }
+ *     }
+ *   }
+ * }
+ * </pre>
+ *
+ * <p>
+ * You can also use labels to track different types of metric:
+ * <pre>
+ * {@code
+ *   class YourClass {
+ *     static final Counter requests = (Counter) Counter.build()
+ *         .name("requests_total").help("Total requests.")
+ *         .labelNames("method").register();
+ *
+ *     void processGetRequest() {
+ *        requests.labels("get").inc();
+ *        // Your code here.
+ *     }
+ *     void processPostRequest() {
+ *        requests.labels("post").inc();
+ *        // Your code here.
+ *     }
+ *   }
+ * }
+ * </pre>
+ * These can be aggregated and processed together much more easily in the Promtheus 
+ * server than individual metrics for each labelset.
+ */
+public class Counter extends SimpleCollector<Counter.Child> {
+
+  public Counter(Builder b) {
+    super(b);
+    if (labelNames.length == 0) {
+      inc(0);
+    }
+  }
+
+  public static class Builder extends SimpleCollector.Builder {
+    @Override
+    public SimpleCollector create() {
+      return new Counter(this);
+    }
+  }
+
+  /**
+   *  Return a Builder to allow configuration of a new Counter.
+   */
+  public static Builder build() {
+    return new Builder();
+  }
+
+  @Override
+  protected Child newChild() {
+    return new Child();
+  }
+
+  /**
+   * The value of a single Counter.
+   * <p>
+   * <em>Warning:</em> References to a Child become invalid after using
+   * {@link SimpleCollector#remove} or {@link SimpleCollector#clear},
+   */
+  public static class Child {
+    private volatile double value;
+    /**
+     * Increment the counter by 1.
+     */
+    public void inc() {
+      inc(1);
+    }
+    /**
+     * Increment the counter by the given amount.
+     * @throws IllegalArgumentException If amt is negative.
+     */
+    public void inc(double amt) {
+      if (amt < 0) {
+        throw new IllegalArgumentException("Amount to increment must be non-negative.");
+      }
+      synchronized(this){
+        value += amt;
+      }
+    }
+    /**
+     * Get the value of the counter.
+     */
+    public double get() {
+      return value;
+    }
+  }
+
+  // Convenience methods.
+  /**
+   * Increment the counter with no labels by 1.
+   */
+  public void inc() {
+    inc(1);
+  }
+  /**
+   * Increment the counter with no labels by the given amount.
+   * @throws IllegalArgumentException If amt is negative.
+   */
+  public void inc(double amt) {
+    labels().inc(amt);
+  }
+
+  @Override
+  public MetricFamilySamples[] collect() {
+    Vector<MetricFamilySamples.Sample> samples = new Vector<MetricFamilySamples.Sample>();
+    for(Map.Entry<List<String>, Child> c: children.entrySet()) {
+      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+    }
+
+    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.COUNTER, help, samples);
+    return new MetricFamilySamples[]{mfs};
+  }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -1,0 +1,184 @@
+package io.prometheus.client;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+/**
+ * Gauge metric, to report instantaneous values.
+ * <p>
+ * Examples of Gauges include:
+ * <ul>
+ *  <li>Inprogress requests</li>
+ *  <li>Number of items in a queue</li>
+ *  <li>Free memory</li>
+ *  <li>Total memory</li>
+ *  <li>Temperature</li>
+ * </ul>
+ *
+ * Gauges can go both up and down.
+ * <p>
+ * An example Gauge:
+ * <pre>
+ * {@code
+ *   class YourClass {
+ *     static final Gauge inprogressRequests = (Gauge) Gauge.build()
+ *         .name("inprogress_requests").help("Inprogress requests.").register();
+ *
+ *     void processRequest() {
+ *        inprogressRequest.inc();
+ *        // Your code here.
+ *        inprogressRequest.dec();
+ *     }
+ *   }
+ * }
+ * </pre>
+ *
+ * <p>
+ * You can also use labels to track different types of metric:
+ * <pre>
+ * {@code
+ *   class YourClass {
+ *     static final Gauge inprogressRequests = (Gauge) Gauge.build()
+ *         .name("inprogress_requests").help("Inprogress requests.")
+ *         .labelNames("method").register();
+ *
+ *     void processGetRequest() {
+ *        inprogressRequests.labels("get").inc();
+ *        // Your code here.
+ *        inprogressRequests.labels("get").dec();
+ *     }
+ *     void processPostRequest() {
+ *        inprogressRequests.labels("post").inc();
+ *        // Your code here.
+ *        inprogressRequests.labels("post").dec();
+ *     }
+ *   }
+ * }
+ * </pre>
+ * These can be aggregated and processed together much more easily in the Promtheus 
+ * server than individual metrics for each labelset.
+ */
+public class Gauge extends SimpleCollector<Gauge.Child> {
+  
+  public Gauge(Builder b) {
+    super(b);
+    if (labelNames.length == 0) {
+      set(0);
+    }
+  }
+
+  public static class Builder extends SimpleCollector.Builder {
+    @Override
+    public SimpleCollector create() {
+      return new Gauge(this);
+    }
+  }
+
+  /**
+   *  Return a Builder to allow configuration of a new Gauge.
+   */
+  public static Builder build() {
+    return new Builder();
+  }
+
+  @Override
+  protected Child newChild() {
+    return new Child();
+  }
+
+  /**
+   * The value of a single Gauge.
+   * <p>
+   * <em>Warning:</em> References to a Child become invalid after using
+   * {@link SimpleCollector#remove} or {@link SimpleCollector#clear},
+   */
+  public static class Child {
+    private volatile double value;
+    /**
+     * Increment the gauge by 1.
+     */
+    public void inc() {
+      inc(1);
+    }
+    /**
+     * Increment the gauge by the given amount.
+     */
+    public void inc(double amt) {
+      synchronized(this){
+        value += amt;
+      }
+    }
+    /**
+     * Decrement the gauge by 1.
+     */
+    public void dec() {
+      dec(1);
+    }
+    /**
+     * Decrement the gauge by the given amount.
+     */
+    public void dec(double amt) {
+      synchronized(this){
+        value -= amt;
+      }
+    }
+    /**
+     * Set the gauge to the given value.
+     */
+    public void set(double val) {
+      synchronized(this){
+        value = val;
+      }
+    }
+    /**
+     * Get the value of the gauge.
+     */
+    public double get() {
+      return value;
+    }
+  }
+
+  // Convenience methods.
+  /**
+   * Increment the gauge with no labels by 1.
+   */
+  public void inc() {
+    inc(1);
+  }
+  /**
+   * Increment the gauge with no labels by the given amount.
+   */
+  public void inc(double amt) {
+    labels().inc(amt);
+  }
+  /**
+   * Increment the gauge with no labels by 1.
+   */
+  public void dec() {
+    dec(1);
+  }
+  /**
+   * Decrement the gauge with no labels by the given amount.
+   */
+  public void dec(double amt) {
+    labels().dec(amt);
+  }
+  /**
+   * Set the gauge with no labels to the given value.
+   */
+  public void set(double val) {
+    labels().set(val);
+  }
+
+  @Override
+  public MetricFamilySamples[] collect() {
+    Vector<MetricFamilySamples.Sample> samples = new Vector<MetricFamilySamples.Sample>();
+    for(Map.Entry<List<String>, Child> c: children.entrySet()) {
+      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+    }
+    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.GAUGE, help, samples);
+
+    return new MetricFamilySamples[]{mfs};
+  }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -1,0 +1,179 @@
+package io.prometheus.client;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Common functionality for {@link Gauge}, {@link Counter} and {@link Summary}.
+ * <p>
+ * This class handles common initlization and label logic for the standard metrics.
+ * You should never need to subclass this class.
+ * <p>
+ * <h2>Initilization</h2>
+ * After calling build() on a subclass, {@link Builder#name(String) name},
+ * {@link SimpleCollector.Builder#help(String) help},
+ * {@link SimpleCollector.Builder#labelNames(String...) labelNames},
+ * {@link SimpleCollector.Builder#namespace(String) namespace} and
+ * {@link SimpleCollector.Builder#subsystem(String) subsystem} can be called to configure the Collector.
+ * These return <code>this</code> to allow calls to be chained.
+ * Once configured, call {@link SimpleCollector.Builder#create create}
+ * (which is also called by {@link SimpleCollector.Builder#register register}).
+ * <p>
+ * The fullname of the metric is <code>namespace_subsystem_name</code>, but only <code>name</code> is required.
+ *
+ * <h2>Labels</h2>
+ * {@link SimpleCollector.Builder#labelNames labelNames} specifies which (if any) labels the metrics will have, and 
+ * {@link #labels} returns the Child of the metric that represents that particular set of labels.
+ * {@link Gauge}, {@link Counter} and {@link Summary} all offer convienence methods to avoid needing to call
+ * {@link #labels} for metrics with no labels.
+ * <p>
+ * {@link #remove} and {@link #clear} can be used to remove children.
+ * <p>
+ * <em>Warning #1:</em> Metrics that don't always something are difficult to monitor, if you know in advance
+ * what labels will be in use you should initilise them to 0. This is done for you for metrics with no labels.
+ * <p>
+ * <em>Warning #2:</em> While labels are very powerful, avoid overly granular metric labels. 
+ * The combinatorial explosion of breaking out a metric in many dimensions can produce huge numberts
+ * of timeseries, which will then take longer and more resources to process.
+ * <br/>
+ * As a rule of thumb aim to keep the cardinality of metrics below ten, and limit where the
+ * cardinality exceeds that value. For example rather than breaking out latency
+ * by customer and endpoint in one metric, you might have two metrics with one breaking out
+ * by each. If the cardinality is in the hundreds, you may wish to consider removing the breakout
+ * by one of the dimensions altogether.
+ */
+abstract public class SimpleCollector<Child> extends Collector {
+  final String fullname;
+  final String help;
+  final String[] labelNames;
+
+  final ConcurrentHashMap<List<String>, Child> children = new ConcurrentHashMap<List<String>, Child>();;
+
+  /**
+   * Return the Child with the given labels, creating it if needed.
+   * <p>
+   * Must be passed the same number of labels are were passed to {@link #labelNames}.
+   */
+  public Child labels(String... labelValues) {
+    if (labelValues.length != labelNames.length) {
+      throw new IllegalArgumentException("Incorrect number of labels.");
+    }
+    List<String> key = Arrays.asList(labelValues);
+    Child c = children.get(key);
+    if (c != null) {
+      return c;
+    }
+    children.putIfAbsent(key, newChild());
+    return children.get(key);
+  }
+
+  /**
+   * Remove the Child with the given labels.
+   * <p>
+   * Any references to the Child are invalidated.
+   */
+  public void remove(String... labelValues) {
+    children.remove(Arrays.asList(labelValues));
+  }
+  
+  /**
+   * Remove all children.
+   * <p>
+   * Any references to any children are invalidated.
+   */
+  public void clear() {
+    children.clear();
+  }
+
+  /**
+   * Return a new child, workaround for Java generics limitations.
+   */
+  abstract protected Child newChild();
+
+  protected SimpleCollector(Builder b) {
+    if (b.name.isEmpty()) throw new IllegalStateException("Name hasn't been set.");
+    String name = b.name;
+    if (!b.subsystem.isEmpty()) {
+      name = b.subsystem + '_' + name;
+    }
+    if (!b.namespace.isEmpty()) {
+      name = b.namespace + '_' + name;
+    }
+    fullname = name;
+    if (b.help.isEmpty()) throw new IllegalStateException("Help hasn't been set.");
+    help = b.help;
+    labelNames = b.labelNames;
+  }
+
+  /**
+   * Builders let you configure and then create collectors.
+   */
+  abstract public static class Builder {
+    String namespace = "";
+    String subsystem = "";
+    String name = "";
+    String fullname = "";
+    String help = "";
+    String[] labelNames = new String[]{};
+
+    /**
+     * Set the name of the metric. Required.
+     */
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+    /**
+     * Set the subsystem of the metric. Optional.
+     */
+    public Builder subsystem(String subsystem) {
+      this.subsystem = subsystem;
+      return this;
+    }
+    /**
+     * Set the namespace of the metric. Optional.
+     */
+    public Builder namespace(String namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+    /**
+     * Set the help string of the metric. Required.
+     */
+    public Builder help(String help) {
+      this.help = help;
+      return this;
+    }
+    /**
+     * Set the labelNames of the metric. Optional, defaults to no labels.
+     */
+    public Builder labelNames(String... labelNames) {
+      this.labelNames = labelNames;
+      return this;
+    }
+
+    /**
+     * Return the constructed collector.
+     * <p>
+     * Abstract due to generics limitations.
+     */
+    abstract public SimpleCollector create();
+
+    /**
+     * Create and register the Collector with the default registry.
+     */
+    public SimpleCollector register() {
+      return register(CollectorRegistry.defaultRegistry);
+    }
+
+    /**
+     * Create and register the Collector with the given registry.
+     */
+    public SimpleCollector register(CollectorRegistry registry) {
+      SimpleCollector sc = create();
+      registry.register(sc);
+      return sc;
+    }
+  }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -1,0 +1,130 @@
+package io.prometheus.client;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+/**
+ * Summary metric, to track distributions and frequencies..
+ * <p>
+ * Example of uses for Summaries include:
+ * <ul>
+ *  <li>Response latency</li>
+ *  <li>Request size</li>
+ * </ul>
+ * <p>
+ * <em>Note:</em> Full distribution support is still a work in progress. Currently it reports only
+ * the count of observations and their sum, allowing for calculation of the rate of 
+ * observations and the average observation size.
+ * 
+ * <p>
+ * An example Summary:
+ * <pre>
+ * {@code
+ *   class YourClass {
+ *     static final Summary requestLatency = (Summary) Summary.build()
+ *         .name("requests_latency_s_total").help("Request latency in seconds.").register();
+ *
+ *     void processRequest() {  
+ *        long start = System.nanoTime();
+ *        try {
+ *          // Your code here.
+ *        } finally {
+ *          requestLatency.observe((System.nanoTime() - start) / 1000000000.0);
+ *        }
+ *     }
+ *   }
+ * }
+ * </pre>
+ */
+public class Summary extends SimpleCollector<Summary.Child> {
+
+  public Summary(Builder b) {
+    super(b);
+    if (labelNames.length == 0) {
+      labels().set(0, 0);
+    }
+  }
+
+  public static class Builder extends SimpleCollector.Builder {
+    @Override
+    public SimpleCollector create() {
+      return new Summary(this);
+    }
+  }
+
+  /**
+   *  Return a Builder to allow configuration of a new Summary.
+   */
+  public static Builder build() {
+    return new Builder();
+  }
+
+  @Override
+  protected Child newChild() {
+    return new Child();
+  }
+
+  /**
+   * The value of a single Summary.
+   * <p>
+   * <em>Warning:</em> References to a Child become invalid after using
+   * {@link SimpleCollector#remove} or {@link SimpleCollector#clear},
+   */
+  public static class Child {
+    public static class Value {
+      private volatile double count;
+      private volatile double sum;
+    }
+    private final Value value = new Value();
+    /**
+     * Observe the given amount.
+     */
+    public void observe(double amt) {
+      synchronized(this){
+        value.count++;
+        value.sum += amt;
+      }
+    }
+    void set(double c, double s) {
+      synchronized(this){
+        value.count = c;
+        value.sum = s;
+      }
+    }
+    /**
+     * Get the value of the Summary.
+     * <p>
+     * <em>Warning:</em> The definition of {@link Value} is subject to change.
+     */
+    public Value get() {
+      Value v = new Value();
+      synchronized(this){
+        v.sum = value.sum;
+        v.count = value.count;
+      }
+      return v;
+    }
+  }
+
+  // Convenience method.
+  /**
+   * Observe the given amount on the Summary with no labels.
+   */
+  public void observe(double amt) {
+    labels().observe(amt);
+  }
+
+  @Override
+  public MetricFamilySamples[] collect() {
+    Vector<MetricFamilySamples.Sample> samples = new Vector<MetricFamilySamples.Sample>();
+    for(Map.Entry<List<String>, Child> c: children.entrySet()) {
+      Child.Value v = c.getValue().get();
+      samples.add(new MetricFamilySamples.Sample(fullname + "_count", labelNames, c.getKey(), v.count));
+      samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum));
+    }
+
+    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.SUMMARY, help, samples);
+    return new MetricFamilySamples[]{mfs};
+  }
+}

--- a/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
@@ -1,0 +1,85 @@
+package io.prometheus.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Vector;
+import org.junit.Test;
+import org.junit.Before;
+
+
+public class CollectorRegistryTest {
+
+  CollectorRegistry registry;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+  }
+
+  @Test
+  public void testRegisteredCollectorsAreCollected() {
+    Collector g = Gauge.build().name("g").help("h").register(registry);
+    List<Collector.MetricFamilySamples> mfs = Collections.list(registry.metricFamilySamples());
+    assertEquals(1, mfs.size());
+    assertEquals("g", mfs.get(0).name);
+  }
+
+  @Test
+  public void testUnregister() {
+    Collector g = Gauge.build().name("g").help("h").register(registry);
+    Collector c = Counter.build().name("c").help("h").register(registry);
+    List<Collector.MetricFamilySamples> mfs = Collections.list(registry.metricFamilySamples());
+    assertEquals(2, mfs.size());
+    registry.unregister(g);
+    mfs = Collections.list(registry.metricFamilySamples());
+    assertEquals(1, mfs.size());
+    assertEquals("c", mfs.get(0).name);
+  }
+
+  @Test
+  public void testClear() {
+    Collector g = Gauge.build().name("g").help("h").register(registry);
+    Collector c = Counter.build().name("c").help("h").register(registry);
+    List<Collector.MetricFamilySamples> mfs = Collections.list(registry.metricFamilySamples());
+    assertEquals(2, mfs.size());
+    registry.clear();
+    mfs = Collections.list(registry.metricFamilySamples());
+    assertEquals(0, mfs.size());
+  }
+
+  class EmptyCollector extends Collector {
+    public MetricFamilySamples[] collect(){
+      return new MetricFamilySamples[]{};
+    }
+  }
+
+  @Test
+  public void testMetricFamilySamples() {
+    Collector g = Gauge.build().name("g").help("h").register(registry);
+    Collector c = Counter.build().name("c").help("h").register(registry);
+    Collector s = Summary.build().name("s").help("h").register(registry);
+    Collector ec = new EmptyCollector().register(registry);
+    HashSet<String> names = new HashSet<String>();
+    for (Collector.MetricFamilySamples metricFamilySamples: Collections.list(registry.metricFamilySamples())) {
+      names.add(metricFamilySamples.name);
+    }
+    assertEquals(new HashSet<String>(Arrays.asList("g", "c", "s")), names);
+  }
+
+  @Test
+  public void testEmptyRegistryHasNoMoreElements() {
+    assertFalse(registry.metricFamilySamples().hasMoreElements());
+  }
+
+  @Test
+  public void testRegistryWithEmptyCollectorHasNoMoreElements() {
+    registry.register(new EmptyCollector());
+    assertFalse(registry.metricFamilySamples().hasMoreElements());
+  }
+  
+}

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -1,0 +1,79 @@
+package io.prometheus.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Vector;
+import org.junit.Test;
+import org.junit.Before;
+
+
+public class CounterTest {
+
+  CollectorRegistry registry;
+  Counter noLabels, labels;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+    noLabels = (Counter) Counter.build().name("nolabels").help("help").register(registry);
+    labels = (Counter) Counter.build().name("labels").help("help").labelNames("l").register(registry);
+  }
+
+  private double getValue() {
+    return registry.getSampleValue("nolabels", new String[]{}, new String[]{}).doubleValue();
+  }
+  
+  @Test
+  public void testIncrement() {
+    noLabels.inc();
+    assertEquals(1.0, getValue(), .001);
+    noLabels.inc(2);
+    assertEquals(3.0, getValue(), .001);
+    noLabels.labels().inc(4);
+    assertEquals(7.0, getValue(), .001);
+    noLabels.labels().inc();
+    assertEquals(8.0, getValue(), .001);
+  }
+    
+  @Test(expected=IllegalArgumentException.class)
+  public void testNegativeIncrementFails() {
+    noLabels.inc(-1);
+  }
+  
+  @Test
+  public void noLabelsDefaultZeroValue() {
+    assertEquals(0.0, getValue(), .001);
+  }
+  
+  private Double getLabelsValue(String labelValue) {
+    return registry.getSampleValue("labels", new String[]{"l"}, new String[]{labelValue});
+  }
+
+  @Test
+  public void testLabels() {
+    assertEquals(null, getLabelsValue("a"));
+    assertEquals(null, getLabelsValue("b"));
+    labels.labels("a").inc();
+    assertEquals(1.0, getLabelsValue("a").doubleValue(), .001);
+    assertEquals(null, getLabelsValue("b"));
+    labels.labels("b").inc(3);
+    assertEquals(1.0, getLabelsValue("a").doubleValue(), .001);
+    assertEquals(3.0, getLabelsValue("b").doubleValue(), .001);
+  }
+
+  @Test
+  public void testCollect() {
+    labels.labels("a").inc();
+    Collector.MetricFamilySamples[] mfs = labels.collect();
+    
+    Vector<Collector.MetricFamilySamples.Sample> samples = new Vector<Collector.MetricFamilySamples.Sample>();
+    Vector<String> labelValues = new Vector<String>();
+    labelValues.add("a");
+    samples.add(new Collector.MetricFamilySamples.Sample("labels", new String[]{"l"}, labelValues, 1.0));
+    Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.COUNTER, "help", samples);
+
+    assertEquals(1, mfs.length);
+    assertEquals(mfsFixture, mfs[0]);
+  }
+
+}

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
@@ -1,0 +1,94 @@
+package io.prometheus.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Vector;
+import org.junit.Test;
+import org.junit.Before;
+
+
+public class GaugeTest {
+
+  CollectorRegistry registry;
+  Gauge noLabels, labels;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+    noLabels = (Gauge) Gauge.build().name("nolabels").help("help").register(registry);
+    labels = (Gauge) Gauge.build().name("labels").help("help").labelNames("l").register(registry);
+  }
+
+  private double getValue() {
+    return registry.getSampleValue("nolabels", new String[]{}, new String[]{}).doubleValue();
+  }
+  
+  @Test
+  public void testIncrement() {
+    noLabels.inc();
+    assertEquals(1.0, getValue(), .001);
+    noLabels.inc(2);
+    assertEquals(3.0, getValue(), .001);
+    noLabels.labels().inc(4);
+    assertEquals(7.0, getValue(), .001);
+    noLabels.labels().inc();
+    assertEquals(8.0, getValue(), .001);
+  }
+    
+  @Test
+  public void testDecrement() {
+    noLabels.dec();
+    assertEquals(-1.0, getValue(), .001);
+    noLabels.dec(2);
+    assertEquals(-3.0, getValue(), .001);
+    noLabels.labels().dec(4);
+    assertEquals(-7.0, getValue(), .001);
+    noLabels.labels().dec();
+    assertEquals(-8.0, getValue(), .001);
+  }
+  
+  @Test
+  public void testSet() {
+    noLabels.set(42);
+    assertEquals(42, getValue(), .001);
+    noLabels.labels().set(7);
+    assertEquals(7.0, getValue(), .001);
+  }
+ 
+  @Test
+  public void noLabelsDefaultZeroValue() {
+    assertEquals(0.0, getValue(), .001);
+  }
+  
+  private Double getLabelsValue(String labelValue) {
+    return registry.getSampleValue("labels", new String[]{"l"}, new String[]{labelValue});
+  }
+
+  @Test
+  public void testLabels() {
+    assertEquals(null, getLabelsValue("a"));
+    assertEquals(null, getLabelsValue("b"));
+    labels.labels("a").inc();
+    assertEquals(1.0, getLabelsValue("a").doubleValue(), .001);
+    assertEquals(null, getLabelsValue("b"));
+    labels.labels("b").inc(3);
+    assertEquals(1.0, getLabelsValue("a").doubleValue(), .001);
+    assertEquals(3.0, getLabelsValue("b").doubleValue(), .001);
+  }
+
+  @Test
+  public void testCollect() {
+    labels.labels("a").inc();
+    Collector.MetricFamilySamples[] mfs = labels.collect();
+    
+    Vector<Collector.MetricFamilySamples.Sample> samples = new Vector<Collector.MetricFamilySamples.Sample>();
+    Vector<String> labelValues = new Vector<String>();
+    labelValues.add("a");
+    samples.add(new Collector.MetricFamilySamples.Sample("labels", new String[]{"l"}, labelValues, 1.0));
+    Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.GAUGE, "help", samples);
+
+    assertEquals(1, mfs.length);
+    assertEquals(mfsFixture, mfs[0]);
+  }
+
+}

--- a/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
@@ -1,0 +1,80 @@
+package io.prometheus.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.Before;
+
+
+public class SimpleCollectorTest {
+
+  CollectorRegistry registry;
+  Gauge metric;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+    metric = (Gauge) Gauge.build().name("labels").help("help").labelNames("l").register(registry);
+  }
+  
+  private Double getValue(String labelValue) {
+    return registry.getSampleValue("labels", new String[]{"l"}, new String[]{labelValue});
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testTooFewLabelsThrows() {
+    metric.labels();
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testTooManyLabelsThrows() {
+    metric.labels("a", "b");
+  }
+  
+  @Test
+  public void testRemove() {
+    metric.labels("a");
+    assertNotNull(getValue("a"));
+    assertNull(getValue("b"));
+    metric.labels("b").set(7);
+    assertNotNull(getValue("a"));
+    assertNotNull(getValue("b"));
+    metric.remove("b");
+    assertNotNull(getValue("a"));
+    assertNull(getValue("b"));
+   
+    // Brand new Child.
+    metric.labels("b").inc();
+    assertEquals(1.0, getValue("b").doubleValue(), .001);
+  }
+
+  @Test
+  public void testClear() {
+    assertNull(getValue("a"));
+    metric.labels("a").set(7);
+    assertNotNull(getValue("a"));
+    metric.clear();
+    assertNull(getValue("a"));
+   
+    // Brand new Child.
+    metric.labels("a").inc();
+    assertEquals(1.0, getValue("a").doubleValue(), .001);
+  }
+
+  @Test
+  public void testNameIsConcatenated() {
+    assertEquals("a_b_c", Gauge.build().name("c").subsystem("b").namespace("a").help("h").create().fullname);
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testNameIsRequired() {
+    Gauge.build().help("h").create();
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testHelpIsRequired() {
+    Gauge.build().name("c").create();
+  }
+}

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -1,0 +1,86 @@
+package io.prometheus.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Vector;
+import org.junit.Test;
+import org.junit.Before;
+
+
+public class SummaryTest {
+
+  CollectorRegistry registry;
+  Summary noLabels, labels;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+    noLabels = (Summary) Summary.build().name("nolabels").help("help").register(registry);
+    labels = (Summary) Summary.build().name("labels").help("help").labelNames("l").register(registry);
+  }
+
+  private double getCount() {
+    return registry.getSampleValue("nolabels_count", new String[]{}, new String[]{}).doubleValue();
+  }
+  private double getSum() {
+    return registry.getSampleValue("nolabels_sum", new String[]{}, new String[]{}).doubleValue();
+  }
+  
+  @Test
+  public void testObserve() {
+    noLabels.observe(2);
+    assertEquals(1.0, getCount(), .001);
+    assertEquals(2.0, getSum(), .001);
+    noLabels.labels().observe(4);
+    assertEquals(2.0, getCount(), .001);
+    assertEquals(6.0, getSum(), .001);
+  }
+  
+  @Test
+  public void noLabelsDefaultZeroValue() {
+    assertEquals(0.0, getCount(), .001);
+    assertEquals(0.0, getSum(), .001);
+  }
+  
+  private Double getLabelsCount(String labelValue) {
+    return registry.getSampleValue("labels_count", new String[]{"l"}, new String[]{labelValue});
+  }
+  private Double getLabelsSum(String labelValue) {
+    return registry.getSampleValue("labels_sum", new String[]{"l"}, new String[]{labelValue});
+  }
+
+  @Test
+  public void testLabels() {
+    assertEquals(null, getLabelsCount("a"));
+    assertEquals(null, getLabelsSum("a"));
+    assertEquals(null, getLabelsCount("b"));
+    assertEquals(null, getLabelsSum("b"));
+    labels.labels("a").observe(2);
+    assertEquals(1.0, getLabelsCount("a").doubleValue(), .001);
+    assertEquals(2.0, getLabelsSum("a").doubleValue(), .001);
+    assertEquals(null, getLabelsCount("b"));
+    assertEquals(null, getLabelsSum("b"));
+    labels.labels("b").observe(3);
+    assertEquals(1.0, getLabelsCount("a").doubleValue(), .001);
+    assertEquals(2.0, getLabelsSum("a").doubleValue(), .001);
+    assertEquals(1.0, getLabelsCount("b").doubleValue(), .001);
+    assertEquals(3.0, getLabelsSum("b").doubleValue(), .001);
+  }
+
+  @Test
+  public void testCollect() {
+    labels.labels("a").observe(2);
+    Collector.MetricFamilySamples[] mfs = labels.collect();
+    
+    Vector<Collector.MetricFamilySamples.Sample> samples = new Vector<Collector.MetricFamilySamples.Sample>();
+    Vector<String> labelValues = new Vector<String>();
+    labelValues.add("a");
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_count", new String[]{"l"}, labelValues, 1.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_sum", new String[]{"l"}, labelValues, 2.0));
+    Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.SUMMARY, "help", samples);
+
+    assertEquals(1, mfs.length);
+    assertEquals(mfsFixture, mfs[0]);
+  }
+
+}

--- a/simpleclient_servlet/pom.xml
+++ b/simpleclient_servlet/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.5-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.prometheus</groupId>
+    <artifactId>simpleclient_servlet</artifactId>
+    <version>0.0.2</version>
+
+    <name>Prometheus Java Client Metrics</name>
+    <description>
+        Prometheus Java Client Metrics
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>brian-brazil</id>
+            <name>Brian Brazil</name>
+            <email>brian.brazil@boxever.com</email>
+        </developer>
+    </developers>
+
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Test Dependencies Follow -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>8.1.7.v20120910</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/simpleclient_servlet/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
@@ -1,0 +1,91 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.io.IOException;
+import java.io.Writer;
+
+public class MetricsServlet extends HttpServlet {
+
+  private CollectorRegistry registry;
+
+  /**
+   * Construct a MetricsServlet for the default registry.
+   */
+  public MetricsServlet() {
+    this(CollectorRegistry.defaultRegistry);
+  }
+
+  /**
+   * Construct a MetricsServlet for the given registry.
+   */
+  public MetricsServlet(CollectorRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+      throws ServletException, IOException {
+    resp.setStatus(HttpServletResponse.SC_OK);
+    /* See https://docs.google.com/a/boxever.com/document/d/1ZjyKiKxZV83VI9ZKAXRGKaUKK2BIWCT7oiGBKDBpjEY/edit# 
+     * for the output format specification. */
+    resp.setContentType("text/plain; version=0.0.4; charset=utf-8");
+
+    Writer writer = resp.getWriter();
+    writeTextOutput(writer, registry.metricFamilySamples());
+    writer.flush();
+    writer.close();
+  }
+
+  static void writeTextOutput(Writer writer, Enumeration<Collector.MetricFamilySamples> mfs) throws IOException {
+    for (Collector.MetricFamilySamples metricFamilySamples: Collections.list(mfs)) {
+      writer.write("# HELP " + metricFamilySamples.name + " " + escapeHelp(metricFamilySamples.help) + "\n");
+      writer.write("# TYPE " + metricFamilySamples.name + " " + typeString(metricFamilySamples.type) + "\n");
+      for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
+        writer.write(sample.name);
+        if (sample.labelNames.length > 0) {
+          writer.write("{");
+          for (int i = 0; i < sample.labelNames.length; ++i) {
+            writer.write(sample.labelNames[i] + "=\"" + escapeLabelValue(sample.labelValues.get(i)) + "\",");
+          }
+          writer.write("}");
+        }
+        writer.write(" " + sample.value + "\n");
+      }
+    }
+  }
+
+  static String escapeHelp(String s) {
+    return s.replace("\\", "\\\\").replace("\n", "\\n");
+  }
+  static String escapeLabelValue(String s) {
+    return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+  }
+  
+  static String typeString(Collector.Type t) {
+    switch (t) {
+      case GAUGE:
+        return "gauge";
+      case COUNTER:
+        return "counter";
+      case SUMMARY:
+        return "summary";
+      default:
+        return "uptyped";
+    }
+  }
+
+  @Override
+  protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
+        throws ServletException, IOException {
+    doGet(req, resp);
+  }
+
+}

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/ExampleExporter.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/ExampleExporter.java
@@ -1,0 +1,32 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
+public class ExampleExporter {
+
+  static final Gauge g = (Gauge) Gauge.build().name("gauge").help("blah").register();
+  static final Counter c = (Counter) Counter.build().name("counter").help("meh").register();
+  static final Summary s = (Summary) Summary.build().name("summary").help("meh").register();
+  static final Gauge l = (Gauge) Gauge.build().name("labels").help("blah").labelNames("l").register();
+
+  public static void main(String[] args) throws Exception {
+    Server server = new Server(1234);
+    ServletContextHandler context = new ServletContextHandler();
+    context.setContextPath("/");
+    server.setHandler(context);
+    context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+    server.start();
+    g.set(1);
+    c.inc(2);
+    s.observe(3);
+    l.labels("foo").inc(4);
+    while(true) {
+    }
+  }
+
+}

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
@@ -1,0 +1,87 @@
+package io.prometheus.client.exporter;
+
+import static org.junit.Assert.assertEquals;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Vector;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class MetricsServletTest {
+  CollectorRegistry registry;
+  StringWriter writer;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+    writer = new StringWriter();
+  }
+
+  @Test
+  public void testGaugeOutput() throws IOException {
+    Gauge noLabels = (Gauge) Gauge.build().name("nolabels").help("help").register(registry);
+    noLabels.inc();
+    MetricsServlet.writeTextOutput(writer, registry.metricFamilySamples());
+    assertEquals("# HELP nolabels help\n"
+                 + "# TYPE nolabels gauge\n"
+                 + "nolabels 1.0\n", writer.toString());
+  }
+
+  @Test
+  public void testCounterOutput() throws IOException {
+    Counter noLabels = (Counter) Counter.build().name("nolabels").help("help").register(registry);
+    noLabels.inc();
+    MetricsServlet.writeTextOutput(writer, registry.metricFamilySamples());
+    assertEquals("# HELP nolabels help\n"
+                 + "# TYPE nolabels counter\n"
+                 + "nolabels 1.0\n", writer.toString());
+  }
+
+  @Test
+  public void testSummaryOutput() throws IOException {
+    Summary noLabels = (Summary) Summary.build().name("nolabels").help("help").register(registry);
+    noLabels.observe(2);
+    MetricsServlet.writeTextOutput(writer, registry.metricFamilySamples());
+    assertEquals("# HELP nolabels help\n"
+                 + "# TYPE nolabels summary\n"
+                 + "nolabels_count 1.0\n"
+                 + "nolabels_sum 2.0\n", writer.toString());
+  }
+
+  @Test
+  public void testLabelsOutput() throws IOException {
+    Gauge labels = (Gauge) Gauge.build().name("labels").help("help").labelNames("l").register(registry);
+    labels.labels("a").inc();
+    MetricsServlet.writeTextOutput(writer, registry.metricFamilySamples());
+    assertEquals("# HELP labels help\n"
+                 + "# TYPE labels gauge\n"
+                 + "labels{l=\"a\",} 1.0\n", writer.toString());
+  }
+
+  @Test
+  public void testLabelValuesEscaped() throws IOException {
+    Gauge labels = (Gauge) Gauge.build().name("labels").help("help").labelNames("l").register(registry);
+    labels.labels("a\nb\\c\"d").inc();
+    MetricsServlet.writeTextOutput(writer, registry.metricFamilySamples());
+    assertEquals("# HELP labels help\n"
+                 + "# TYPE labels gauge\n"
+                 + "labels{l=\"a\\nb\\\\c\\\"d\",} 1.0\n", writer.toString());
+  }
+
+  @Test
+  public void testHelpEscaped() throws IOException {
+    Gauge noLabels = (Gauge) Gauge.build().name("nolabels").help("h\"e\\l\np").register(registry);
+    noLabels.inc();
+    MetricsServlet.writeTextOutput(writer, registry.metricFamilySamples());
+    assertEquals("# HELP nolabels h\"e\\\\l\\np\n"
+                 + "# TYPE nolabels gauge\n"
+                 + "nolabels 1.0\n", writer.toString());
+  }
+}


### PR DESCRIPTION
This is based on the existing client, with the following changes:
- No external dependencies in core client
- Number of labels is fixed
- Initilises to 0 when there's no labels
- Convenience methods for no labels
- Support for multiple registries
- Only supports text output format

This code is MVP, there's no validation of metric or label names,
AtomicDouble might be better in Counter/Gauge and I'm sure there's a better
way to architect all this class wise (the api is a bit text format specific
for Summary for example).
