### PR TITLE
Allow for large amounts of memory.

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
@@ -102,11 +102,11 @@ public class StandardExports extends Collector {
         if (line.startsWith("VmSize:")) {
           mfs.add(singleMetric("process_virtual_memory_bytes", Type.GAUGE,
               "The virtual memory size of the process, in bytes.",
-              Float.parseFloat(line.split(" +")[1]) * KB));
+              Float.parseFloat(line.split("\\s+")[1]) * KB));
         } else if (line.startsWith("VmRSS:")) {
           mfs.add(singleMetric("process_resident_memory_bytes", Type.GAUGE,
               "The resident memory size of the process, in bytes.",
-              Float.parseFloat(line.split(" +")[1]) * KB));
+              Float.parseFloat(line.split("\\s+")[1]) * KB));
         }
       }
     } catch (IOException e) {

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/StandardExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/StandardExportsTest.java
@@ -19,7 +19,7 @@ public class StandardExportsTest {
 
   static class StatusReaderTest extends StandardExports.StatusReader {
     BufferedReader procSelfStatusReader() throws FileNotFoundException {
-      return new BufferedReader(new StringReader("Name:   cat\nVmSize:     5900 kB\nVmRSS:       360 kB\n"));
+      return new BufferedReader(new StringReader("Name:   cat\nVmSize:\t5900 kB\nVmRSS:\t   360 kB\n"));
     }
   }
 


### PR DESCRIPTION
There's a \t after the :, and the space padding, the number, a space and the unit.
When the number is big, there's no padding so allow for that.