### PR TITLE
Add apache felix bundle plugin to add OSGi metadata to manifest during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <version>2.7</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+            </plugin>
         </plugins>
     </build>
 

--- a/simpleclient/pom.xml
+++ b/simpleclient/pom.xml
@@ -10,6 +10,7 @@
 
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient</artifactId>
+    <packaging>bundle</packaging>
 
     <name>Prometheus Java Simpleclient</name>
     <description>

--- a/simpleclient_common/pom.xml
+++ b/simpleclient_common/pom.xml
@@ -10,6 +10,7 @@
 
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient_common</artifactId>
+    <packaging>bundle</packaging>
 
     <name>Prometheus Java Simpleclient Common</name>
     <description>

--- a/simpleclient_hotspot/pom.xml
+++ b/simpleclient_hotspot/pom.xml
@@ -10,6 +10,7 @@
 
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient_hotspot</artifactId>
+    <packaging>bundle</packaging>
 
     <name>Prometheus Java Simpleclient Hotspot</name>
     <description>

--- a/simpleclient_pushgateway/pom.xml
+++ b/simpleclient_pushgateway/pom.xml
@@ -10,6 +10,7 @@
 
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient_pushgateway</artifactId>
+    <packaging>bundle</packaging>
 
     <name>Prometheus Java Simpleclient Pushgateway</name>
     <description>

--- a/simpleclient_servlet/pom.xml
+++ b/simpleclient_servlet/pom.xml
@@ -10,6 +10,7 @@
 
     <groupId>io.prometheus</groupId>
     <artifactId>simpleclient_servlet</artifactId>
+    <packaging>bundle</packaging>
 
     <name>Prometheus Java Simpleclient Servlet</name>
     <description>


### PR DESCRIPTION
@brian-brazil:
We are working on using the simpleclient in OSGi (https://github.com/swookiee/). For that (and for being usable in OSGi in general), the jars need to have additional metadata in the manifest. This PR adds the Apache Felix bundle plugin to the parent pom and sets the packaging to "bundle" in all simpleclient poms. This adds the necessary metadata to the manifest during build. 

Impact assessment: There should be no impact on other things as this only adds additional metadata to the manifest.

