### PR TITLE
Added support for basic Thread Counts

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java
@@ -23,6 +23,7 @@ public class DefaultExports {
       new StandardExports().register();
       new MemoryPoolsExports().register();
       new GarbageCollectorExports().register();
+      new ThreadExports().register();
       initialized = true;
     }
   }

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -1,0 +1,89 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.Collector;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Exports metrics about JVM thread areas.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new ThreadExports().register();
+ * }
+ * </pre>
+ * Example metrics being exported:
+ * <pre>
+ *   jvm_threads_current{} 300
+ *   jvm_threads_daemon{} 200
+ *   jvm_threads_peak{} 410
+ *   jvm_threads_started_total{} 1200
+ * </pre>
+ */
+public class ThreadExports extends Collector {
+  private final ThreadMXBean threadBean;
+
+  public static final List<String> EMPTY_LABEL = Collections.emptyList();
+
+  public ThreadExports() {
+    this(ManagementFactory.getThreadMXBean());
+  }
+
+  public ThreadExports(ThreadMXBean threadBean) {
+    this.threadBean = threadBean;
+  }
+
+  void addThreadMetrics(List<MetricFamilySamples> sampleFamilies) {
+    sampleFamilies.add(
+            new MetricFamilySamples(
+                    "jvm_threads_current",
+                    Type.GAUGE,
+                    "Current thread count of a JVM",
+                    Collections.singletonList(
+                            new MetricFamilySamples.Sample(
+                                    "jvm_threads_current", EMPTY_LABEL, EMPTY_LABEL,
+                                    threadBean.getThreadCount()))));
+
+    sampleFamilies.add(
+            new MetricFamilySamples(
+                    "jvm_threads_daemon",
+                    Type.GAUGE,
+                    "Daemon thread count of a JVM",
+                    Collections.singletonList(
+                            new MetricFamilySamples.Sample(
+                                    "jvm_threads_daemon", EMPTY_LABEL, EMPTY_LABEL,
+                                    threadBean.getDaemonThreadCount()))));
+
+    sampleFamilies.add(
+            new MetricFamilySamples(
+                    "jvm_peak_threads",
+                    Type.GAUGE,
+                    "Peak thread count of a JVM",
+                    Collections.singletonList(
+                            new MetricFamilySamples.Sample(
+                                    "jvm_threads_peak", EMPTY_LABEL, EMPTY_LABEL,
+                                    threadBean.getPeakThreadCount()))));
+
+    sampleFamilies.add(
+            new MetricFamilySamples(
+                    "jvm_threads_started_total",
+                    Type.COUNTER,
+                    "Started thread count of a JVM",
+                    Collections.singletonList(
+                            new MetricFamilySamples.Sample(
+                                    "jvm_threads_started_total", EMPTY_LABEL, EMPTY_LABEL,
+                                    threadBean.getTotalStartedThreadCount()))));
+  }
+
+
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+    addThreadMetrics(mfs);
+    return mfs;
+  }
+}

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/ThreadExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/ThreadExportsTest.java
@@ -1,0 +1,53 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.management.ThreadMXBean;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class ThreadExportsTest {
+
+  private ThreadMXBean mockThreadsBean = Mockito.mock(ThreadMXBean.class);
+  private CollectorRegistry registry = new CollectorRegistry();
+  private ThreadExports collectorUnderTest;
+
+  private static final String[] EMPTY_LABEL = new String[0];
+
+  @Before
+  public void setUp() {
+    when(mockThreadsBean.getThreadCount()).thenReturn(300);
+    when(mockThreadsBean.getDaemonThreadCount()).thenReturn(200);
+    when(mockThreadsBean.getPeakThreadCount()).thenReturn(301);
+    when(mockThreadsBean.getTotalStartedThreadCount()).thenReturn(503L);
+    collectorUnderTest = new ThreadExports(mockThreadsBean).register(registry);
+  }
+
+  @Test
+  public void testThreadPools() {
+    assertEquals(
+            300L,
+            registry.getSampleValue(
+                    "jvm_threads_current", EMPTY_LABEL, EMPTY_LABEL),
+            .0000001);
+    assertEquals(
+            200L,
+            registry.getSampleValue(
+                    "jvm_threads_daemon", EMPTY_LABEL, EMPTY_LABEL),
+            .0000001);
+    assertEquals(
+            301L,
+            registry.getSampleValue(
+                    "jvm_threads_peak", EMPTY_LABEL, EMPTY_LABEL),
+            .0000001);
+    assertEquals(
+            503L,
+            registry.getSampleValue(
+                    "jvm_threads_started_total", EMPTY_LABEL, EMPTY_LABEL),
+            .0000001);
+  }
+}


### PR DESCRIPTION
Added support for basic Thread Counts.  This is similar to what is available from codahale.  Missing from current lib for some reason and much needed for tracking thread leaks.