### PR TITLE
Make it easier to push just one metric.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ assets:
     * [PushGateway support](http://mvnrepository.com/artifact/io.prometheus.client/simpleclient_pushgateway)
       * groupId: _io.prometheus_
       * artifactId: _simpleclient_pushgateway_
-      * version: _0.0.3_
+      * version: _0.0.4_
 
 ### Getting Started
 There are canonical examples defined in the class definition Javadoc of the client packages.

--- a/simpleclient_pushgateway/pom.xml
+++ b/simpleclient_pushgateway/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient_pushgateway</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
 
     <name>Prometheus Java Client Metrics</name>
     <description>

--- a/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
+++ b/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
@@ -1,5 +1,6 @@
 package io.prometheus.client.exporter;
 
+import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
 
@@ -46,6 +47,21 @@ public class PushGateway {
   }
 
   /**
+   * Pushes all metrics in a Collector, replacing all those with the same job and instance.
+   * <p>
+   * This is useful for pushing a single Gauge.
+   * <p>
+   * See the Pushgateway documentation for detailed implications of the job and
+   * instance parameter. instance can be left empty. The Pushgateway will then
+   * use the client's IP number instead. This uses the POST HTTP method.
+  */
+  public void push(Collector collector, String job, String instance) throws IOException {
+    CollectorRegistry registry = new CollectorRegistry();
+    collector.register(registry);
+    push(registry, job, instance);
+  }
+
+  /**
    * Pushes all metrics in a registry, replacing only previously pushed metrics of the same name.
    * <p>
    * See the Pushgateway documentation for detailed implications of the job and
@@ -54,6 +70,21 @@ public class PushGateway {
   */
   public void pushAdd(CollectorRegistry registry, String job, String instance) throws IOException {
     doRequest(registry, job, instance, "PUT");
+  }
+
+  /**
+   * Pushes all metrics in a Collector, replacing only previously pushed metrics of the same name.
+   * <p>
+   * This is useful for pushing a single Gauge.
+   * <p>
+   * See the Pushgateway documentation for detailed implications of the job and
+   * instance parameter. instance can be left empty. The Pushgateway will then
+   * use the client's IP number instead. This uses the POST HTTP method.
+  */
+  public void pushAdd(Collector collector, String job, String instance) throws IOException {
+    CollectorRegistry registry = new CollectorRegistry();
+    collector.register(registry);
+    pushAdd(registry, job, instance);
   }
 
   /**


### PR DESCRIPTION
These convenience methods take care of creating a registry, when you just want to push one Gauge to a pushgateway.
