### PR TITLE
remove runtime dependency on simpleclient_servlet. fixes #103

### DIFF
--- a/simpleclient_hotspot/pom.xml
+++ b/simpleclient_hotspot/pom.xml
@@ -39,13 +39,14 @@
             <artifactId>simpleclient</artifactId>
             <version>0.0.14-SNAPSHOT</version>
         </dependency>
+        
+        <!-- Test Dependencies Follow -->
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_servlet</artifactId>
             <version>0.0.14-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
-        
-        <!-- Test Dependencies Follow -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
Turns out the ExampleExporter in the test packages is using simpleclient_servlet.
So I just changed the scope to `test`.