### PR TITLE
Add set() to Counters.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -114,6 +114,23 @@ public class Counter extends SimpleCollector<Counter.Child> {
       value.add(amt);
     }
     /**
+     * Set is used to set the Counter to an arbitrary value. It is only used
+     * if you have to transfer a value from an external counter into this
+     * Prometheus metric. Do not use it for regular handling of a
+     * Prometheus counter (as it can be used to break the contract of
+     * monotonically increasing values).
+     * @param value
+     */
+    public void set(double val) {
+      synchronized(this) {
+        value.reset();
+        // If get() were called here it'd see an invalid value, so use a lock.
+        // inc()/dec() don't need locks, as all the possible outcomes
+        // are still possible if set() were atomic so no new races are introduced.
+        value.add(val);
+      }
+    }
+    /**
      * Get the value of the counter.
      */
     public double get() {
@@ -134,6 +151,12 @@ public class Counter extends SimpleCollector<Counter.Child> {
    */
   public void inc(double amt) {
     noLabelsChild.inc(amt);
+  }
+  /**
+   * Set the gauge with no labels to the given value.
+   */
+  public void set(double val) {
+    noLabelsChild.set(val);
   }
 
   @Override

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -34,7 +34,15 @@ public class CounterTest {
     noLabels.labels().inc();
     assertEquals(8.0, getValue(), .001);
   }
-    
+
+  @Test
+  public void testSet() {
+    noLabels.set(42);
+    assertEquals(42, getValue(), .001);
+    noLabels.labels().set(7);
+    assertEquals(7.0, getValue(), .001);
+  }
+
   @Test(expected=IllegalArgumentException.class)
   public void testNegativeIncrementFails() {
     noLabels.inc(-1);


### PR DESCRIPTION
While it should generally not be used, having a set() method
for counters is this only way to relay counters from other
monitoring systems. It was implemented in the golang client
for the same reasons.