### PR TITLE
Replace synchronization in Gauge with the use of volatile

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -113,7 +113,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> {
    * {@link SimpleCollector#remove} or {@link SimpleCollector#clear},
    */
   public static class Child {
-    private final DoubleAdder value = new DoubleAdder();
+    private volatile double value;
 
     static TimeProvider timeProvider = new TimeProvider();
     /**
@@ -126,7 +126,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> {
      * Increment the gauge by the given amount.
      */
     public void inc(double amt) {
-      value.add(amt);
+      value += amt;
     }
     /**
      * Decrement the gauge by 1.
@@ -138,19 +138,13 @@ public class Gauge extends SimpleCollector<Gauge.Child> {
      * Decrement the gauge by the given amount.
      */
     public void dec(double amt) {
-      value.add(-amt);
+      value -=amt;
     }
     /**
      * Set the gauge to the given value.
      */
     public void set(double val) {
-      synchronized(this) {
-        value.reset();
-        // If get() were called here it'd see an invalid value, so use a lock.
-        // inc()/dec() don't need locks, as all the possible outcomes
-        // are still possible if set() were atomic so no new races are introduced.
-        value.add(val);
-      }
+      value = val;
     }
     /**
      * Set the gauge to the current unixtime.
@@ -174,9 +168,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> {
      * Get the value of the gauge.
      */
     public double get() {
-      synchronized(this) {
-        return value.sum();
-      }
+      return value;
     }
   }
 


### PR DESCRIPTION
There is no sense in using DoubleAdded (promising to reduce a chance
of thread locks) and then synchronize over it.
A plain volatile double is enough as it is guaranteed to be atomic:
https://docs.oracle.com/javase/specs/jls/se6/html/memory.html#17.7

Gauge Benchmark run on my machine:

After:

```
Benchmark                                                         Mode  Samples    Score     Error  Units
i.p.b.GaugeBenchmark.codahaleCounterDecBenchmark                  avgt        4   14.739 ±   1.320  ns/op
i.p.b.GaugeBenchmark.codahaleCounterIncBenchmark                  avgt        4   14.755 ±   0.464  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeChildDecBenchmark             avgt        4  352.766 ± 121.665  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeChildIncBenchmark             avgt        4  367.678 ±  81.826  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeChildSetBenchmark             avgt        4   94.045 ±   7.879  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeDecBenchmark                  avgt        4  221.809 ±  14.444  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeIncBenchmark                  avgt        4  223.763 ±  12.044  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeSetBenchmark                  avgt        4  142.472 ±   8.114  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildDecBenchmark       avgt        4   70.428 ±  16.341  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildIncBenchmark       avgt        4   70.713 ±   3.768  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildSetBenchmark       avgt        4   40.997 ±   8.408  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeDecBenchmark            avgt        4   91.380 ±  13.906  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeIncBenchmark            avgt        4   98.121 ±  28.364  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsDecBenchmark    avgt        4   72.474 ±   1.951  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsIncBenchmark    avgt        4   76.178 ±  14.539  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsSetBenchmark    avgt        4   66.269 ±   1.834  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeSetBenchmark            avgt        4   90.543 ±   6.621  ns/op
```

Before:

```
Benchmark                                                         Mode  Samples    Score     Error  Units
i.p.b.GaugeBenchmark.codahaleCounterDecBenchmark                  avgt        4   15.343 ±   5.113  ns/op
i.p.b.GaugeBenchmark.codahaleCounterIncBenchmark                  avgt        4   15.173 ±   3.344  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeChildDecBenchmark             avgt        4  355.033 ±  82.498  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeChildIncBenchmark             avgt        4  324.476 ± 375.589  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeChildSetBenchmark             avgt        4   87.491 ±  27.689  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeDecBenchmark                  avgt        4  229.647 ±  43.418  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeIncBenchmark                  avgt        4  223.994 ±  77.977  ns/op
i.p.b.GaugeBenchmark.prometheusGaugeSetBenchmark                  avgt        4  168.277 ± 119.829  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildDecBenchmark       avgt        4   15.486 ±   2.620  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildIncBenchmark       avgt        4   15.600 ±   2.124  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeChildSetBenchmark       avgt        4  150.970 ±  72.651  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeDecBenchmark            avgt        4   69.743 ±  10.904  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeIncBenchmark            avgt        4   68.180 ±  13.910  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsDecBenchmark    avgt        4   17.629 ±   6.610  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsIncBenchmark    avgt        4   15.730 ±   2.197  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeNoLabelsSetBenchmark    avgt        4  165.577 ±  19.035  ns/op
i.p.b.GaugeBenchmark.prometheusSimpleGaugeSetBenchmark            avgt        4  322.609 ±  14.338  ns/op
```

So if I understand correctly my change looses some performance for inc/dec, but provides a huge gain in set (get is not measured). Also note that using volatile makes all operations take roughly the same time, while with DoubleAdder in one case set was 10 times slower than inc.