### PR TITLE
Add basic JVM metrics: MemoryPoolsExports GarbageCollectorExports.

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/GarbageCollectorExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/GarbageCollectorExports.java
@@ -1,0 +1,94 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.Collector;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Exports metrics about JVM garbage collectors.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new GarbageCollectorExports().register();
+ * }
+ * </pre>
+ * Example metrics being exported:
+ * <pre>
+ *   jvm_gc_collections{gc="PS1} 200
+ *   jvm_gc_collections_time{gc="PS1} 6.7
+ * </pre>
+ */
+public class GarbageCollectorExports extends Collector {
+  private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+  static final String COLLECTIONS_COUNT_METRIC = "jvm_gc_collections";
+  static final String COLLECTIONS_TIME_METRIC = "jvm_gc_collections_time";
+  static final List<String> LABEL_NAMES = Arrays.asList("gc");
+  private static final List<String> DEFAULT_LABEL = Arrays.asList("unknown");
+
+  private final HashMap<GarbageCollectorMXBean, List<String>> labelValues =
+      new HashMap<GarbageCollectorMXBean, List<String>>();
+  private final List<GarbageCollectorMXBean> garbageCollectors;
+
+  public GarbageCollectorExports() {
+    this(ManagementFactory.getGarbageCollectorMXBeans());
+  }
+
+  GarbageCollectorExports(List<GarbageCollectorMXBean> garbageCollectors) {
+    this.garbageCollectors = garbageCollectors;
+    for (final GarbageCollectorMXBean gc : garbageCollectors) {
+      if (!labelValues.containsKey(gc)) {
+        String gcName = WHITESPACE.matcher(gc.getName()).replaceAll("-");
+        labelValues.put(gc, Arrays.asList(gcName));
+      }
+    }
+  }
+
+  MetricFamilySamples collectorCountMetric() {
+    ArrayList<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+    for (final GarbageCollectorMXBean gc : garbageCollectors) {
+      samples.add(
+          new MetricFamilySamples.Sample(
+              COLLECTIONS_COUNT_METRIC,
+              LABEL_NAMES,
+              labelValues.getOrDefault(gc, DEFAULT_LABEL),
+              gc.getCollectionCount()));
+    }
+    return new MetricFamilySamples(
+        COLLECTIONS_COUNT_METRIC,
+        Type.COUNTER,
+        "Number of collections of a given JVM garbage collector.",
+        samples);
+  }
+
+  MetricFamilySamples collectorTimeMetric() {
+    ArrayList<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+    for (final GarbageCollectorMXBean gc : garbageCollectors) {
+      samples.add(
+          new MetricFamilySamples.Sample(
+              COLLECTIONS_TIME_METRIC,
+              LABEL_NAMES,
+              labelValues.getOrDefault(gc, DEFAULT_LABEL),
+              gc.getCollectionTime() / MILLISECONDS_PER_SECOND));
+    }
+    return new MetricFamilySamples(
+        COLLECTIONS_TIME_METRIC,
+        Type.COUNTER,
+        "Accumulated time (s) spent in a given JVM garbage collector.",
+        samples);
+  }
+
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+    mfs.add(collectorCountMetric());
+    mfs.add(collectorTimeMetric());
+
+    return mfs;
+  }
+}

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
@@ -1,0 +1,149 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.Collector;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Exports metrics about JVM memory areas.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new MemoryPoolsExports().register();
+ * }
+ * </pre>
+ * Example metrics being exported:
+ * <pre>
+ *   jvm_memory_used{area="heap} 2000000
+ *   jvm_memory_limit{area="nonheap"} 200000
+ *   jvm_memory_pool_used{pool="PS-Eden-Space"} 2000
+ * </pre>
+ */
+public class MemoryPoolsExports extends Collector {
+  private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+  static final String MEMORY_USED_METRIC = "jvm_memory_used";
+  static final String MEMORY_LIMIT_METRIC = "jvm_memory_limit";
+  static final String POOLS_USED_METRIC = "jvm_memory_pool_used";
+  static final String POOLS_LIMIT_METRIC = "jvm_memory_pool_limit";
+
+  private static final List<String> MEMORY_LABEL_NAMES = Arrays.asList("area");
+  private static final List<String> MEMORY_HEAP_LABEL = Arrays.asList("heap");
+  private static final List<String> MEMORY_NONHEAP_LABEL = Arrays.asList("nonheap");
+
+  private static final List<String> POOLS_LABEL_NAMES = Arrays.asList("pool");
+
+  private final HashMap<MemoryPoolMXBean, List<String>> poolLabelValues = new HashMap<MemoryPoolMXBean, List<String>>();
+  private final MemoryMXBean memoryBean;
+  private final List<MemoryPoolMXBean> poolBeans;
+
+  public MemoryPoolsExports() {
+    this(
+        ManagementFactory.getMemoryMXBean(),
+        ManagementFactory.getMemoryPoolMXBeans());
+  }
+
+  public MemoryPoolsExports(MemoryMXBean memoryBean,
+                             List<MemoryPoolMXBean> poolBeans) {
+    this.memoryBean = memoryBean;
+    this.poolBeans = poolBeans;
+    for (final MemoryPoolMXBean pool : poolBeans) {
+      if (!poolLabelValues.containsKey(pool)) {
+        String gcName = WHITESPACE.matcher(pool.getName()).replaceAll("-");
+        poolLabelValues.put(pool, Arrays.asList(gcName));
+      }
+    }
+  }
+
+  void addMemoryAreaMetrics(List<MetricFamilySamples> sampleFamilies) {
+    MemoryUsage heapUsage = memoryBean.getHeapMemoryUsage();
+    MemoryUsage nonHeapUsage = memoryBean.getNonHeapMemoryUsage();
+    ArrayList<MetricFamilySamples.Sample> usedSamples = new ArrayList<MetricFamilySamples.Sample>();
+    usedSamples.add(
+        new MetricFamilySamples.Sample(
+            MEMORY_USED_METRIC,
+            MEMORY_LABEL_NAMES,
+            MEMORY_HEAP_LABEL,
+            heapUsage.getUsed()));
+    usedSamples.add(
+        new MetricFamilySamples.Sample(
+            MEMORY_USED_METRIC,
+            MEMORY_LABEL_NAMES,
+            MEMORY_NONHEAP_LABEL,
+            nonHeapUsage.getUsed()));
+    sampleFamilies.add(
+        new MetricFamilySamples(
+            MEMORY_USED_METRIC,
+            Type.GAUGE,
+            "Used bytes of a given JVM memory area (heap, nonheap).",
+            usedSamples));
+    ArrayList<MetricFamilySamples.Sample> limitSamples = new ArrayList<MetricFamilySamples.Sample>();
+    limitSamples.add(
+        new MetricFamilySamples.Sample(
+            MEMORY_LIMIT_METRIC,
+            MEMORY_LABEL_NAMES,
+            MEMORY_HEAP_LABEL,
+            heapUsage.getMax() == -1 ? heapUsage.getMax() : heapUsage.getCommitted()));
+    limitSamples.add(
+        new MetricFamilySamples.Sample(
+            MEMORY_LIMIT_METRIC,
+            MEMORY_LABEL_NAMES,
+            MEMORY_NONHEAP_LABEL,
+            nonHeapUsage.getMax() == -1 ? nonHeapUsage.getMax() : nonHeapUsage.getCommitted()));
+    sampleFamilies.add(
+        new MetricFamilySamples(
+            MEMORY_LIMIT_METRIC,
+            Type.GAUGE,
+            "Limit (bytes) of a given JVM memory area (heap, nonheap).",
+            limitSamples));
+  }
+
+  void addMemoryPoolMetrics(List<MetricFamilySamples> sampleFamilies) {
+    ArrayList<MetricFamilySamples.Sample> usedSamples = new ArrayList<MetricFamilySamples.Sample>();
+    ArrayList<MetricFamilySamples.Sample> limitSamples = new ArrayList<MetricFamilySamples.Sample>();
+    for (final MemoryPoolMXBean pool : poolBeans) {
+      MemoryUsage poolUsage = pool.getUsage();
+      usedSamples.add(
+          new MetricFamilySamples.Sample(
+              POOLS_USED_METRIC,
+              POOLS_LABEL_NAMES,
+              poolLabelValues.get(pool),
+              poolUsage.getUsed()));
+      limitSamples.add(
+          new MetricFamilySamples.Sample(
+              POOLS_LIMIT_METRIC,
+              POOLS_LABEL_NAMES,
+              poolLabelValues.get(pool),
+              poolUsage.getMax() != -1 ? poolUsage.getMax() : poolUsage.getCommitted()));
+    }
+    sampleFamilies.add(
+        new MetricFamilySamples(
+            POOLS_USED_METRIC,
+            Type.GAUGE,
+            "Used bytes of a given JVM memory pool.",
+            usedSamples));
+
+    sampleFamilies.add(
+        new MetricFamilySamples(
+            POOLS_LIMIT_METRIC,
+            Type.GAUGE,
+            "Limit (bytes) of a given JVM memory pool.",
+            limitSamples));
+  }
+
+
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+    addMemoryAreaMetrics(mfs);
+    addMemoryPoolMetrics(mfs);
+    return mfs;
+  }
+}

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/GarbageCollectorExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/GarbageCollectorExportsTest.java
@@ -1,0 +1,66 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class GarbageCollectorExportsTest {
+
+  private GarbageCollectorMXBean mockGcBean1 = Mockito.mock(GarbageCollectorMXBean.class);
+  private GarbageCollectorMXBean mockGcBean2 = Mockito.mock(GarbageCollectorMXBean.class);
+  private List<GarbageCollectorMXBean> mockList = Arrays.asList(mockGcBean1, mockGcBean2);
+  private CollectorRegistry registry = new CollectorRegistry();
+  private GarbageCollectorExports collectorUnderTest;
+
+  @Before
+  public void setUp() {
+    Mockito.when(mockGcBean1.getName()).thenReturn("MyGC1");
+    Mockito.when(mockGcBean1.getCollectionCount()).thenReturn(100L);
+    Mockito.when(mockGcBean1.getCollectionTime()).thenReturn(TimeUnit.SECONDS.toMillis(10));
+    Mockito.when(mockGcBean2.getName()).thenReturn("MyGC2");
+    Mockito.when(mockGcBean2.getCollectionCount()).thenReturn(200L);
+    Mockito.when(mockGcBean2.getCollectionTime()).thenReturn(TimeUnit.SECONDS.toMillis(20));
+    collectorUnderTest = new GarbageCollectorExports(mockList).register(registry);
+  }
+
+  @Test
+  public void testGarbageCollectorExports() {
+    assertEquals(
+        100L,
+        registry.getSampleValue(
+            GarbageCollectorExports.COLLECTIONS_COUNT_METRIC,
+            new String[]{"gc"},
+            new String[]{"MyGC1"}),
+        .0000001);
+    assertEquals(
+        10d,
+        registry.getSampleValue(
+            GarbageCollectorExports.COLLECTIONS_TIME_METRIC,
+            new String[]{"gc"},
+            new String[]{"MyGC1"}),
+        .0000001);
+    assertEquals(
+        200L,
+        registry.getSampleValue(
+            GarbageCollectorExports.COLLECTIONS_COUNT_METRIC,
+            new String[]{"gc"},
+            new String[]{"MyGC2"}),
+        .0000001);
+    assertEquals(
+        20d,
+        registry.getSampleValue(
+            GarbageCollectorExports.COLLECTIONS_TIME_METRIC,
+            new String[]{"gc"},
+            new String[]{"MyGC2"}),
+        .0000001);
+  }
+}

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/MemoryPoolsExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/MemoryPoolsExportsTest.java
@@ -1,0 +1,107 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class MemoryPoolsExportsTest {
+
+  private MemoryPoolMXBean mockPoolsBean1 = Mockito.mock(MemoryPoolMXBean.class);
+  private MemoryPoolMXBean mockPoolsBean2 = Mockito.mock(MemoryPoolMXBean.class);
+  private MemoryMXBean mockMemoryBean = Mockito.mock(MemoryMXBean.class);
+  private MemoryUsage mockUsage1 = Mockito.mock(MemoryUsage.class);
+  private MemoryUsage mockUsage2 = Mockito.mock(MemoryUsage.class);
+  private List<MemoryPoolMXBean> mockList = Arrays.asList(mockPoolsBean1, mockPoolsBean2);
+  private CollectorRegistry registry = new CollectorRegistry();
+  private MemoryPoolsExports collectorUnderTest;
+
+  @Before
+  public void setUp() {
+    Mockito.when(mockPoolsBean1.getName()).thenReturn("PS Eden Space");
+    Mockito.when(mockPoolsBean1.getUsage()).thenReturn(mockUsage1);
+    Mockito.when(mockPoolsBean2.getName()).thenReturn("PS Old Gen");
+    Mockito.when(mockPoolsBean2.getUsage()).thenReturn(mockUsage2);
+    Mockito.when(mockMemoryBean.getHeapMemoryUsage()).thenReturn(mockUsage1);
+    Mockito.when(mockMemoryBean.getNonHeapMemoryUsage()).thenReturn(mockUsage2);
+    Mockito.when(mockUsage1.getUsed()).thenReturn(500000L);
+    Mockito.when(mockUsage1.getMax()).thenReturn(1000000L);
+    Mockito.when(mockUsage2.getUsed()).thenReturn(10000L);
+    Mockito.when(mockUsage2.getMax()).thenReturn(-1L);  // will use committed instead
+    Mockito.when(mockUsage2.getCommitted()).thenReturn(20000L);
+    collectorUnderTest = new MemoryPoolsExports(mockMemoryBean, mockList).register(registry);
+  }
+
+  @Test
+  public void testMemoryPools() {
+    assertEquals(
+        500000L,
+        registry.getSampleValue(
+            MemoryPoolsExports.POOLS_USED_METRIC,
+            new String[]{"pool"},
+            new String[]{"PS-Eden-Space"}),
+        .0000001);
+    assertEquals(
+        1000000L,
+        registry.getSampleValue(
+            MemoryPoolsExports.POOLS_LIMIT_METRIC,
+            new String[]{"pool"},
+            new String[]{"PS-Eden-Space"}),
+        .0000001);
+    assertEquals(
+        10000L,
+        registry.getSampleValue(
+            MemoryPoolsExports.POOLS_USED_METRIC,
+            new String[]{"pool"},
+            new String[]{"PS-Old-Gen"}),
+        .0000001);
+    assertEquals(
+        20000L,
+        registry.getSampleValue(
+            MemoryPoolsExports.POOLS_LIMIT_METRIC,
+            new String[]{"pool"},
+            new String[]{"PS-Old-Gen"}),
+        .0000001);
+  }
+
+  @Test
+  public void testMemoryAreas() {
+    assertEquals(
+        500000L,
+        registry.getSampleValue(
+            MemoryPoolsExports.MEMORY_USED_METRIC,
+            new String[]{"area"},
+            new String[]{"heap"}),
+        .0000001);
+    assertEquals(
+        1000000L,
+        registry.getSampleValue(
+            MemoryPoolsExports.MEMORY_LIMIT_METRIC,
+            new String[]{"area"},
+            new String[]{"heap"}),
+        .0000001);
+    assertEquals(
+        10000L,
+        registry.getSampleValue(
+            MemoryPoolsExports.MEMORY_USED_METRIC,
+            new String[]{"area"},
+            new String[]{"nonheap"}),
+        .0000001);
+    assertEquals(
+        20000L,
+        registry.getSampleValue(
+            MemoryPoolsExports.MEMORY_LIMIT_METRIC,
+            new String[]{"area"},
+            new String[]{"nonheap"}),
+        .0000001);
+  }
+}


### PR DESCRIPTION
This PR implements metrics for JVM GC stats and basic memory pool stats. The theme for metrics 
 - use `jvm_` prefix to make the metrics easily discoverable and not mix with user-metrics
 - use labels heavily, e.g. ``jvm_memory_used{area="heap|nonheap"}`` so you can easily sum them

Code layout and tests follow the existing precedents of `StandardExports`.