### PR TITLE
Make it easier to capture durations.

### DIFF
--- a/benchmark/src/main/java/io/prometheus/benchmark/GaugeBenchmark.java
+++ b/benchmark/src/main/java/io/prometheus/benchmark/GaugeBenchmark.java
@@ -1,0 +1,188 @@
+package io.prometheus.benchmark;
+
+import com.codahale.metrics.MetricRegistry;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+public class GaugeBenchmark {
+
+  MetricRegistry registry;
+  com.codahale.metrics.Counter codahaleCounter;
+
+  io.prometheus.client.metrics.Gauge prometheusGauge;
+  io.prometheus.client.metrics.Gauge.Child prometheusGaugeChild;
+  io.prometheus.client.Gauge prometheusSimpleGauge;
+  io.prometheus.client.Gauge.Child prometheusSimpleGaugeChild;
+  io.prometheus.client.Gauge prometheusSimpleGaugeNoLabels;
+
+  @Setup
+  public void setup() {
+    prometheusGauge = io.prometheus.client.metrics.Gauge.newBuilder()
+      .name("name")
+      .documentation("some description..")
+      .build();
+    prometheusGaugeChild = prometheusGauge.newPartial().apply();
+
+    prometheusSimpleGauge = io.prometheus.client.Gauge.build()
+      .name("name")
+      .help("some description..")
+      .labelNames("some", "group").create();
+    prometheusSimpleGaugeChild = prometheusSimpleGauge.labels("test", "group");
+
+    prometheusSimpleGaugeNoLabels = io.prometheus.client.Gauge.build()
+      .name("name")
+      .help("some description..")
+      .create();
+
+    registry = new MetricRegistry();
+    codahaleCounter = registry.counter("name");
+  }
+
+  // Increment.
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusGaugeIncBenchmark() {
+    prometheusGauge.newPartial().apply().increment();
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusGaugeChildIncBenchmark() {
+    prometheusGaugeChild.increment();
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleGaugeIncBenchmark() {
+    prometheusSimpleGauge.labels("test", "group").inc(); 
+  }
+  
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleGaugeChildIncBenchmark() {
+    prometheusSimpleGaugeChild.inc(); 
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleGaugeNoLabelsIncBenchmark() {
+    prometheusSimpleGaugeNoLabels.inc(); 
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void codahaleCounterIncBenchmark() {
+    codahaleCounter.inc();
+  }
+
+
+  // Decrement.
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusGaugeDecBenchmark() {
+    prometheusGauge.newPartial().apply().decrement();
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusGaugeChildDecBenchmark() {
+    prometheusGaugeChild.decrement();
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleGaugeDecBenchmark() {
+    prometheusSimpleGauge.labels("test", "group").dec(); 
+  }
+  
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleGaugeChildDecBenchmark() {
+    prometheusSimpleGaugeChild.dec(); 
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleGaugeNoLabelsDecBenchmark() {
+    prometheusSimpleGaugeNoLabels.dec(); 
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void codahaleCounterDecBenchmark() {
+    codahaleCounter.dec();
+  }
+
+  // Set.
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusGaugeSetBenchmark() {
+    prometheusGauge.newPartial().apply().set(42);
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusGaugeChildSetBenchmark() {
+    prometheusGaugeChild.set(42);
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleGaugeSetBenchmark() {
+    prometheusSimpleGauge.labels("test", "group").set(42); 
+  }
+  
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleGaugeChildSetBenchmark() {
+    prometheusSimpleGaugeChild.set(42);
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleGaugeNoLabelsSetBenchmark() {
+    prometheusSimpleGaugeNoLabels.set(42); 
+  }
+
+  public static void main(String[] args) throws RunnerException {
+
+    Options opt = new OptionsBuilder()
+      .include(GaugeBenchmark.class.getSimpleName())
+      .warmupIterations(5)
+      .measurementIterations(4)
+      .threads(4)
+      .forks(1)
+      .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmark/src/main/java/io/prometheus/benchmark/SummaryBenchmark.java
+++ b/benchmark/src/main/java/io/prometheus/benchmark/SummaryBenchmark.java
@@ -1,0 +1,107 @@
+package io.prometheus.benchmark;
+
+import com.codahale.metrics.MetricRegistry;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+public class SummaryBenchmark {
+
+  MetricRegistry registry;
+  com.codahale.metrics.Histogram codahaleHistogram;
+
+  io.prometheus.client.metrics.Summary prometheusSummary;
+  io.prometheus.client.metrics.Summary.Child prometheusSummaryChild;
+  io.prometheus.client.Summary prometheusSimpleSummary;
+  io.prometheus.client.Summary.Child prometheusSimpleSummaryChild;
+  io.prometheus.client.Summary prometheusSimpleSummaryNoLabels;
+
+  @Setup
+  public void setup() {
+    prometheusSummary = io.prometheus.client.metrics.Summary.newBuilder()
+      .name("name")
+      .documentation("some description..")
+      .build();
+    prometheusSummaryChild = prometheusSummary.newPartial().apply();
+
+    prometheusSimpleSummary = io.prometheus.client.Summary.build()
+      .name("name")
+      .help("some description..")
+      .labelNames("some", "group").create();
+    prometheusSimpleSummaryChild = prometheusSimpleSummary.labels("test", "group");
+
+    prometheusSimpleSummaryNoLabels = io.prometheus.client.Summary.build()
+      .name("name")
+      .help("some description..")
+      .create();
+
+    registry = new MetricRegistry();
+    codahaleHistogram = registry.histogram("name");
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSummaryBenchmark() {
+    prometheusSummary.newPartial().apply().observe(1.0);
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSummaryChildBenchmark() {
+    prometheusSummaryChild.observe(1.0);
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleSummaryBenchmark() {
+    prometheusSimpleSummary.labels("test", "group").observe(1) ;
+  }
+  
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleSummaryChildBenchmark() {
+    prometheusSimpleSummaryChild.observe(1); 
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void prometheusSimpleSummaryNoLabelsBenchmark() {
+    prometheusSimpleSummaryNoLabels.observe(1); 
+  }
+
+  @Benchmark
+  @BenchmarkMode({Mode.AverageTime})
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void codahaleHistogramBenchmark() {
+    codahaleHistogram.update(1);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+
+    Options opt = new OptionsBuilder()
+      .include(SummaryBenchmark.class.getSimpleName())
+      .warmupIterations(5)
+      .measurementIterations(4)
+      .threads(4)
+      .forks(1)
+      .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -100,10 +100,10 @@ public abstract class SimpleCollector<Child, T extends SimpleCollector> extends 
    * <p>
    * This is intended for advanced uses, in particular proxying metrics
    * from another monitoring system. This allows for callbacks for returning
-   * values for {@Link Counter} and {@Link Gauge} without having to implement
+   * values for {@link Counter} and {@link Gauge} without having to implement
    * a full {@link Collector}.
    * <p>
-   * An example with {@Link Gauge}:
+   * An example with {@link Gauge}:
    * <pre>
    * {@code
    *   Gauge.build().name("current_time").help("Current unixtime.").create()

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
@@ -72,7 +72,21 @@ public class GaugeTest {
     noLabels.setToCurrentTime();
     assertEquals(42, getValue(), .001);
   }
- 
+
+  @Test
+  public void testTimer() {
+    Gauge.Child.timeProvider = new Gauge.TimeProvider() {
+      long value = (long)(30 * 1e9);
+      long nanoTime() {
+        value += (long)(10 * 1e9);
+        return value;
+      }
+    };
+    Gauge.Timer timer = noLabels.startTimer();
+    timer.setDuration();
+    assertEquals(10, getValue(), .001);
+  }
+
   @Test
   public void noLabelsDefaultZeroValue() {
     assertEquals(0.0, getValue(), .001);

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -44,13 +44,16 @@ public class SummaryTest {
   }
 
   @Test
-  public void testObserveSecondsSinceNanoTime() {
+  public void testTimer() {
     Summary.Child.timeProvider = new Summary.TimeProvider() {
+      long value = (long)(30 * 1e9);
       long nanoTime() {
-        return (long)(30 * 1e9);
+        value += (long)(10 * 1e9);
+        return value;
       }
     };
-    noLabels.observeSecondsSinceNanoTime((long)(20 * 1e9));
+    Summary.Timer timer = noLabels.startTimer();
+    timer.observeDuration();
     assertEquals(1, getCount(), .001);
     assertEquals(10, getSum(), .001);
   }

--- a/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
+++ b/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
@@ -20,6 +20,31 @@ import java.io.OutputStreamWriter;
  * to a Pushgateway. This class allows pushing the contents of a {@link CollectorRegistry} to
  * a Pushgateway.
  * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   void executeBatchJob() throws Exception {
+ *     CollectorRegistry registry = new CollectorRegistry();
+ *     Gauge duration = Gauge.build()
+ *         .name("my_batch_job_duration_seconds").help("Duration of my batch job in seconds.").register(registry);
+ *     Gauge.Timer durationTimer = duration.startTimer();
+ *     try {
+ *       // Your code here.
+ *
+ *       // This is only added to the registry after success,
+ *       // so that a previous success in the Pushgateway isn't overwritten on failure.
+ *       Gauge lastSuccess = Gauge.build()
+ *           .name("my_batch_job_last_success").help("Last time my batch job succeeded, in unixtime.").register(registry);
+ *       lastSuccess.setToCurrentTime();
+ *     } finally {
+ *       durationTimer.setDuration();
+ *       PushGateway pg = new PushGateway("127.0.0.1:9091");
+ *       pg.pushAdd(registry, "my_batch_job", "my_batch_job");
+ *     }
+ *   }
+ * }
+ * </pre>
+ * <p>
  * See <a href="https://github.com/prometheus/pushgateway">https://github.com/prometheus/pushgateway</a>
  */
 public class PushGateway {


### PR DESCRIPTION
Use an object to time things, rather than making System.nanoTime part of our API.
If something more granular ever appears, we can use it.

Allow timing of events in gauges too, this is useful in batch jobs.
Expand PushGateway docs.

Add some files missed in the previous DoubleAdder pull request.
Make javadoc run have no warnings for simpleclient.
