### PR TITLE
Switch to DoubleAdder for simpleclient, it's more performant.

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,150 @@
+# Client Benchmarks
+
+This module contains microbenchmarks for client instrumentation operations.
+
+## Result Overview
+
+The main outcomes of the benchmarks:
+* Simpleclient Counters/Gauges have similar performance to Codahale Counters.
+* The original client is much slower than the Simpleclient or Codahale, especially when used concurrently.
+* Codahale Meters are slower than Codahale/Simpleclient Counters
+* Codahale and original client Summaries are 10x slower than other metrics.
+* Simpleclient `Gauge.Child.set` is relatively slow, especially when done concurrently.
+* Label lookups in both Prometheus clients is relatively slow.
+
+Accordingly, in terms of client instrumentation performance I suggest the following:
+* It's cheap to extensively instrument your code with Simpleclient Counters/Gauges/Summaries without labels, or Codahale Counters.
+* Avoid Codahale Meters, in favour of Codahale/Simpleclient Counters and calculating the rate in your monitoring system (e.g. the `rate()` function in Prometheus).
+* Avoid original client Summaries and Codahale Histograms/Timers on high update rate code paths.
+* Avoid the original client.
+* For high update rate (&gt;1000 per second) prometheus metrics using labels, you should cache the Child. Java 8 may make this better due to an improved ConcurrentHashMap implementation.
+* If a use case appears for high update rate use of SimpleClient's `Gauge.Child.set`, we should alter `DoubleAdder` to more efficiently handle this use case.
+
+## Benchmark Results
+
+These benchmarks were run using JMH on a 2-core MacBook Pro with a 2.5GHz i5 processor, 
+with Oracle Java 64 1.7.0\_51.
+
+### Counters
+    java -jar target/benchmarks.jar CounterBenchmark -wi 5 -i 5 -f 1 -t 1
+    i.p.b.CounterBenchmark.codahaleCounterIncBenchmark                    avgt        5   11.554 ± 0.251  ns/op
+    i.p.b.CounterBenchmark.codahaleMeterMarkBenchmark                     avgt        5   75.305 ± 7.147  ns/op
+    i.p.b.CounterBenchmark.prometheusCounterChildIncBenchmark             avgt        5   13.249 ± 0.029  ns/op
+    i.p.b.CounterBenchmark.prometheusCounterIncBenchmark                  avgt        5  127.397 ± 4.072  ns/op
+    i.p.b.CounterBenchmark.prometheusSimpleCounterChildIncBenchmark       avgt        5   12.989 ± 0.285  ns/op
+    i.p.b.CounterBenchmark.prometheusSimpleCounterIncBenchmark            avgt        5   54.822 ± 7.994  ns/op
+    i.p.b.CounterBenchmark.prometheusSimpleCounterNoLabelsIncBenchmark    avgt        5   13.131 ± 1.661  ns/op
+
+    java -jar target/benchmarks.jar CounterBenchmark -wi 5 -i 5 -f 1 -t 2
+    i.p.b.CounterBenchmark.codahaleCounterIncBenchmark                    avgt        5   16.707 ±  2.116  ns/op
+    i.p.b.CounterBenchmark.codahaleMeterMarkBenchmark                     avgt        5  107.346 ± 23.127  ns/op
+    i.p.b.CounterBenchmark.prometheusCounterChildIncBenchmark             avgt        5   41.912 ± 18.167  ns/op
+    i.p.b.CounterBenchmark.prometheusCounterIncBenchmark                  avgt        5  170.860 ±  5.110  ns/op
+    i.p.b.CounterBenchmark.prometheusSimpleCounterChildIncBenchmark       avgt        5   17.782 ±  2.764  ns/op
+    i.p.b.CounterBenchmark.prometheusSimpleCounterIncBenchmark            avgt        5   89.656 ±  4.577  ns/op
+    i.p.b.CounterBenchmark.prometheusSimpleCounterNoLabelsIncBenchmark    avgt        5   16.109 ±  1.723  ns/op
+
+    java -jar target/benchmarks.jar CounterBenchmark -wi 5 -i 5 -f 1 -t 4
+    i.p.b.CounterBenchmark.codahaleCounterIncBenchmark                    avgt        5   17.628 ±  0.501  ns/op
+    i.p.b.CounterBenchmark.codahaleMeterMarkBenchmark                     avgt        5  121.836 ± 15.888  ns/op
+    i.p.b.CounterBenchmark.prometheusCounterChildIncBenchmark             avgt        5  377.916 ±  7.965  ns/op
+    i.p.b.CounterBenchmark.prometheusCounterIncBenchmark                  avgt        5  250.919 ±  2.728  ns/op
+    i.p.b.CounterBenchmark.prometheusSimpleCounterChildIncBenchmark       avgt        5   18.055 ±  1.391  ns/op
+    i.p.b.CounterBenchmark.prometheusSimpleCounterIncBenchmark            avgt        5  120.543 ±  1.770  ns/op
+    i.p.b.CounterBenchmark.prometheusSimpleCounterNoLabelsIncBenchmark    avgt        5   19.334 ±  1.471  ns/op
+
+### Gauges
+
+Codahale lacks a metric with a `set` method, so we'll compare to `Counter` which has `inc` and `dec`.
+
+    java -jar target/benchmarks.jar GaugeBenchmark -wi 5 -i 5 -f 1 -t 1
+    i.p.b.GaugeBenchmark.codahaleCounterDecBenchmark                  avgt        5   11.620 ± 0.288  ns/op
+    i.p.b.GaugeBenchmark.codahaleCounterIncBenchmark                  avgt        5   11.718 ± 0.333  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeChildDecBenchmark             avgt        5   13.358 ± 0.554  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeChildIncBenchmark             avgt        5   13.268 ± 0.276  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeChildSetBenchmark             avgt        5   11.624 ± 0.210  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeDecBenchmark                  avgt        5  125.058 ± 2.764  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeIncBenchmark                  avgt        5  127.814 ± 7.741  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeSetBenchmark                  avgt        5  127.899 ± 6.690  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildDecBenchmark       avgt        5   12.961 ± 0.393  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildIncBenchmark       avgt        5   12.932 ± 0.212  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildSetBenchmark       avgt        5   36.672 ± 1.112  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeDecBenchmark            avgt        5   54.677 ± 3.704  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeIncBenchmark            avgt        5   53.278 ± 1.104  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeSetBenchmark            avgt        5   79.724 ± 2.723  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsDecBenchmark    avgt        5   12.957 ± 0.437  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsIncBenchmark    avgt        5   12.932 ± 0.284  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsSetBenchmark    avgt        5   40.235 ± 1.735  ns/op
+
+    java -jar target/benchmarks.jar GaugeBenchmark -wi 5 -i 5 -f 1 -t 2
+    i.p.b.GaugeBenchmark.codahaleCounterDecBenchmark                  avgt        5   17.443 ±  4.819  ns/op
+    i.p.b.GaugeBenchmark.codahaleCounterIncBenchmark                  avgt        5   14.882 ±  2.875  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeChildDecBenchmark             avgt        5   45.206 ± 29.575  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeChildIncBenchmark             avgt        5   46.657 ± 33.518  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeChildSetBenchmark             avgt        5   21.810 ±  9.370  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeDecBenchmark                  avgt        5  177.370 ±  2.477  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeIncBenchmark                  avgt        5  172.136 ±  3.056  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeSetBenchmark                  avgt        5  186.791 ±  7.996  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildDecBenchmark       avgt        5   15.978 ±  2.762  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildIncBenchmark       avgt        5   15.457 ±  1.052  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildSetBenchmark       avgt        5  156.604 ± 10.953  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeDecBenchmark            avgt        5  107.134 ± 33.620  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeIncBenchmark            avgt        5   89.362 ± 16.608  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeSetBenchmark            avgt        5  163.823 ± 25.270  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsDecBenchmark    avgt        5   16.380 ±  1.915  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsIncBenchmark    avgt        5   17.042 ±  1.113  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsSetBenchmark    avgt        5  164.930 ±  2.565  ns/op
+
+    java -jar target/benchmarks.jar GaugeBenchmark -wi 5 -i 5 -f 1 -t 4
+    i.p.b.GaugeBenchmark.codahaleCounterDecBenchmark                  avgt        5   17.291 ±  1.769  ns/op
+    i.p.b.GaugeBenchmark.codahaleCounterIncBenchmark                  avgt        5   17.445 ±  0.709  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeChildDecBenchmark             avgt        5  389.411 ± 13.078  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeChildIncBenchmark             avgt        5  399.549 ± 29.274  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeChildSetBenchmark             avgt        5  123.700 ±  3.894  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeDecBenchmark                  avgt        5  244.741 ± 22.477  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeIncBenchmark                  avgt        5  243.525 ±  6.332  ns/op
+    i.p.b.GaugeBenchmark.prometheusGaugeSetBenchmark                  avgt        5  252.363 ±  2.664  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildDecBenchmark       avgt        5   18.330 ±  2.673  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildIncBenchmark       avgt        5   20.633 ±  1.219  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildSetBenchmark       avgt        5  335.455 ±  4.562  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeDecBenchmark            avgt        5  116.432 ±  4.793  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeIncBenchmark            avgt        5  129.390 ±  2.360  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeSetBenchmark            avgt        5  613.186 ± 20.548  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsDecBenchmark    avgt        5   19.765 ±  3.189  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsIncBenchmark    avgt        5   19.589 ±  1.634  ns/op
+    i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsSetBenchmark    avgt        5  307.238 ±  1.918  ns/op
+
+### Summaries
+
+The simpleclient `Summary` doesn't have percentiles, so it's not an apples to
+apples comparison. The closest to the original client's `Summary` is Codahale's 
+`Timer`, but that includes timing calls so we compare with `Histogram` instead.
+
+    java -jar target/benchmarks.jar SummaryBenchmark -wi 5 -i 5 -f 1 -t 1
+    i.p.b.SummaryBenchmark.codahaleHistogramBenchmark                  avgt        5   187.192 ±  12.304  ns/op
+    i.p.b.SummaryBenchmark.prometheusSimpleSummaryBenchmark            avgt        5    61.140 ±   1.298  ns/op
+    i.p.b.SummaryBenchmark.prometheusSimpleSummaryChildBenchmark       avgt        5    15.322 ±   0.266  ns/op
+    i.p.b.SummaryBenchmark.prometheusSimpleSummaryNoLabelsBenchmark    avgt        5    15.750 ±   0.476  ns/op
+    i.p.b.SummaryBenchmark.prometheusSummaryBenchmark                  avgt        5   988.597 ± 343.221  ns/op
+    i.p.b.SummaryBenchmark.prometheusSummaryChildBenchmark             avgt        5  1165.270 ± 916.324  ns/op
+
+    java -jar target/benchmarks.jar SummaryBenchmark -wi 5 -i 5 -f 1 -t 2
+    i.p.b.SummaryBenchmark.codahaleHistogramBenchmark                  avgt        5   243.749 ±   37.080  ns/op
+    i.p.b.SummaryBenchmark.prometheusSimpleSummaryBenchmark            avgt        5   119.753 ±   15.056  ns/op
+    i.p.b.SummaryBenchmark.prometheusSimpleSummaryChildBenchmark       avgt        5    32.614 ±   15.976  ns/op
+    i.p.b.SummaryBenchmark.prometheusSimpleSummaryNoLabelsBenchmark    avgt        5    32.627 ±    8.943  ns/op
+    i.p.b.SummaryBenchmark.prometheusSummaryBenchmark                  avgt        5  2021.984 ±  561.545  ns/op
+    i.p.b.SummaryBenchmark.prometheusSummaryChildBenchmark             avgt        5  2338.371 ± 1515.886  ns/op
+
+    java -jar target/benchmarks.jar SummaryBenchmark -wi 5 -i 5 -f 1 -t 4
+    i.p.b.SummaryBenchmark.codahaleHistogramBenchmark                  avgt        5   559.505 ±    5.169  ns/op
+    i.p.b.SummaryBenchmark.prometheusSimpleSummaryBenchmark            avgt        5   137.072 ±   12.044  ns/op
+    i.p.b.SummaryBenchmark.prometheusSimpleSummaryChildBenchmark       avgt        5    44.228 ±    0.697  ns/op
+    i.p.b.SummaryBenchmark.prometheusSimpleSummaryNoLabelsBenchmark    avgt        5    41.223 ±    1.978  ns/op
+    i.p.b.SummaryBenchmark.prometheusSummaryBenchmark                  avgt        5  4023.354 ± 1122.317  ns/op
+    i.p.b.SummaryBenchmark.prometheusSummaryChildBenchmark             avgt        5  4606.571 ± 3392.565  ns/op
+
+Note the high error bars for the original client, it got slower with each iteration
+so I suspect a flaw in the test setup.
+
+

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.6-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.prometheus</groupId>
+    <artifactId>benchmarks</artifactId>
+
+    <name>Prometheus Java Client Benchmarks</name>
+    <description>
+        Benchmarks of client performance, and comparison to other systems.
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>client</artifactId>
+            <version>0.0.6-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.0.6-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+          <groupId>com.codahale.metrics</groupId>
+          <artifactId>metrics-core</artifactId>
+          <version>3.0.2</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>benchmarks</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/benchmark/src/main/java/io/prometheus/benchmark/CounterBenchmark.java
+++ b/benchmark/src/main/java/io/prometheus/benchmark/CounterBenchmark.java
@@ -1,0 +1,116 @@
+package io.prometheus.benchmark;
+
+import com.codahale.metrics.MetricRegistry;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+public class CounterBenchmark {
+
+  MetricRegistry registry;
+  com.codahale.metrics.Counter codahaleCounter;
+  com.codahale.metrics.Meter codahaleMeter;
+
+  io.prometheus.client.metrics.Counter prometheusCounter;
+  io.prometheus.client.metrics.Counter.Child prometheusCounterChild;
+  io.prometheus.client.Counter prometheusSimpleCounter;
+  io.prometheus.client.Counter.Child prometheusSimpleCounterChild;
+  io.prometheus.client.Counter prometheusSimpleCounterNoLabels;
+
+  @Setup
+  public void setup() {
+    prometheusCounter = io.prometheus.client.metrics.Counter.newBuilder()
+      .name("name")
+      .documentation("some description..")
+      .build();
+    prometheusCounterChild = prometheusCounter.newPartial().apply();
+
+    prometheusSimpleCounter = io.prometheus.client.Counter.build()
+      .name("name")
+      .help("some description..")
+      .labelNames("some", "group").create();
+    prometheusSimpleCounterChild = prometheusSimpleCounter.labels("test", "group");
+
+    prometheusSimpleCounterNoLabels = io.prometheus.client.Counter.build()
+      .name("name")
+      .help("some description..")
+      .create();
+
+    registry = new MetricRegistry();
+    codahaleCounter = registry.counter("counter");
+    codahaleMeter = registry.meter("meter");
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusCounterIncBenchmark() {
+    prometheusCounter.newPartial().apply().increment();
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusCounterChildIncBenchmark() {
+    prometheusCounterChild.increment();
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleCounterIncBenchmark() {
+    prometheusSimpleCounter.labels("test", "group").inc(); 
+  }
+  
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleCounterChildIncBenchmark() {
+    prometheusSimpleCounterChild.inc(); 
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleCounterNoLabelsIncBenchmark() {
+    prometheusSimpleCounterNoLabels.inc(); 
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void codahaleCounterIncBenchmark() {
+    codahaleCounter.inc();
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void codahaleMeterMarkBenchmark() {
+    codahaleMeter.mark();
+  }
+
+  public static void main(String[] args) throws RunnerException {
+
+    Options opt = new OptionsBuilder()
+      .include(CounterBenchmark.class.getSimpleName())
+      .warmupIterations(5)
+      .measurementIterations(4)
+      .threads(4)
+      .forks(1)
+      .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>simpleclient_hotspot</module>
         <module>simpleclient_servlet</module>
         <module>simpleclient_pushgateway</module>
+        <module>benchmark</module>
     </modules>
 
     <build>

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -96,7 +96,7 @@ public class Counter extends SimpleCollector<Counter.Child, Counter> {
    * {@link SimpleCollector#remove} or {@link SimpleCollector#clear},
    */
   public static class Child {
-    private volatile double value;
+    private DoubleAdder value = new DoubleAdder();
     /**
      * Increment the counter by 1.
      */
@@ -111,15 +111,13 @@ public class Counter extends SimpleCollector<Counter.Child, Counter> {
       if (amt < 0) {
         throw new IllegalArgumentException("Amount to increment must be non-negative.");
       }
-      synchronized(this){
-        value += amt;
-      }
+      value.add(amt);
     }
     /**
      * Get the value of the counter.
      */
     public double get() {
-      return value;
+      return value.sum();
     }
   }
 
@@ -135,7 +133,7 @@ public class Counter extends SimpleCollector<Counter.Child, Counter> {
    * @throws IllegalArgumentException If amt is negative.
    */
   public void inc(double amt) {
-    labels().inc(amt);
+    noLabelsChild.inc(amt);
   }
 
   @Override

--- a/simpleclient/src/main/java/io/prometheus/client/DoubleAdder.java
+++ b/simpleclient/src/main/java/io/prometheus/client/DoubleAdder.java
@@ -1,0 +1,201 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package io.prometheus.client;
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * One or more variables that together maintain an initially zero
+ * {@code double} sum.  When updates (method {@link #add}) are
+ * contended across threads, the set of variables may grow dynamically
+ * to reduce contention.  Method {@link #sum} (or, equivalently {@link
+ * #doubleValue}) returns the current total combined across the
+ * variables maintaining the sum.
+ *
+ * <p>This class extends {@link Number}, but does <em>not</em> define
+ * methods such as {@code hashCode} and {@code compareTo} because
+ * instances are expected to be mutated, and so are not useful as
+ * collection keys.
+ *
+ * <p><em>jsr166e note: This class is targeted to be placed in
+ * java.util.concurrent.atomic<em>
+ *
+ * @since 1.8
+ * @author Doug Lea
+ */
+public class DoubleAdder extends Striped64 implements Serializable {
+    private static final long serialVersionUID = 7249069246863182397L;
+
+    /**
+     * Update function. Note that we must use "long" for underlying
+     * representations, because there is no compareAndSet for double,
+     * due to the fact that the bitwise equals used in any CAS
+     * implementation is not the same as double-precision equals.
+     * However, we use CAS only to detect and alleviate contention,
+     * for which bitwise equals works best anyway. In principle, the
+     * long/double conversions used here should be essentially free on
+     * most platforms since they just re-interpret bits.
+     *
+     * Similar conversions are used in other methods.
+     */
+    final long fn(long v, long x) {
+        return Double.doubleToRawLongBits
+            (Double.longBitsToDouble(v) +
+             Double.longBitsToDouble(x));
+    }
+
+    /**
+     * Creates a new adder with initial sum of zero.
+     */
+    public DoubleAdder() {
+    }
+
+    /**
+     * Adds the given value.
+     *
+     * @param x the value to add
+     */
+    public void add(double x) {
+        Cell[] as; long b, v; HashCode hc; Cell a; int n;
+        if ((as = cells) != null ||
+            !casBase(b = base,
+                     Double.doubleToRawLongBits
+                     (Double.longBitsToDouble(b) + x))) {
+            boolean uncontended = true;
+            int h = (hc = threadHashCode.get()).code;
+            if (as == null || (n = as.length) < 1 ||
+                (a = as[(n - 1) & h]) == null ||
+                !(uncontended = a.cas(v = a.value,
+                                      Double.doubleToRawLongBits
+                                      (Double.longBitsToDouble(v) + x))))
+                retryUpdate(Double.doubleToRawLongBits(x), hc, uncontended);
+        }
+    }
+
+    /**
+     * Returns the current sum.  The returned value is <em>NOT</em> an
+     * atomic snapshot: Invocation in the absence of concurrent
+     * updates returns an accurate result, but concurrent updates that
+     * occur while the sum is being calculated might not be
+     * incorporated.  Also, because double-precision arithmetic is not
+     * strictly associative, the returned result need not be identical
+     * to the value that would be obtained in a sequential series of
+     * updates to a single variable.
+     *
+     * @return the sum
+     */
+    public double sum() {
+        Cell[] as = cells;
+        double sum = Double.longBitsToDouble(base);
+        if (as != null) {
+            int n = as.length;
+            for (int i = 0; i < n; ++i) {
+                Cell a = as[i];
+                if (a != null)
+                    sum += Double.longBitsToDouble(a.value);
+            }
+        }
+        return sum;
+    }
+
+    /**
+     * Resets variables maintaining the sum to zero.  This method may
+     * be a useful alternative to creating a new adder, but is only
+     * effective if there are no concurrent updates.  Because this
+     * method is intrinsically racy, it should only be used when it is
+     * known that no threads are concurrently updating.
+     */
+    public void reset() {
+        internalReset(0L);
+    }
+
+    /**
+     * Equivalent in effect to {@link #sum} followed by {@link
+     * #reset}. This method may apply for example during quiescent
+     * points between multithreaded computations.  If there are
+     * updates concurrent with this method, the returned value is
+     * <em>not</em> guaranteed to be the final value occurring before
+     * the reset.
+     *
+     * @return the sum
+     */
+    public double sumThenReset() {
+        Cell[] as = cells;
+        double sum = Double.longBitsToDouble(base);
+        base = 0L;
+        if (as != null) {
+            int n = as.length;
+            for (int i = 0; i < n; ++i) {
+                Cell a = as[i];
+                if (a != null) {
+                    long v = a.value;
+                    a.value = 0L;
+                    sum += Double.longBitsToDouble(v);
+                }
+            }
+        }
+        return sum;
+    }
+
+    /**
+     * Returns the String representation of the {@link #sum}.
+     * @return the String representation of the {@link #sum}
+     */
+    public String toString() {
+        return Double.toString(sum());
+    }
+
+    /**
+     * Equivalent to {@link #sum}.
+     *
+     * @return the sum
+     */
+    public double doubleValue() {
+        return sum();
+    }
+
+    /**
+     * Returns the {@link #sum} as a {@code long} after a
+     * narrowing primitive conversion.
+     */
+    public long longValue() {
+        return (long)sum();
+    }
+
+    /**
+     * Returns the {@link #sum} as an {@code int} after a
+     * narrowing primitive conversion.
+     */
+    public int intValue() {
+        return (int)sum();
+    }
+
+    /**
+     * Returns the {@link #sum} as a {@code float}
+     * after a narrowing primitive conversion.
+     */
+    public float floatValue() {
+        return (float)sum();
+    }
+
+    private void writeObject(java.io.ObjectOutputStream s)
+        throws java.io.IOException {
+        s.defaultWriteObject();
+        s.writeDouble(sum());
+    }
+
+    private void readObject(ObjectInputStream s)
+        throws IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        busy = 0;
+        cells = null;
+        base = Double.doubleToRawLongBits(s.readDouble());
+    }
+
+}

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -1,6 +1,7 @@
 package io.prometheus.client;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.Arrays;
 import java.util.List;
 
@@ -49,7 +50,8 @@ public abstract class SimpleCollector<Child, T extends SimpleCollector> extends 
   protected final String help;
   protected final List<String> labelNames;
 
-  protected final ConcurrentHashMap<List<String>, Child> children = new ConcurrentHashMap<List<String>, Child>();;
+  protected final ConcurrentMap<List<String>, Child> children = new ConcurrentHashMap<List<String>, Child>();;
+  protected Child noLabelsChild;
 
   /**
    * Return the Child with the given labels, creating it if needed.
@@ -76,6 +78,9 @@ public abstract class SimpleCollector<Child, T extends SimpleCollector> extends 
    */
   public void remove(String... labelValues) {
     children.remove(Arrays.asList(labelValues));
+    if (labelNames.size() == 0) {
+      noLabelsChild = labels();
+    }
   }
   
   /**
@@ -85,6 +90,9 @@ public abstract class SimpleCollector<Child, T extends SimpleCollector> extends 
    */
   public void clear() {
     children.clear();
+    if (labelNames.size() == 0) {
+      noLabelsChild = labels();
+    }
   }
 
   /**
@@ -139,7 +147,7 @@ public abstract class SimpleCollector<Child, T extends SimpleCollector> extends 
 
     // Initlize metric if it has no labels.
     if (labelNames.size() == 0) {
-      labels();
+      noLabelsChild = labels();
     }
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Striped64.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Striped64.java
@@ -1,0 +1,340 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package io.prometheus.client;
+import java.util.Random;
+
+/**
+ * A package-local class holding common representation and mechanics
+ * for classes supporting dynamic striping on 64bit values. The class
+ * extends Number so that concrete subclasses must publicly do so.
+ */
+abstract class Striped64 extends Number {
+    /*
+     * This class maintains a lazily-initialized table of atomically
+     * updated variables, plus an extra "base" field. The table size
+     * is a power of two. Indexing uses masked per-thread hash codes.
+     * Nearly all declarations in this class are package-private,
+     * accessed directly by subclasses.
+     *
+     * Table entries are of class Cell; a variant of AtomicLong padded
+     * to reduce cache contention on most processors. Padding is
+     * overkill for most Atomics because they are usually irregularly
+     * scattered in memory and thus don't interfere much with each
+     * other. But Atomic objects residing in arrays will tend to be
+     * placed adjacent to each other, and so will most often share
+     * cache lines (with a huge negative performance impact) without
+     * this precaution.
+     *
+     * In part because Cells are relatively large, we avoid creating
+     * them until they are needed.  When there is no contention, all
+     * updates are made to the base field.  Upon first contention (a
+     * failed CAS on base update), the table is initialized to size 2.
+     * The table size is doubled upon further contention until
+     * reaching the nearest power of two greater than or equal to the
+     * number of CPUS. Table slots remain empty (null) until they are
+     * needed.
+     *
+     * A single spinlock ("busy") is used for initializing and
+     * resizing the table, as well as populating slots with new Cells.
+     * There is no need for a blocking lock: When the lock is not
+     * available, threads try other slots (or the base).  During these
+     * retries, there is increased contention and reduced locality,
+     * which is still better than alternatives.
+     *
+     * Per-thread hash codes are initialized to random values.
+     * Contention and/or table collisions are indicated by failed
+     * CASes when performing an update operation (see method
+     * retryUpdate). Upon a collision, if the table size is less than
+     * the capacity, it is doubled in size unless some other thread
+     * holds the lock. If a hashed slot is empty, and lock is
+     * available, a new Cell is created. Otherwise, if the slot
+     * exists, a CAS is tried.  Retries proceed by "double hashing",
+     * using a secondary hash (Marsaglia XorShift) to try to find a
+     * free slot.
+     *
+     * The table size is capped because, when there are more threads
+     * than CPUs, supposing that each thread were bound to a CPU,
+     * there would exist a perfect hash function mapping threads to
+     * slots that eliminates collisions. When we reach capacity, we
+     * search for this mapping by randomly varying the hash codes of
+     * colliding threads.  Because search is random, and collisions
+     * only become known via CAS failures, convergence can be slow,
+     * and because threads are typically not bound to CPUS forever,
+     * may not occur at all. However, despite these limitations,
+     * observed contention rates are typically low in these cases.
+     *
+     * It is possible for a Cell to become unused when threads that
+     * once hashed to it terminate, as well as in the case where
+     * doubling the table causes no thread to hash to it under
+     * expanded mask.  We do not try to detect or remove such cells,
+     * under the assumption that for long-running instances, observed
+     * contention levels will recur, so the cells will eventually be
+     * needed again; and for short-lived ones, it does not matter.
+     */
+
+    /**
+     * Padded variant of AtomicLong supporting only raw accesses plus CAS.
+     * The value field is placed between pads, hoping that the JVM doesn't
+     * reorder them.
+     *
+     * JVM intrinsics note: It would be possible to use a release-only
+     * form of CAS here, if it were provided.
+     */
+    static final class Cell {
+        volatile long p0, p1, p2, p3, p4, p5, p6;
+        volatile long value;
+        volatile long q0, q1, q2, q3, q4, q5, q6;
+        Cell(long x) { value = x; }
+
+        final boolean cas(long cmp, long val) {
+            return UNSAFE.compareAndSwapLong(this, valueOffset, cmp, val);
+        }
+
+        // Unsafe mechanics
+        private static final sun.misc.Unsafe UNSAFE;
+        private static final long valueOffset;
+        static {
+            try {
+                UNSAFE = getUnsafe();
+                Class<?> ak = Cell.class;
+                valueOffset = UNSAFE.objectFieldOffset
+                    (ak.getDeclaredField("value"));
+            } catch (Exception e) {
+                throw new Error(e);
+            }
+        }
+
+    }
+
+    /**
+     * Holder for the thread-local hash code. The code is initially
+     * random, but may be set to a different value upon collisions.
+     */
+    static final class HashCode {
+        static final Random rng = new Random();
+        int code;
+        HashCode() {
+            int h = rng.nextInt(); // Avoid zero to allow xorShift rehash
+            code = (h == 0) ? 1 : h;
+        }
+    }
+
+    /**
+     * The corresponding ThreadLocal class
+     */
+    static final class ThreadHashCode extends ThreadLocal<HashCode> {
+        public HashCode initialValue() { return new HashCode(); }
+    }
+
+    /**
+     * Static per-thread hash codes. Shared across all instances to
+     * reduce ThreadLocal pollution and because adjustments due to
+     * collisions in one table are likely to be appropriate for
+     * others.
+     */
+    static final ThreadHashCode threadHashCode = new ThreadHashCode();
+
+    /** Number of CPUS, to place bound on table size */
+    static final int NCPU = Runtime.getRuntime().availableProcessors();
+
+    /**
+     * Table of cells. When non-null, size is a power of 2.
+     */
+    transient volatile Cell[] cells;
+
+    /**
+     * Base value, used mainly when there is no contention, but also as
+     * a fallback during table initialization races. Updated via CAS.
+     */
+    transient volatile long base;
+
+    /**
+     * Spinlock (locked via CAS) used when resizing and/or creating Cells.
+     */
+    transient volatile int busy;
+
+    /**
+     * Package-private default constructor
+     */
+    Striped64() {
+    }
+
+    /**
+     * CASes the base field.
+     */
+    final boolean casBase(long cmp, long val) {
+        return UNSAFE.compareAndSwapLong(this, baseOffset, cmp, val);
+    }
+
+    /**
+     * CASes the busy field from 0 to 1 to acquire lock.
+     */
+    final boolean casBusy() {
+        return UNSAFE.compareAndSwapInt(this, busyOffset, 0, 1);
+    }
+
+    /**
+     * Computes the function of current and new value. Subclasses
+     * should open-code this update function for most uses, but the
+     * virtualized form is needed within retryUpdate.
+     *
+     * @param currentValue the current value (of either base or a cell)
+     * @param newValue the argument from a user update call
+     * @return result of the update function
+     */
+    abstract long fn(long currentValue, long newValue);
+
+    /**
+     * Handles cases of updates involving initialization, resizing,
+     * creating new Cells, and/or contention. See above for
+     * explanation. This method suffers the usual non-modularity
+     * problems of optimistic retry code, relying on rechecked sets of
+     * reads.
+     *
+     * @param x the value
+     * @param hc the hash code holder
+     * @param wasUncontended false if CAS failed before call
+     */
+    final void retryUpdate(long x, HashCode hc, boolean wasUncontended) {
+        int h = hc.code;
+        boolean collide = false;                // True if last slot nonempty
+        for (;;) {
+            Cell[] as; Cell a; int n; long v;
+            if ((as = cells) != null && (n = as.length) > 0) {
+                if ((a = as[(n - 1) & h]) == null) {
+                    if (busy == 0) {            // Try to attach new Cell
+                        Cell r = new Cell(x);   // Optimistically create
+                        if (busy == 0 && casBusy()) {
+                            boolean created = false;
+                            try {               // Recheck under lock
+                                Cell[] rs; int m, j;
+                                if ((rs = cells) != null &&
+                                    (m = rs.length) > 0 &&
+                                    rs[j = (m - 1) & h] == null) {
+                                    rs[j] = r;
+                                    created = true;
+                                }
+                            } finally {
+                                busy = 0;
+                            }
+                            if (created)
+                                break;
+                            continue;           // Slot is now non-empty
+                        }
+                    }
+                    collide = false;
+                }
+                else if (!wasUncontended)       // CAS already known to fail
+                    wasUncontended = true;      // Continue after rehash
+                else if (a.cas(v = a.value, fn(v, x)))
+                    break;
+                else if (n >= NCPU || cells != as)
+                    collide = false;            // At max size or stale
+                else if (!collide)
+                    collide = true;
+                else if (busy == 0 && casBusy()) {
+                    try {
+                        if (cells == as) {      // Expand table unless stale
+                            Cell[] rs = new Cell[n << 1];
+                            for (int i = 0; i < n; ++i)
+                                rs[i] = as[i];
+                            cells = rs;
+                        }
+                    } finally {
+                        busy = 0;
+                    }
+                    collide = false;
+                    continue;                   // Retry with expanded table
+                }
+                h ^= h << 13;                   // Rehash
+                h ^= h >>> 17;
+                h ^= h << 5;
+            }
+            else if (busy == 0 && cells == as && casBusy()) {
+                boolean init = false;
+                try {                           // Initialize table
+                    if (cells == as) {
+                        Cell[] rs = new Cell[2];
+                        rs[h & 1] = new Cell(x);
+                        cells = rs;
+                        init = true;
+                    }
+                } finally {
+                    busy = 0;
+                }
+                if (init)
+                    break;
+            }
+            else if (casBase(v = base, fn(v, x)))
+                break;                          // Fall back on using base
+        }
+        hc.code = h;                            // Record index for next time
+    }
+
+
+    /**
+     * Sets base and all cells to the given value.
+     */
+    final void internalReset(long initialValue) {
+        Cell[] as = cells;
+        base = initialValue;
+        if (as != null) {
+            int n = as.length;
+            for (int i = 0; i < n; ++i) {
+                Cell a = as[i];
+                if (a != null)
+                    a.value = initialValue;
+            }
+        }
+    }
+
+    // Unsafe mechanics
+    private static final sun.misc.Unsafe UNSAFE;
+    private static final long baseOffset;
+    private static final long busyOffset;
+    static {
+        try {
+            UNSAFE = getUnsafe();
+            Class<?> sk = Striped64.class;
+            baseOffset = UNSAFE.objectFieldOffset
+                (sk.getDeclaredField("base"));
+            busyOffset = UNSAFE.objectFieldOffset
+                (sk.getDeclaredField("busy"));
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    /**
+     * Returns a sun.misc.Unsafe.  Suitable for use in a 3rd party package.
+     * Replace with a simple call to Unsafe.getUnsafe when integrating
+     * into a jdk.
+     *
+     * @return a sun.misc.Unsafe
+     */
+    private static sun.misc.Unsafe getUnsafe() {
+        try {
+            return sun.misc.Unsafe.getUnsafe();
+        } catch (SecurityException se) {
+            try {
+                return java.security.AccessController.doPrivileged
+                    (new java.security
+                     .PrivilegedExceptionAction<sun.misc.Unsafe>() {
+                        public sun.misc.Unsafe run() throws Exception {
+                            java.lang.reflect.Field f = sun.misc
+                                .Unsafe.class.getDeclaredField("theUnsafe");
+                            f.setAccessible(true);
+                            return (sun.misc.Unsafe) f.get(null);
+                        }});
+            } catch (java.security.PrivilegedActionException e) {
+                throw new RuntimeException("Could not initialize intrinsics",
+                                           e.getCause());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request depends on https://github.com/prometheus/client_java/pull/49

Add benchmarks for both of our java clients, and a comparison with
codahale/yammer metrics. This is based on internal benchmarks by Will Fleury.

Add caching of the Child when there's no labels. This is the most common use
case, and makes it 4-5x faster than the naive approach.

Performance comparison:
Codehale(a popular java instrumention library) takes 12ns per increment
of a counter uncontended, rising to 18ns with 4 threads

The original client takes 126ns, rising to 245ns with 4 threads.
Incrementing the child takes 13ns, rising to 382ns with 4 threads (odd - it should be <245ns).

With theese changes the Simpleclient's performance goes from:
- Uncontended labels() increment: 70ns -> 54ns
- 2-thread labels() increment: 146ns -> 103ns
- 4-thread labels() increment: 509ns -> 130ns
- Uncontended Child increment: 29ns -> 13ns
- 2-thread Child increment: 102ns -> 16ns
- 4-thread Child increment: 215ns -> 19ns
- Uncontended nolabels convenience increment: 50ns -> 13ns
- 2-thread nolabels convenience increment: 172ns -> 17ns
- 4-thread nolabels convenience increment: 434ns -> 20ns

The new numbers are much faster, and comparable with codehale.
ConcurrentHashMap doesn't seem great with lots of threads, avoiding
that by caching the Child is advised where you have labels and a high rate of concurrent updates.
I tested on a 2-core MacBook Pro with a 2.5GHz i5 processor, Oracle Java 64 1.7.0_51.
