### PR TITLE
Adds return values to Timer observations.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -97,9 +97,12 @@ public class Gauge extends SimpleCollector<Gauge.Child, Gauge> {
      }
      /**
       * Set the amount of time in seconds since {@link Child#startTimer} was called.
+      * @return Measured duration in seconds since {@link Child#startTimer} was called.
       */
-     public void setDuration() {
-       child.set((Child.timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND);
+     public double setDuration() {
+       double elapsed = (Child.timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND;
+       child.set(elapsed);
+       return elapsed;
      }
    }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -147,9 +147,12 @@ public class Histogram extends SimpleCollector<Histogram.Child, Histogram> {
     }
     /**
      * Observe the amount of time in seconds since {@link Child#startTimer} was called.
+     * @return Measured duration in seconds since {@link Child#startTimer} was called.
      */
-    public void observeDuration() {
-      child.observe((Child.timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND);
+    public double observeDuration() {
+        double elapsed = (Child.timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND;
+        child.observe(elapsed);
+        return elapsed;
     }
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -74,9 +74,12 @@ public class Summary extends SimpleCollector<Summary.Child, Summary> {
     }
     /**
      * Observe the amount of time in seconds since {@link Child#startTimer} was called.
+     * @return Measured duration in seconds since {@link Child#startTimer} was called.
      */
-    public void observeDuration() {
-      child.observe((Child.timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND);
+    public double observeDuration() {
+      double elapsed = (Child.timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND;
+      child.observe(elapsed);
+      return elapsed;
     }
   }
 

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
@@ -83,8 +83,9 @@ public class GaugeTest {
       }
     };
     Gauge.Timer timer = noLabels.startTimer();
-    timer.setDuration();
+    double elapsed = timer.setDuration();
     assertEquals(10, getValue(), .001);
+    assertEquals(10, elapsed, .001);
   }
 
   @Test

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -108,9 +108,10 @@ public class HistogramTest {
       }
     };
     Histogram.Timer timer = noLabels.startTimer();
-    timer.observeDuration();
+    double elapsed = timer.observeDuration();
     assertEquals(1, getCount(), .001);
     assertEquals(10, getSum(), .001);
+    assertEquals(10, elapsed, .001);
   }
   
   @Test

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -53,9 +53,10 @@ public class SummaryTest {
       }
     };
     Summary.Timer timer = noLabels.startTimer();
-    timer.observeDuration();
+    double elapsed = timer.observeDuration();
     assertEquals(1, getCount(), .001);
     assertEquals(10, getSum(), .001);
+    assertEquals(10, elapsed, .001);
   }
   
   @Test


### PR DESCRIPTION
While using the client library we ran into the situation where we'd like to expose the measured ```Timer``` observations (e.g. in HTTP response headers). Since the ```Timer::observeDuration()``` methods didn't not return the elapsed time we had to measure internally and call ```observe(double amt)``` on their respective ```Collector```. This PR enables the ```Timer```s to serve such use cases.

@beorn7 @brian-brazil please have look whether you'd like this feature to be merged. Thanks!