### PR TITLE
Add checks for invalid metric names and labels.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -141,9 +141,14 @@ public abstract class SimpleCollector<Child, T extends SimpleCollector> extends 
       name = b.namespace + '_' + name;
     }
     fullname = name;
+    checkMetricName(fullname);
     if (b.help.isEmpty()) throw new IllegalStateException("Help hasn't been set.");
     help = b.help;
     labelNames = Arrays.asList(b.labelNames);
+
+    for (String n: labelNames) {
+      checkMetricLabelName(n);
+    }
 
     // Initlize metric if it has no labels.
     if (labelNames.size() == 0) {

--- a/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
@@ -102,6 +102,21 @@ public class SimpleCollectorTest {
     Gauge.build().name("c").create();
   }
 
+  @Test(expected=IllegalArgumentException.class)
+  public void testInvalidNameThrows() {
+    Gauge.build().name("c'a").create();
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testInvalidLabelNameThrows() {
+    Gauge.build().name("a").labelNames("c:d").help("h").create();
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testReservedLabelNameThrows() {
+    Gauge.build().name("a").labelNames("__name__").help("h").create();
+  }
+
   @Test
   public void testSetChild() {
     metric.setChild(new Gauge.Child(){


### PR DESCRIPTION
Document who's responsible for checking produced metrics are valid.

Closes #28 
@juliusv 