### PR TITLE
Add label and mapping support in dropwizard metric exporter

### DIFF
--- a/simpleclient_common/pom.xml
+++ b/simpleclient_common/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>simpleclient</artifactId>
             <version>0.0.12-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.16</version>
+        </dependency>
         <!-- Test Dependencies Follow -->
         <dependency>
             <groupId>junit</groupId>

--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/MetricMapper.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/MetricMapper.java
@@ -1,0 +1,252 @@
+package io.prometheus.client.exporter.common;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+
+/**
+ * Map origin names with a target name, label names and values according a specified configuration.
+ */
+public class MetricMapper {
+
+    private static final Pattern snakeCasePattern = Pattern.compile("([a-z0-9])([A-Z])");
+    private final boolean lowerCaseOutputNames;
+    private final boolean lowerCaseOutputLabelNames;
+    private final Pattern unsafeChars = Pattern.compile("[^a-zA-Z0-9:_]");
+    private final Pattern multipleUnderscores = Pattern.compile("__+");
+    Map<String, MetricMapping> mappingCache;
+    private ArrayList<Rule> rules = new ArrayList<Rule>();
+
+    /**
+     * @param rules                    a list of mapping rules to apply.
+     * @param lowerCaseOutputNames     lowercase metric names.
+     * @param lowerCaseOutpuLabelNames lowercase metric labels names.
+     */
+    public MetricMapper(ArrayList<Rule> rules, boolean lowerCaseOutputNames, boolean lowerCaseOutpuLabelNames) {
+        this.rules = rules;
+        this.mappingCache = new HashMap<String, MetricMapping>();
+        this.lowerCaseOutputNames = lowerCaseOutputNames;
+        this.lowerCaseOutputLabelNames = lowerCaseOutpuLabelNames;
+    }
+
+    /**
+     * Replace invalid chars to underscore and replace multiple underscores with one underscore.
+     *
+     * @param s a metric name or label name.
+     * @return a sanitized name.
+     */
+    private String safeName(String s) {
+        // Change invalid chars to underscore, and merge underscores.
+        return multipleUnderscores.matcher(unsafeChars.matcher(s).replaceAll("_")).replaceAll("_");
+    }
+
+    /**
+     * Map a metric to target mapping.
+     *
+     * @param metricName
+     * @return a mapping for the specified metric name.
+     */
+    public MetricMapping map(String metricName) {
+        if (!mappingCache.containsKey(metricName)) {
+            mappingCache.put(metricName, process(metricName));
+        }
+        return mappingCache.get(metricName);
+    }
+
+    /**
+     * Process rules for the specified metric name and map it with label names, values and
+     * help according to the first matched rule.
+     *
+     * @param metricName
+     * @return a MetricMapping associated with a metricName.
+     */
+    public MetricMapping process(String metricName) {
+        String targetMetricName;
+        final String targetHelp;
+        final String snakeCaseMetricName = snakeCasePattern.matcher(metricName).replaceAll("$1_$2").toLowerCase();
+
+        for (Rule rule : rules) {
+            Matcher matcher = null;
+            String matchName = (rule.attrNameSnakeCase ? snakeCaseMetricName : metricName);
+            if (rule.pattern != null) {
+                matcher = rule.pattern.matcher(matchName);
+                if (!matcher.matches()) {
+                    continue;
+                }
+            }
+            // Replace matches in help if a help was specified
+            targetHelp = (rule.help != null) ? matcher.replaceAll(rule.help) : "";
+            // Replace matches in metric rule name if specified. Sanitize name
+            targetMetricName = safeName((rule.name == null) ? metricName : matcher.replaceAll(rule.name));
+            if (targetMetricName.isEmpty()) {
+                throw new IllegalArgumentException("Empty metric name. Original metric name: " + metricName);
+            }
+            if (this.lowerCaseOutputNames) {
+                targetMetricName = targetMetricName.toLowerCase();
+            }
+            ArrayList<String> labelNames = new ArrayList<String>();
+            ArrayList<String> labelValues = new ArrayList<String>();
+            if (rule.labelNames != null) {
+                for (int i = 0; i < rule.labelNames.size(); i++) {
+                    final String unsafeLabelName = rule.labelNames.get(i);
+                    final String labelValReplacement = rule.labelValues.get(i);
+                    try {
+                        String labelName = safeName(matcher.replaceAll(unsafeLabelName));
+                        String labelValue = matcher.replaceAll(labelValReplacement);
+                        if (this.lowerCaseOutputLabelNames) {
+                            labelName = labelName.toLowerCase();
+                        }
+                        if (!labelName.isEmpty() && !labelValue.isEmpty()) {
+                            labelNames.add(labelName);
+                            labelValues.add(labelValue);
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(
+                                format("Matcher '%s' unable to use: '%s' value: '%s'", matcher, unsafeLabelName, labelValReplacement), e);
+                    }
+                }
+            }
+            return new MetricMapping(targetMetricName, labelNames, labelValues, targetHelp);
+        }
+        return MetricMapping.defaultMapping((lowerCaseOutputNames ? metricName.toLowerCase() : metricName));
+    }
+
+
+    public static MetricMapper load(String yamlConfig) {
+        return load((Map<String, Object>) new Yaml().load(yamlConfig));
+    }
+
+    public static MetricMapper load(Reader reader) {
+        return load((Map<String, Object>) new Yaml().load(reader));
+    }
+
+    public static MetricMapper load() {
+        return load((Map<String, Object>) null);
+    }
+
+    public static MetricMapper load(Map<String, Object> config) {
+        boolean lowercaseOutputName = false;
+        boolean lowercaseOutputLabelNames = false;
+        ArrayList<Rule> rules = new ArrayList<Rule>();
+
+        if (config == null) {  //Yaml config empty, set config to empty map.
+            config = new HashMap<String, Object>();
+        }
+        if (config.containsKey("lowercaseOutputName")) {
+            lowercaseOutputName = (Boolean) config.get("lowercaseOutputName");
+        }
+        if (config.containsKey("lowercaseOutputLabelNames")) {
+            lowercaseOutputLabelNames = (Boolean) config.get("lowercaseOutputLabelNames");
+        }
+
+        if (config.containsKey("rules")) {
+            List<Map<String, Object>> configRules = (List<Map<String, Object>>) config.get("rules");
+            for (Map<String, Object> ruleObject : configRules) {
+                Map<String, Object> yamlRule = ruleObject;
+                Rule rule = new Rule();
+                if (yamlRule.containsKey("pattern")) {
+                    rule.pattern = Pattern.compile("^.*" + (String) yamlRule.get("pattern") + ".*$");
+                }
+                if (yamlRule.containsKey("name")) {
+                    rule.name = (String) yamlRule.get("name");
+                }
+                if (yamlRule.containsKey("attrNameSnakeCase")) {
+                    rule.attrNameSnakeCase = (Boolean) yamlRule.get("attrNameSnakeCase");
+                }
+                if (yamlRule.containsKey("help")) {
+                    rule.help = (String) yamlRule.get("help");
+                }
+                if (yamlRule.containsKey("labels")) {
+                    TreeMap labels = new TreeMap((Map<String, Object>) yamlRule.get("labels"));
+                    rule.labelNames = new ArrayList<String>();
+                    rule.labelValues = new ArrayList<String>();
+                    for (Map.Entry<String, Object> entry : (Set<Map.Entry<String, Object>>) labels.entrySet()) {
+                        rule.labelNames.add(entry.getKey());
+                        rule.labelValues.add((String) entry.getValue());
+                    }
+                }
+
+                // Validation.
+                if ((rule.labelNames != null || rule.help != null) && rule.name == null) {
+                    throw new IllegalArgumentException("Must provide name, if help or labels are given: " + yamlRule);
+                }
+                if (rule.name != null && rule.pattern == null) {
+                    throw new IllegalArgumentException("Must provide pattern, if name is given: " + yamlRule);
+                }
+                rules.add(rule);
+            }
+        } else {
+            // Default to a single default rule.
+            rules.add(new Rule());
+        }
+
+        return new MetricMapper(rules, lowercaseOutputName, lowercaseOutputLabelNames);
+    }
+
+    /**
+     * A mapping rule.
+     */
+    private static class Rule {
+        Pattern pattern;
+        String name;
+        String help;
+        boolean attrNameSnakeCase;
+        ArrayList<String> labelNames;
+        ArrayList<String> labelValues;
+    }
+
+    /**
+     * Contains prometheus metric name, label names and values for a source metric name
+     */
+    public static class MetricMapping {
+
+        private ArrayList<String> labelNames;
+        private ArrayList<String> labelValues;
+        private String name;
+        private String help;
+
+        public MetricMapping(String name, ArrayList<String> labelNames, ArrayList<String> labelValues, String help) {
+            this.labelNames = labelNames;
+            this.name = name;
+            this.labelValues = labelValues;
+            this.help = help;
+        }
+
+        public ArrayList<String> getLabelNames() {
+            return labelNames;
+        }
+
+        public ArrayList<String> getLabelValues() {
+            return labelValues;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getHelp() {
+            return help;
+        }
+
+        /**
+         * Return a default mapping for a metric.
+         * This mapping contains unmodified metric name, empty label names, values and help.
+         *
+         * @param name
+         * @return the default MetricMapping associated to this metricName.
+         */
+        public static MetricMapping defaultMapping(String name) {
+            return new MetricMapping(name, new ArrayList<String>(), new ArrayList<String>(), "");
+        }
+    }
+}

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/MetricMapperTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/MetricMapperTest.java
@@ -1,0 +1,119 @@
+package io.prometheus.client.exporter.common;
+
+
+import org.junit.Test;
+import org.yaml.snakeyaml.error.YAMLException;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class MetricMapperTest {
+
+    private void assertMapTo(String name, List<String> labelNames, List<String> labelValues,
+                             String help, MetricMapper.MetricMapping mapping) {
+        assertEquals(mapping.getName(), name);
+        assertEquals(mapping.getLabelNames(), labelNames);
+        assertEquals(mapping.getLabelValues(), labelValues);
+        assertEquals(mapping.getHelp(), help);
+    }
+
+    @Test
+    public void testBasicMapping() {
+        String rules = "---\n" +
+                "rules:\n" +
+                " - name: http_requests_errors\n" +
+                "   pattern: ^RequestErrors$\n" +
+                " - name: foo_bar_bazz\n" +
+                "   pattern: foo_bar_bazz\n" +
+                "   attrNameSnakeCase: true\n" +
+                " - name: http_requests\n" +
+                "   help: This an help message.\n" +
+                "   pattern: HttpRequest(.*)\n" +
+                "   labels: \n" +
+                "     status: $1\n" +
+                "     foo: bar\n";
+        MetricMapper mapper = MetricMapper.load(rules);
+        assertMapTo("http_requests", Arrays.asList("foo", "status"), Arrays.asList("bar", "Buzzy"),
+                "This an help message.", mapper.map("HttpRequestBuzzy"));
+        assertMapTo("http_requests_errors", new ArrayList<String>(), new ArrayList<String>(), "",
+                mapper.map("RequestErrors"));
+        assertMapTo("foo_bar_bazz", new ArrayList<String>(), new ArrayList<String>(), "",
+                mapper.map("FooBarBazz"));
+        assertMapTo("AnotherNonMatchedRequest", new ArrayList<String>(), new ArrayList<String>(), "",
+                mapper.map("AnotherNonMatchedRequest"));
+
+    }
+
+    @Test
+    public void testLowerCaseMapping() {
+        String rules = "---\n" +
+                "lowercaseOutputName: true\n" +
+                "lowercaseOutputLabelNames: true\n" +
+                "rules:\n" +
+                " - name: http_requests_errors\n" +
+                "   pattern: ^RequestErrors$\n" +
+                " - name: http_requests\n" +
+                "   pattern: HttpRequest(.*)\n" +
+                "   labels: \n" +
+                "     Status: $1\n" +
+                "     foo: bar\n";
+        MetricMapper mapper = MetricMapper.load(rules);
+        assertMapTo("http_requests", Arrays.asList("status", "foo"), Arrays.asList("Buzzy", "bar"),
+                "", mapper.map("HttpRequestBuzzy"));
+        assertMapTo("http_requests_errors", new ArrayList<String>(), new ArrayList<String>(), "",
+                mapper.map("RequestErrors"));
+        assertMapTo("anothernonmatchedrequest", new ArrayList<String>(), new ArrayList<String>(), "",
+                mapper.map("AnotherNonMatchedRequest"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testReplaceToEmptyName() {
+        String rules = "---\n" +
+                "rules:\n" +
+                " - name: $1\n" +
+                "   pattern: ^RequestErrors(.*)$\n";
+        MetricMapper mapper = MetricMapper.load(rules);
+        mapper.map("RequestErrors");
+    }
+
+    @Test(expected = YAMLException.class)
+    public void testLoadInvalidYaml() {
+        MetricMapper.load("{invali");
+    }
+
+    @Test
+    public void testLoadDefaultMapping() {
+        MetricMapper mapper = MetricMapper.load();
+        assertMapTo("AnotherNonMatchedRequest", new ArrayList<String>(), new ArrayList<String>(), "",
+                mapper.map("AnotherNonMatchedRequest"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseInvalidRuleWithNoName() {
+        String rules = "---\n" +
+                "rules:\n" +
+                " - name: foobar\n";
+        MetricMapper.load(new StringReader(rules));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseHelpWithNoName() {
+        String rules = "---\n" +
+                "rules:\n" +
+                " - help: foobar\n";
+        MetricMapper.load(new StringReader(rules));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseLabelNamesWithNoName() {
+        String rules = "---\n" +
+                "rules:\n" +
+                " - labels:\n" +
+                "     foo: bar\n";
+        MetricMapper.load(new StringReader(rules));
+    }
+}

--- a/simpleclient_dropwizard/pom.xml
+++ b/simpleclient_dropwizard/pom.xml
@@ -49,5 +49,10 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+            <version>0.0.12-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -2,7 +2,9 @@ package io.prometheus.client.dropwizard;
 
 
 import com.codahale.metrics.*;
+import io.prometheus.client.exporter.common.MetricMapper;
 
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -16,33 +18,50 @@ import java.util.logging.Logger;
  */
 public class DropwizardExports extends io.prometheus.client.Collector {
     private MetricRegistry registry;
+    private MetricMapper metricMapper;
     private static final Logger LOGGER = Logger.getLogger(DropwizardExports.class.getName());
+
+    /**
+     * @param registry   a metric registry to export in prometheus.
+     * @param yamlConfig a yaml mapping configuration
+     */
+    DropwizardExports(MetricRegistry registry, String yamlConfig) {
+        this.registry = registry;
+        this.metricMapper = MetricMapper.load(yamlConfig);
+    }
+
+    /**
+     * @param registry   a metric registry to export in prometheus.
+     * @param yamlReader a yaml configuration reader.
+     */
+    DropwizardExports(MetricRegistry registry, Reader yamlReader) {
+        this.registry = registry;
+        this.metricMapper = MetricMapper.load(yamlReader);
+    }
 
     /**
      * @param registry a metric registry to export in prometheus.
      */
     DropwizardExports(MetricRegistry registry) {
         this.registry = registry;
+        this.metricMapper = MetricMapper.load();
     }
 
     /**
      * Export counter as prometheus counter.
      */
     List<MetricFamilySamples> fromCounter(String name, Counter counter) {
-        MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name, new ArrayList<String>(), new ArrayList<String>(),
-                new Long(counter.getCount()).doubleValue());
-        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(name, counter), Arrays.asList(sample)));
-    }
-
-    private static String getHelpMessage(String metricName, Metric metric){
-        return String.format("Generated from dropwizard metric import (metric=%s, type=%s)",
-                metricName, metric.getClass().getName());
+        MetricMapper.MetricMapping mapping = metricMapper.map(name);
+        MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name, mapping.getLabelNames(),
+                mapping.getLabelValues(), new Long(counter.getCount()).doubleValue());
+        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, mapping.getHelp(), Arrays.asList(sample)));
     }
 
     /**
      * Export gauge as a prometheus gauge.
      */
     List<MetricFamilySamples> fromGauge(String name, Gauge gauge) {
+        MetricMapper.MetricMapping mapping = metricMapper.map(name);
         Object obj = gauge.getValue();
         Double value;
         if (obj instanceof Integer) {
@@ -58,37 +77,51 @@ public class DropwizardExports extends io.prometheus.client.Collector {
                     obj.getClass().getName()));
             return new ArrayList<MetricFamilySamples>();
         }
-        MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name,
-                new ArrayList<String>(), new ArrayList<String>(), value);
-        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(name, gauge), Arrays.asList(sample)));
+        MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(mapping.getName(),
+                mapping.getLabelNames(), mapping.getLabelValues(), value);
+        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, mapping.getHelp(), Arrays.asList(sample)));
+    }
+
+    private static List<String> mergeList(List<String> list, String... elements) {
+        List<String> targetList = new ArrayList<String>(list);
+        targetList.addAll(Arrays.asList(elements));
+        return targetList;
     }
 
     /**
      * Export a histogram snapshot as a prometheus SUMMARY.
      *
-     * @param name metric name.
+     * @param name     metric name.
      * @param snapshot the histogram snapshot.
-     * @param count the total sample count for this snapshot.
-     * @param factor a factor to apply to histogram values.
-     *
+     * @param count    the total sample count for this snapshot.
+     * @param factor   a factor to apply to histogram values.
      */
-    List<MetricFamilySamples> fromSnapshotAndCount(String name, Snapshot snapshot, long count, double factor, String helpMessage) {
+    List<MetricFamilySamples> fromSnapshotAndCount(String name, Snapshot snapshot, long count, double factor) {
         long sum = 0;
         for (long i : snapshot.getValues()) {
             sum += i;
         }
+        MetricMapper.MetricMapping mapping = metricMapper.map(name);
         List<MetricFamilySamples.Sample> samples = Arrays.asList(
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.5"), snapshot.getMedian() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.75"), snapshot.get75thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.95"), snapshot.get95thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.98"), snapshot.get98thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.99"), snapshot.get99thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.999"), snapshot.get999thPercentile() * factor),
-                new MetricFamilySamples.Sample(name + "_count", new ArrayList<String>(), new ArrayList<String>(), count),
-                new MetricFamilySamples.Sample(name + "_sum", new ArrayList<String>(), new ArrayList<String>(), sum * factor)
+                new MetricFamilySamples.Sample(mapping.getName(), mergeList(mapping.getLabelNames(), "quantile"),
+                        mergeList(mapping.getLabelValues(), "0.5"), snapshot.getMedian() * factor),
+                new MetricFamilySamples.Sample(mapping.getName(), mergeList(mapping.getLabelNames(), "quantile"),
+                        mergeList(mapping.getLabelValues(), "0.75"), snapshot.get75thPercentile() * factor),
+                new MetricFamilySamples.Sample(mapping.getName(), mergeList(mapping.getLabelNames(), "quantile"),
+                        mergeList(mapping.getLabelValues(), "0.95"), snapshot.get95thPercentile() * factor),
+                new MetricFamilySamples.Sample(mapping.getName(), mergeList(mapping.getLabelNames(), "quantile"),
+                        mergeList(mapping.getLabelValues(), "0.98"), snapshot.get98thPercentile() * factor),
+                new MetricFamilySamples.Sample(mapping.getName(), mergeList(mapping.getLabelNames(), "quantile"),
+                        mergeList(mapping.getLabelValues(), "0.99"), snapshot.get99thPercentile() * factor),
+                new MetricFamilySamples.Sample(mapping.getName(), mergeList(mapping.getLabelNames(), "quantile"),
+                        mergeList(mapping.getLabelValues(), "0.999"), snapshot.get999thPercentile() * factor),
+                new MetricFamilySamples.Sample(mapping.getName() + "_count", mapping.getLabelNames(),
+                        mapping.getLabelValues(), count),
+                new MetricFamilySamples.Sample(mapping.getName() + "_sum", mapping.getLabelNames(),
+                        mapping.getLabelValues(), sum * factor)
         );
         return Arrays.asList(
-                new MetricFamilySamples(name, Type.SUMMARY, helpMessage, samples)
+                new MetricFamilySamples(name, Type.SUMMARY, mapping.getHelp(), samples)
         );
     }
 
@@ -96,8 +129,7 @@ public class DropwizardExports extends io.prometheus.client.Collector {
      * Convert histogram snapshot.
      */
     List<MetricFamilySamples> fromHistogram(String name, Histogram histogram) {
-        return fromSnapshotAndCount(name, histogram.getSnapshot(), histogram.getCount(), 1.0,
-                getHelpMessage(name, histogram));
+        return fromSnapshotAndCount(name, histogram.getSnapshot(), histogram.getCount(), 1.0);
     }
 
     /**
@@ -105,18 +137,19 @@ public class DropwizardExports extends io.prometheus.client.Collector {
      */
     List<MetricFamilySamples> fromTimer(String name, Timer timer) {
         return fromSnapshotAndCount(name, timer.getSnapshot(), timer.getCount(),
-                1.0D / TimeUnit.SECONDS.toNanos(1L), getHelpMessage(name, timer));
+                1.0D / TimeUnit.SECONDS.toNanos(1L));
     }
 
     /**
      * Export a Meter as as prometheus COUNTER.
      */
     List<MetricFamilySamples> fromMeter(String name, Meter meter) {
+        MetricMapper.MetricMapping mapping = metricMapper.map(name);
         return Arrays.asList(
-                new MetricFamilySamples(name + "_total", Type.COUNTER, getHelpMessage(name, meter),
+                new MetricFamilySamples(name + "_total", Type.COUNTER, mapping.getHelp(),
                         Arrays.asList(new MetricFamilySamples.Sample(name + "_total",
-                                new ArrayList<String>(),
-                                new ArrayList<String>(),
+                                mapping.getLabelNames(),
+                                mapping.getLabelValues(),
                                 meter.getCount())))
 
         );
@@ -128,7 +161,7 @@ public class DropwizardExports extends io.prometheus.client.Collector {
      * @param name metric name.
      * @return the sanitized metric name.
      */
-    public static String sanitizeMetricName(String name){
+    public static String sanitizeMetricName(String name) {
         return name.replaceAll("[^a-zA-Z0-9:_]", "_");
     }
 
@@ -136,19 +169,19 @@ public class DropwizardExports extends io.prometheus.client.Collector {
     public List<MetricFamilySamples> collect() {
         ArrayList<MetricFamilySamples> mfSamples = new ArrayList<MetricFamilySamples>();
         for (SortedMap.Entry<String, Gauge> entry : registry.getGauges().entrySet()) {
-            mfSamples.addAll(fromGauge(sanitizeMetricName(entry.getKey()), entry.getValue()));
+            mfSamples.addAll(fromGauge(entry.getKey(), entry.getValue()));
         }
         for (SortedMap.Entry<String, Counter> entry : registry.getCounters().entrySet()) {
-            mfSamples.addAll(fromCounter(sanitizeMetricName(entry.getKey()), entry.getValue()));
+            mfSamples.addAll(fromCounter(entry.getKey(), entry.getValue()));
         }
         for (SortedMap.Entry<String, Histogram> entry : registry.getHistograms().entrySet()) {
-            mfSamples.addAll(fromHistogram(sanitizeMetricName(entry.getKey()), entry.getValue()));
+            mfSamples.addAll(fromHistogram(entry.getKey(), entry.getValue()));
         }
         for (SortedMap.Entry<String, Timer> entry : registry.getTimers().entrySet()) {
-            mfSamples.addAll(fromTimer(sanitizeMetricName(entry.getKey()), entry.getValue()));
+            mfSamples.addAll(fromTimer(entry.getKey(), entry.getValue()));
         }
         for (SortedMap.Entry<String, Meter> entry : registry.getMeters().entrySet()) {
-            mfSamples.addAll(fromMeter(sanitizeMetricName(entry.getKey()), entry.getValue()));
+            mfSamples.addAll(fromMeter(entry.getKey(), entry.getValue()));
         }
         return mfSamples;
     }


### PR DESCRIPTION
Introcude a metric mapper (higly inspired from jmx_exporter code) that allows to map dropwizard metrics to target metric and labels.

This code will be re-used in jmx_exporter in a further review.
