### PR TITLE
Switch to new pushgateway URL.

### DIFF
--- a/simpleclient_pushgateway/src/test/java/io/prometheus/client/exporter/PushGatewayTest.java
+++ b/simpleclient_pushgateway/src/test/java/io/prometheus/client/exporter/PushGatewayTest.java
@@ -7,6 +7,8 @@ import static org.mockserver.model.HttpResponse.response;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
 import java.io.IOException;;
+import java.util.TreeMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,32 +24,25 @@ public class PushGatewayTest {
   CollectorRegistry registry;
   Gauge gauge;
   PushGateway pg;
+  Map groupingKey;
 
   @Before
   public void setUp() {
     registry = new CollectorRegistry();
     gauge = (Gauge) Gauge.build().name("g").help("help").create();
     pg = new PushGateway("localhost:" + mockServerRule.getHttpPort());
+    groupingKey = new TreeMap<String, String>();
+    groupingKey.put("l", "v");
   }
 
   @Test
-  public void testPushWithoutInstance() throws IOException {
+  public void testPush() throws IOException {
     mockServerClient.when(
         request()
           .withMethod("POST")
-          .withPath("/metrics/jobs/j")
+          .withPath("/metrics/job/j")
       ).respond(response().withStatusCode(202));
-    pg.push(registry, "j", "");
-  }
-
-  @Test
-  public void testPushWithInstance() throws IOException {
-    mockServerClient.when(
-        request()
-          .withMethod("POST")
-          .withPath("/metrics/jobs/j/instances/i")
-      ).respond(response().withStatusCode(202));
-    pg.push(registry, "j", "i");
+    pg.push(registry, "j");
   }
 
   @Test(expected=IOException.class)
@@ -55,19 +50,9 @@ public class PushGatewayTest {
     mockServerClient.when(
         request()
           .withMethod("POST")
-          .withPath("/metrics/jobs/j/instances/i")
+          .withPath("/metrics/job/j")
       ).respond(response().withStatusCode(500));
-    pg.push(registry,"j", "i");
-  }
-
-  @Test
-  public void testPushWithSlashes() throws IOException {
-    mockServerClient.when(
-        request()
-          .withMethod("POST")
-          .withPath("/metrics/jobs/a%2Fb/instances/c%2Fd")
-      ).respond(response().withStatusCode(202));
-    pg.push(registry, "a/b", "c/d");
+    pg.push(registry, "j");
   }
 
   @Test
@@ -75,9 +60,51 @@ public class PushGatewayTest {
     mockServerClient.when(
         request()
           .withMethod("POST")
-          .withPath("/metrics/jobs/j/instances/i")
+          .withPath("/metrics/job/j")
       ).respond(response().withStatusCode(202));
-    pg.push(gauge, "j", "i");
+    pg.push(gauge, "j");
+  }
+
+  @Test
+  public void testPushWithGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j/l/v")
+      ).respond(response().withStatusCode(202));
+    pg.push(registry, "j", groupingKey);
+  }
+
+  @Test
+  public void testPushWithMultiGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j/l/v/l2/v2")
+      ).respond(response().withStatusCode(202));
+    groupingKey.put("l2", "v2");
+    pg.push(registry, "j", groupingKey);
+  }
+
+  @Test
+  public void testPushWithGroupingKeyWithSlashes() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/a%2Fb/l/v/l2/v%2F2")
+      ).respond(response().withStatusCode(202));
+    groupingKey.put("l2", "v/2");
+    pg.push(registry, "a/b", groupingKey);
+  }
+
+  @Test
+  public void testPushCollectorWithGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j/l/v")
+      ).respond(response().withStatusCode(202));
+    pg.push(gauge, "j", groupingKey);
   }
 
   @Test
@@ -85,9 +112,9 @@ public class PushGatewayTest {
     mockServerClient.when(
         request()
           .withMethod("PUT")
-          .withPath("/metrics/jobs/j/instances/i")
+          .withPath("/metrics/job/j")
       ).respond(response().withStatusCode(202));
-    pg.pushAdd(registry, "j", "i");
+    pg.pushAdd(registry, "j");
   }
 
   @Test
@@ -95,9 +122,29 @@ public class PushGatewayTest {
     mockServerClient.when(
         request()
           .withMethod("PUT")
-          .withPath("/metrics/jobs/j/instances/i")
+          .withPath("/metrics/job/j")
       ).respond(response().withStatusCode(202));
-    pg.pushAdd(gauge, "j", "i");
+    pg.pushAdd(gauge, "j");
+  }
+
+  @Test
+  public void testPushAddWithGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("PUT")
+          .withPath("/metrics/job/j/l/v")
+      ).respond(response().withStatusCode(202));
+    pg.pushAdd(registry, "j", groupingKey);
+  }
+
+  @Test
+  public void testPushAddCollectorWithGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("PUT")
+          .withPath("/metrics/job/j/l/v")
+      ).respond(response().withStatusCode(202));
+    pg.pushAdd(gauge, "j", groupingKey);
   }
 
   @Test
@@ -105,7 +152,99 @@ public class PushGatewayTest {
     mockServerClient.when(
         request()
           .withMethod("DELETE")
-          .withPath("/metrics/jobs/j/instances/i")
+          .withPath("/metrics/job/j")
+      ).respond(response().withStatusCode(202));
+    pg.delete("j");
+  }
+
+  @Test
+  public void testDeleteWithGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("DELETE")
+          .withPath("/metrics/job/j/l/v")
+      ).respond(response().withStatusCode(202));
+    pg.delete("j", groupingKey);
+  }
+
+
+
+  @Test
+  public void testOldPushWithoutInstance() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j/instance/")
+      ).respond(response().withStatusCode(202));
+    pg.push(registry, "j", "");
+  }
+
+  @Test
+  public void testOldPushWithInstance() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j/instance/i")
+      ).respond(response().withStatusCode(202));
+    pg.push(registry, "j", "i");
+  }
+
+  @Test(expected=IOException.class)
+  public void testOldNon202ResponseThrows() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j/instance/i")
+      ).respond(response().withStatusCode(500));
+    pg.push(registry,"j", "i");
+  }
+
+  @Test
+  public void testOldPushWithSlashes() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/a%2Fb/instance/c%2Fd")
+      ).respond(response().withStatusCode(202));
+    pg.push(registry, "a/b", "c/d");
+  }
+
+  @Test
+  public void testOldPushCollector() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j/instance/i")
+      ).respond(response().withStatusCode(202));
+    pg.push(gauge, "j", "i");
+  }
+
+  @Test
+  public void testOldPushAdd() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("PUT")
+          .withPath("/metrics/job/j/instance/i")
+      ).respond(response().withStatusCode(202));
+    pg.pushAdd(registry, "j", "i");
+  }
+
+  @Test
+  public void testOldPushAddCollector() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("PUT")
+          .withPath("/metrics/job/j/instance/i")
+      ).respond(response().withStatusCode(202));
+    pg.pushAdd(gauge, "j", "i");
+  }
+
+  @Test
+  public void testOldDelete() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("DELETE")
+          .withPath("/metrics/job/j/instance/i")
       ).respond(response().withStatusCode(202));
     pg.delete("j", "i");
   }


### PR DESCRIPTION
Note: Anyone relying on setting the instance to empty string
will now get an empty instance label, rather than the previous
behaviour of the pushgateway using the IP address of the client.