### PR TITLE
Handle Gauges that return both Numbers and Booleans

### DIFF
--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -1,6 +1,5 @@
 package io.prometheus.client.dropwizard;
 
-
 import com.codahale.metrics.*;
 
 import java.util.ArrayList;
@@ -44,15 +43,11 @@ public class DropwizardExports extends io.prometheus.client.Collector {
      */
     List<MetricFamilySamples> fromGauge(String name, Gauge gauge) {
         Object obj = gauge.getValue();
-        Double value;
-        if (obj instanceof Integer) {
-            value = Double.valueOf(((Integer) obj).doubleValue());
-        } else if (obj instanceof Double) {
-            value = (Double) obj;
-        } else if (obj instanceof Float) {
-            value = Double.valueOf(((Float) obj).doubleValue());
-        } else if (obj instanceof Long) {
-            value = Double.valueOf(((Long) obj).doubleValue());
+        double value;
+        if (obj instanceof Number) {
+            value = ((Number) obj).doubleValue();
+        } else if (obj instanceof Boolean) {
+            value = ((Boolean) obj) ? 1 : 0;
         } else {
             LOGGER.log(Level.FINE, String.format("Invalid type for Gauge %s: %s", name,
                     obj.getClass().getName()));

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
@@ -52,17 +52,25 @@ public class DropwizardExportsTest {
                 return 1234L;
             }
         };
-
         Gauge<Float> floatGauge = new Gauge<Float>() {
             @Override
             public Float getValue() {
                 return 0.1234F;
             }
         };
+        Gauge<Boolean> booleanGauge = new Gauge<Boolean>() {
+            @Override
+            public Boolean getValue() {
+                return true;
+            }
+        };
+
         metricRegistry.register("double_gauge", doubleGauge);
         metricRegistry.register("long_gauge", longGauge);
         metricRegistry.register("integer_gauge", integerGauge);
         metricRegistry.register("float_gauge", floatGauge);
+        metricRegistry.register("boolean_gauge", booleanGauge);
+
         assertEquals(new Double(1234),
                 registry.getSampleValue("integer_gauge", new String[]{}, new String[]{}));
         assertEquals(new Double(1234),
@@ -71,6 +79,8 @@ public class DropwizardExportsTest {
                 registry.getSampleValue("double_gauge", new String[]{}, new String[]{}));
         assertEquals(new Double(0.1234F),
                 registry.getSampleValue("float_gauge", new String[]{}, new String[]{}));
+        assertEquals(new Double(1),
+                registry.getSampleValue("boolean_gauge", new String[]{}, new String[]{}));
     }
 
     @Test


### PR DESCRIPTION
Allows us to track Gauges that, for example, reflect circuit-breaker status.