### PR TITLE
Various improvements based on experience from usage.

### DIFF
--- a/simpleclient/pom.xml
+++ b/simpleclient/pom.xml
@@ -11,9 +11,9 @@
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient</artifactId>
 
-    <name>Prometheus Java Client Metrics</name>
+    <name>Prometheus Java Simpleclient</name>
     <description>
-        Prometheus Java Client Metrics, Next Generation
+        Core instrumentation library for the simpleclient.
     </description>
 
     <licenses>

--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -3,7 +3,6 @@ package io.prometheus.client;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Vector;
 
 /**
  * A collector for a set of metrics.
@@ -11,11 +10,11 @@ import java.util.Vector;
  * Normal users should use {@link Gauge}, {@link Counter} and {@link Summary}.
  * Subclasssing Collector is for advanced uses, such as proxying metrics from another monitoring system.
  */
-abstract public class Collector {
+public abstract class Collector {
   /**
    * Return all of the metrics of this Collector.
    */
-  abstract public MetricFamilySamples[] collect();
+  public abstract List<MetricFamilySamples> collect();
   public static enum Type {
     COUNTER,
     GAUGE,
@@ -29,9 +28,9 @@ abstract public class Collector {
     public final String name;
     public final Type type;
     public final String help;
-    public final Vector<Sample> samples;
+    public final List<Sample> samples;
 
-    public MetricFamilySamples(String name, Type type, String help, Vector<Sample> samples) {
+    public MetricFamilySamples(String name, Type type, String help, List<Sample> samples) {
       this.name = name;
       this.type = type;
       this.help = help;
@@ -70,11 +69,11 @@ abstract public class Collector {
    */
     public static class Sample {
       public final String name;
-      public final String[] labelNames;
+      public final List<String> labelNames;
       public final List<String> labelValues;  // Must have same length as labelNames.
       public final double value;
 
-      public Sample(String name, String[] labelNames, List<String> labelValues, double value) {
+      public Sample(String name, List<String> labelNames, List<String> labelValues, double value) {
         this.name = name;
         this.labelNames = labelNames;
         this.labelValues = labelValues;
@@ -87,7 +86,7 @@ abstract public class Collector {
           return false;
         }
         Sample other = (Sample) obj;
-        return other.name.equals(name) && Arrays.equals(other.labelNames, labelNames)
+        return other.name.equals(name) && other.labelNames.equals(labelNames)
           && other.labelValues.equals(labelValues) && other.value == value;
       }
 
@@ -111,17 +110,26 @@ abstract public class Collector {
   }
 
   /**
+   * Number of nanoseconds in a second.
+   */
+  public static final double NANOSECONDS_PER_SECOND = 1E9;
+  /**
+   * Number of milliseconds in a second.
+   */
+  public static final double MILLISECONDS_PER_SECOND = 1E3;
+
+  /**
    * Register the Collector with the default registry.
    */
-  public Collector register() {
+  public <T extends Collector> T register() {
     return register(CollectorRegistry.defaultRegistry);
   }
 
   /**
    * Register the Collector with the given registry.
    */
-  public Collector register(CollectorRegistry registry) {
+  public <T extends Collector> T register(CollectorRegistry registry) {
     registry.register(this);
-    return this;
+    return (T)this;
   }
 }

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -1,8 +1,8 @@
 package io.prometheus.client;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 /**
  * Counter metric, to track counts of events or running totals.
@@ -23,9 +23,9 @@ import java.util.Vector;
  * <pre>
  * {@code
  *   class YourClass {
- *     static final Counter requests = (Counter) Counter.build()
+ *     static final Counter requests = Counter.build()
  *         .name("requests_total").help("Total requests.").register();
- *     static final Counter failedRequests = (Counter) Counter.build()
+ *     static final Counter failedRequests = Counter.build()
  *         .name("requests_failed_total").help("Total failed requests.").register();
  *
  *     void processRequest() {
@@ -46,7 +46,7 @@ import java.util.Vector;
  * <pre>
  * {@code
  *   class YourClass {
- *     static final Counter requests = (Counter) Counter.build()
+ *     static final Counter requests = Counter.build()
  *         .name("requests_total").help("Total requests.")
  *         .labelNames("method").register();
  *
@@ -64,18 +64,15 @@ import java.util.Vector;
  * These can be aggregated and processed together much more easily in the Promtheus 
  * server than individual metrics for each labelset.
  */
-public class Counter extends SimpleCollector<Counter.Child> {
+public class Counter extends SimpleCollector<Counter.Child, Counter> {
 
-  public Counter(Builder b) {
+  Counter(Builder b) {
     super(b);
-    if (labelNames.length == 0) {
-      inc(0);
-    }
   }
 
-  public static class Builder extends SimpleCollector.Builder {
+  public static class Builder extends SimpleCollector.Builder<Counter> {
     @Override
-    public SimpleCollector create() {
+    public Counter create() {
       return new Counter(this);
     }
   }
@@ -142,13 +139,15 @@ public class Counter extends SimpleCollector<Counter.Child> {
   }
 
   @Override
-  public MetricFamilySamples[] collect() {
-    Vector<MetricFamilySamples.Sample> samples = new Vector<MetricFamilySamples.Sample>();
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
       samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
     }
-
     MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.COUNTER, help, samples);
-    return new MetricFamilySamples[]{mfs};
+
+    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
+    mfsList.add(mfs);
+    return mfsList;
   }
 }

--- a/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
@@ -3,11 +3,11 @@ package io.prometheus.client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Vector;
 import org.junit.Test;
 import org.junit.Before;
 
@@ -53,8 +53,8 @@ public class CollectorRegistryTest {
   }
 
   class EmptyCollector extends Collector {
-    public MetricFamilySamples[] collect(){
-      return new MetricFamilySamples[]{};
+    public List<MetricFamilySamples> collect(){
+      return new ArrayList<MetricFamilySamples>();
     }
   }
 

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -2,21 +2,21 @@ package io.prometheus.client;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Test;
 import org.junit.Before;
 
 
 public class CounterTest {
-
   CollectorRegistry registry;
   Counter noLabels, labels;
 
   @Before
   public void setUp() {
     registry = new CollectorRegistry();
-    noLabels = (Counter) Counter.build().name("nolabels").help("help").register(registry);
-    labels = (Counter) Counter.build().name("labels").help("help").labelNames("l").register(registry);
+    noLabels = Counter.build().name("nolabels").help("help").register(registry);
+    labels = Counter.build().name("labels").help("help").labelNames("l").register(registry);
   }
 
   private double getValue() {
@@ -64,16 +64,18 @@ public class CounterTest {
   @Test
   public void testCollect() {
     labels.labels("a").inc();
-    Collector.MetricFamilySamples[] mfs = labels.collect();
+    List<Collector.MetricFamilySamples> mfs = labels.collect();
     
-    Vector<Collector.MetricFamilySamples.Sample> samples = new Vector<Collector.MetricFamilySamples.Sample>();
-    Vector<String> labelValues = new Vector<String>();
+    ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
+    ArrayList<String> labelNames = new ArrayList<String>();
+    labelNames.add("l");
+    ArrayList<String> labelValues = new ArrayList<String>();
     labelValues.add("a");
-    samples.add(new Collector.MetricFamilySamples.Sample("labels", new String[]{"l"}, labelValues, 1.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels", labelNames, labelValues, 1.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.COUNTER, "help", samples);
 
-    assertEquals(1, mfs.length);
-    assertEquals(mfsFixture, mfs[0]);
+    assertEquals(1, mfs.size());
+    assertEquals(mfsFixture, mfs.get(0));
   }
 
 }

--- a/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
@@ -16,7 +16,7 @@ public class SimpleCollectorTest {
   @Before
   public void setUp() {
     registry = new CollectorRegistry();
-    metric = (Gauge) Gauge.build().name("labels").help("help").labelNames("l").register(registry);
+    metric = Gauge.build().name("labels").help("help").labelNames("l").register(registry);
   }
   
   private Double getValue(String labelValue) {
@@ -76,5 +76,29 @@ public class SimpleCollectorTest {
   @Test(expected=IllegalStateException.class)
   public void testHelpIsRequired() {
     Gauge.build().name("c").create();
+  }
+
+  @Test
+  public void testSetChild() {
+    metric.setChild(new Gauge.Child(){
+      public double get() {
+        return 42;
+      }
+    }, "a");
+    assertEquals(42.0, getValue("a").doubleValue(), .001);
+  }
+
+  @Test
+  public void testSetChildReturnsGauge() {
+    Gauge g = metric.setChild(new Gauge.Child(){
+      public double get() {
+        return 42;
+      }
+    }, "a");
+  }
+
+  @Test
+  public void testCreateReturnsGauge() {
+    Gauge g = Gauge.build().name("labels").help("help").labelNames("l").create();
   }
 }

--- a/simpleclient_common/pom.xml
+++ b/simpleclient_common/pom.xml
@@ -11,9 +11,9 @@
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient_common</artifactId>
 
-    <name>Prometheus Java Client Metrics</name>
+    <name>Prometheus Java Simpleclient Common</name>
     <description>
-        Prometheus Java Client Metrics
+        Common code used by various modules of the Simpleclient. 
     </description>
 
     <licenses>

--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -19,10 +19,11 @@ public class TextFormat {
       writer.write("# TYPE " + metricFamilySamples.name + " " + typeString(metricFamilySamples.type) + "\n");
       for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
         writer.write(sample.name);
-        if (sample.labelNames.length > 0) {
+        if (sample.labelNames.size() > 0) {
           writer.write("{");
-          for (int i = 0; i < sample.labelNames.length; ++i) {
-            writer.write(sample.labelNames[i] + "=\"" + escapeLabelValue(sample.labelValues.get(i)) + "\",");
+          for (int i = 0; i < sample.labelNames.size(); ++i) {
+            writer.write(String.format("%s=\"%s\",",
+                sample.labelNames.get(i),  escapeLabelValue(sample.labelValues.get(i))));
           }
           writer.write("}");
         }

--- a/simpleclient_hotspot/pom.xml
+++ b/simpleclient_hotspot/pom.xml
@@ -11,9 +11,9 @@
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient_hotspot</artifactId>
 
-    <name>Prometheus Java Client Metrics</name>
+    <name>Prometheus Java Simpleclient Hotspot</name>
     <description>
-        Prometheus Java Client Metrics
+        Collectors of data from Java Hotspot.
     </description>
 
     <licenses>

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
@@ -8,8 +8,9 @@ import java.io.IOException;
 import java.io.FileNotFoundException;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
-import java.util.Vector;
 
 import io.prometheus.client.Collector;
 
@@ -53,17 +54,15 @@ public class StandardExports extends Collector {
   }
 
   MetricFamilySamples singleMetric(String name, Type type, String help, double value) {
-    Vector<MetricFamilySamples.Sample> samples = new Vector<MetricFamilySamples.Sample>();
-    samples.add(new MetricFamilySamples.Sample(name, new String[]{}, new Vector<String>(), value));
+    ArrayList<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+    samples.add(new MetricFamilySamples.Sample(name, new ArrayList<String>(), new ArrayList<String>(), value));
     return new MetricFamilySamples(name, type, help, samples);
   }
 
-  private final static double NANOSECONDS_PER_SECOND = 1E9;
-  private final static double MILLISECONDS_PER_SECOND = 1E3;
   private final static double KB = 1024;
 
-  public MetricFamilySamples[] collect() {
-    Vector<MetricFamilySamples> mfs = new Vector<MetricFamilySamples>();
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
 
     mfs.add(singleMetric("process_cpu_seconds_total", Type.COUNTER, "CPU time used by the process in seconds.",
         osBean.getProcessCpuTime() / NANOSECONDS_PER_SECOND));
@@ -89,11 +88,10 @@ public class StandardExports extends Collector {
         LOGGER.warning(e.toString());
       }
     }
-
-    return mfs.toArray(new MetricFamilySamples[]{});
+    return mfs;
   }
 
-  void collectMemoryMetricsLinux(Vector<MetricFamilySamples> mfs) {
+  void collectMemoryMetricsLinux(List<MetricFamilySamples> mfs) {
     // statm/stat report in pages, and it's non-trivial to get pagesize from Java
     // so we parse status instead.
     BufferedReader br = null;

--- a/simpleclient_pushgateway/pom.xml
+++ b/simpleclient_pushgateway/pom.xml
@@ -11,9 +11,9 @@
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient_pushgateway</artifactId>
 
-    <name>Prometheus Java Client Metrics</name>
+    <name>Prometheus Java Simpleclient Pushgateway</name>
     <description>
-        Prometheus Java Client Metrics
+        Pushgateway exporter for the simpleclient.
     </description>
 
     <licenses>

--- a/simpleclient_servlet/pom.xml
+++ b/simpleclient_servlet/pom.xml
@@ -11,9 +11,9 @@
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient_servlet</artifactId>
 
-    <name>Prometheus Java Client Metrics</name>
+    <name>Prometheus Java Simpleclient Servlet</name>
     <description>
-        Prometheus Java Client Metrics
+        HTTP servlet exporter for the simpleclient.
     </description>
 
     <licenses>


### PR DESCRIPTION
- Make descriptions/names in poms useful
- Offer commonly used constants in Collector
- Remove need for casting when using register/create
- Use Lists/ArrayLists for Collector api, rather than a mix of arrays/Vectors
- Add setChild to allow for easy callbacks for Gauge/Counter
- Add convenience methods to allow setting a Gauge to the current time,
  common in monitoring batch jobs.
- Add convenience methods to make it easier to observe durations
