### PR TITLE
Improve type inference in SimpleCollector.Builder

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -64,13 +64,13 @@ import java.util.Map;
  * These can be aggregated and processed together much more easily in the Promtheus 
  * server than individual metrics for each labelset.
  */
-public class Counter extends SimpleCollector<Counter.Child, Counter> {
+public class Counter extends SimpleCollector<Counter.Child> {
 
   Counter(Builder b) {
     super(b);
   }
 
-  public static class Builder extends SimpleCollector.Builder<Builder> {
+  public static class Builder extends SimpleCollector.Builder<Builder, Counter> {
     @Override
     public Counter create() {
       return new Counter(this);

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -60,13 +60,13 @@ import java.util.Map;
  * These can be aggregated and processed together much more easily in the Prometheus 
  * server than individual metrics for each labelset.
  */
-public class Gauge extends SimpleCollector<Gauge.Child, Gauge> {
+public class Gauge extends SimpleCollector<Gauge.Child> {
   
   Gauge(Builder b) {
     super(b);
   }
 
-  public static class Builder extends SimpleCollector.Builder<Builder> {
+  public static class Builder extends SimpleCollector.Builder<Builder, Gauge> {
     @Override
     public Gauge create() {
       return new Gauge(this);

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -50,7 +50,7 @@ import java.util.Map;
  * {@link Histogram.Builder#exponentialBuckets(double, double, int) exponentialBuckets}
  * offer easy ways to set common bucket patterns.
  */
-public class Histogram extends SimpleCollector<Histogram.Child, Histogram> {
+public class Histogram extends SimpleCollector<Histogram.Child> {
   double[] buckets;
 
   Histogram(Builder b) {
@@ -59,7 +59,7 @@ public class Histogram extends SimpleCollector<Histogram.Child, Histogram> {
     initializeNoLabelsChild();
   }
 
-  public static class Builder extends SimpleCollector.Builder<Builder> {
+  public static class Builder extends SimpleCollector.Builder<Builder, Histogram> {
     double[] buckets = new double[]{.005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10};
 
     @Override

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -45,7 +45,7 @@ import java.util.List;
  * by each. If the cardinality is in the hundreds, you may wish to consider removing the breakout
  * by one of the dimensions altogether.
  */
-public abstract class SimpleCollector<Child, T extends SimpleCollector> extends Collector {
+public abstract class SimpleCollector<Child> extends Collector {
   protected final String fullname;
   protected final String help;
   protected final List<String> labelNames;
@@ -169,7 +169,7 @@ public abstract class SimpleCollector<Child, T extends SimpleCollector> extends 
   /**
    * Builders let you configure and then create collectors.
    */
-  public abstract static class Builder<B extends Builder<B>> {
+  public abstract static class Builder<B extends Builder<B, C>, C extends SimpleCollector> {
     String namespace = "";
     String subsystem = "";
     String name = "";
@@ -220,20 +220,20 @@ public abstract class SimpleCollector<Child, T extends SimpleCollector> extends 
      * <p>
      * Abstract due to generics limitations.
      */
-    public abstract <T extends SimpleCollector>T create();
+    public abstract C create();
 
     /**
      * Create and register the Collector with the default registry.
      */
-    public <T extends SimpleCollector>T register() {
+    public C register() {
       return register(CollectorRegistry.defaultRegistry);
     }
 
     /**
      * Create and register the Collector with the given registry.
      */
-    public <T extends SimpleCollector>T register(CollectorRegistry registry) {
-      T sc = create();
+    public C register(CollectorRegistry registry) {
+      C sc = create();
       registry.register(sc);
       return sc;
     }

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -37,13 +37,13 @@ import java.util.Map;
  * </pre>
  * This would allow you to track request rate, average latency and average request size.
  */
-public class Summary extends SimpleCollector<Summary.Child, Summary> {
+public class Summary extends SimpleCollector<Summary.Child> {
 
   Summary(Builder b) {
     super(b);
   }
 
-  public static class Builder extends SimpleCollector.Builder<Builder> {
+  public static class Builder extends SimpleCollector.Builder<Builder, Summary> {
     @Override
     public Summary create() {
       return new Summary(this);


### PR DESCRIPTION
I have tweaked some of the generics on `SimpleCollector` and `SimpleCollector.Builder` in order to improve the type inference and compile-time guarantees when using builders. This should fix #65, but it actually also fixes an issue for Java users. Currently, the following code compiles, but fails at runtime with a ClassCastException:

    Gauge gauge = Counter.build().name("name").help("help").register();

This is because the return types of `register` and `create` are currently inferred at the call site, rather than being determined by the builder itself. I have therefore added a second type parameter to the builder, which is the type of collector it builds.

I have also removed the second type parameter from `SimpleCollector`, since it was unused. I think the intention of this parameter was to use it as I am using the new builder type parameter, but since the builder classes are static this was not possible.

This change breaks the API for anyone extending `SimpleCollector`, but since the documentation says "you should never need to subclass this class", I'm assuming this is not really an issue.