### PR TITLE
Undo properties for versions.

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -39,12 +39,12 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>client</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         <dependency>
           <groupId>com.codahale.metrics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,6 @@
         
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        
-        <junit.version>4.11</junit.version>
-        <mockito.version>1.9.5</mockito.version>
     </properties>
 
     <distributionManagement>

--- a/simpleclient/pom.xml
+++ b/simpleclient/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/simpleclient_common/pom.xml
+++ b/simpleclient_common/pom.xml
@@ -37,13 +37,13 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         <!-- Test Dependencies Follow -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/simpleclient_hotspot/pom.xml
+++ b/simpleclient_hotspot/pom.xml
@@ -37,25 +37,25 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_servlet</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         
         <!-- Test Dependencies Follow -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
+            <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
         

--- a/simpleclient_log4j/pom.xml
+++ b/simpleclient_log4j/pom.xml
@@ -33,34 +33,30 @@
         </developer>
     </developers>
 
-    <properties>
-        <log4j.version>1.2.17</log4j.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
+            <version>1.2.17</version>
         </dependency>
         
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
+            <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/simpleclient_logback/pom.xml
+++ b/simpleclient_logback/pom.xml
@@ -32,35 +32,31 @@
             <email>will.fleury@boxever.com</email>
         </developer>
     </developers>
-    
-    <properties>
-        <logback.version>1.1.2</logback.version>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>1.1.2</version>
         </dependency>
         
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
+            <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/simpleclient_pushgateway/pom.xml
+++ b/simpleclient_pushgateway/pom.xml
@@ -38,18 +38,18 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_common</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         <!-- Test Dependencies Follow -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/simpleclient_servlet/pom.xml
+++ b/simpleclient_servlet/pom.xml
@@ -41,12 +41,12 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_common</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This breaks several build tools, including
sbt and leiningen.

@prepor @xperimental This should fix #75. I've pushed this as a snapshot release if you'd like to try it out.