### PR TITLE
Add convenience function for setting instance to the IP.

### DIFF
--- a/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
+++ b/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
@@ -5,6 +5,8 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
 
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Map;
@@ -273,6 +275,18 @@ public class PushGateway {
     } finally {
       connection.disconnect();
     }
+  }
+
+  /**
+   * Returns a grouping key with the instance label set to the machine's IP address.
+   * <p>
+   * This is a convenience function, and should only be used where you want to
+   * push per-instance metrics rather than cluster/job level metrics.
+  */
+  public static Map<String, String> instanceIPGroupingKey() throws UnknownHostException {
+    Map<String, String> groupingKey = new HashMap<String, String>();
+    groupingKey.put("instance", InetAddress.getLocalHost().getHostAddress());
+    return groupingKey;
   }
 
 }

--- a/simpleclient_pushgateway/src/test/java/io/prometheus/client/exporter/ExamplePushGateway.java
+++ b/simpleclient_pushgateway/src/test/java/io/prometheus/client/exporter/ExamplePushGateway.java
@@ -14,7 +14,7 @@ public class ExamplePushGateway {
   public static void main(String[] args) throws Exception {
     PushGateway pg = new PushGateway(args[0]);
     g.set(42);
-    pg.push(pushRegistry, "job", "instance");
+    pg.push(pushRegistry, "job");
   }
 }
 

--- a/simpleclient_pushgateway/src/test/java/io/prometheus/client/exporter/PushGatewayTest.java
+++ b/simpleclient_pushgateway/src/test/java/io/prometheus/client/exporter/PushGatewayTest.java
@@ -9,6 +9,7 @@ import io.prometheus.client.Gauge;
 import java.io.IOException;;
 import java.util.TreeMap;
 import java.util.Map;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -247,5 +248,11 @@ public class PushGatewayTest {
           .withPath("/metrics/job/j/instance/i")
       ).respond(response().withStatusCode(202));
     pg.delete("j", "i");
+  }
+
+  @Test
+  public void testInstanceIPGroupingKey() throws IOException {
+    groupingKey = PushGateway.instanceIPGroupingKey();
+    Assert.assertTrue(!groupingKey.get("instance").equals(""));
   }
 }


### PR DESCRIPTION
The new pushgateway url doesn't support setting the instance to the client IP,
so for those who were doing:
pg.push(registry, "job", "");
they can now do:
pg.push(registry, "job", PushGateway.instanceIPGroupingKey());
instead in many cases.