### PR TITLE
Expose Summary.Child.Value and Histogram.Child.Value fields.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -164,8 +164,8 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
    */
   public static class Child {
     public static class Value {
-      private double sum;  
-      private double[] buckets;
+      public double sum;
+      public double[] buckets;
     }
 
     private Child(double[] buckets) {

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -91,8 +91,8 @@ public class Summary extends SimpleCollector<Summary.Child> {
    */
   public static class Child {
     public static class Value {
-      private double count;  
-      private double sum;
+      public double count;
+      public double sum;
     }
 
     // Having these seperate leaves us open to races,


### PR DESCRIPTION
This is a trivial change to make Summary.labels().get() and Histogram.labels().get() somewhat useful for clients, that want to see current values stored in the metrics.