### PR TITLE
Add simpleclient_httpserver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>simpleclient_hotspot</module>
         <module>simpleclient_servlet</module>
         <module>simpleclient_pushgateway</module>
+        <module>simpleclient_httpserver</module>
         <module>benchmark</module>
     </modules>
 

--- a/simpleclient_httpserver/pom.xml
+++ b/simpleclient_httpserver/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.9-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.prometheus</groupId>
+    <artifactId>simpleclient_httpserver</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Prometheus Java Simpleclient HTTP server</name>
+    <description>
+        HTTP httpserver (com.sun.net.httpserver.HttpServer) exporter for the simpleclient.
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>tgulacsi</id>
+            <name>Tamás Gulácsi</name>
+            <email>tgulacsi78@gmail.com</email>
+        </developer>
+    </developers>
+
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.0.9-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+            <version>0.0.9-SNAPSHOT</version>
+        </dependency>
+        <!-- Test Dependencies Follow -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
+++ b/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
@@ -1,0 +1,53 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.Enumeration;
+import java.util.concurrent.Executors;
+
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpExchange;
+
+public class HTTPServer {
+	static class HTTPMetricHandler implements HttpHandler {
+		public void handle(HttpExchange t) throws IOException {
+			ByteArrayOutputStream response = dump();
+			t.getResponseHeaders().set("Content-Type",
+					TextFormat.CONTENT_TYPE_004);
+			t.getResponseHeaders().set("Content-Length",
+					String.valueOf(response.size()));
+			t.sendResponseHeaders(200, response.size());
+			response.writeTo(t.getResponseBody());
+			t.close();
+		}
+
+	}
+
+	public static ByteArrayOutputStream dump() throws java.io.IOException {
+		ByteArrayOutputStream response = new ByteArrayOutputStream(1 << 20);
+		OutputStreamWriter osw = new OutputStreamWriter(response);
+		TextFormat.write004(osw,
+				CollectorRegistry.defaultRegistry.metricFamilySamples());
+		osw.flush();
+		osw.close();
+		response.flush();
+		response.close();
+		return response;
+	}
+
+	public HTTPServer(int port) throws java.io.IOException {
+		HttpServer mServer = HttpServer.create();
+		mServer.bind(new java.net.InetSocketAddress(port), 3);
+		HttpHandler mHandler = new HTTPMetricHandler();
+		mServer.createContext("/", mHandler);
+		mServer.createContext("/metrics", mHandler);
+		mServer.setExecutor(Executors.newSingleThreadExecutor());
+		mServer.start();
+	}
+}

--- a/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/ExampleExporter.java
+++ b/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/ExampleExporter.java
@@ -1,0 +1,25 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+import io.prometheus.client.Summary;
+
+public class ExampleExporter {
+
+  static final Gauge g = Gauge.build().name("gauge").help("blah").register();
+  static final Counter c = Counter.build().name("counter").help("meh").register();
+  static final Summary s = Summary.build().name("summary").help("meh").register();
+  static final Histogram h = Histogram.build().name("histogram").help("meh").register();
+  static final Gauge l = Gauge.build().name("labels").help("blah").labelNames("l").register();
+
+  public static void main(String[] args) throws Exception {
+    new HTTPServer(1234);
+    g.set(1);
+    c.inc(2);
+    s.observe(3);
+    h.observe(4);
+    l.labels("foo").inc(5);
+  }
+
+}


### PR DESCRIPTION
For the simplest HTTP server, without extra dependencies.
Uses com.sun.net.httpserver.HttpServer, which is in JRE 1.6.


Sorry, I don't have the skills & knowledge for Maven usage, so this is just a copy of simpleclient_servlet - please take as is, and fix it on your side!