### PR TITLE
Remove duplication in collect() of all built-in collectors

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -1,7 +1,6 @@
 
 package io.prometheus.client;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -138,14 +138,10 @@ public class Counter extends SimpleCollector<Counter.Child> {
 
   @Override
   public List<MetricFamilySamples> collect() {
-    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
       samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
     }
-    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.COUNTER, help, samples);
-
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(mfs);
-    return mfsList;
+    return familySamplesList(Type.COUNTER, samples);
   }
 }

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -232,15 +232,11 @@ public class Gauge extends SimpleCollector<Gauge.Child> {
 
   @Override
   public List<MetricFamilySamples> collect() {
-    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
       samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
     }
-    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.GAUGE, help, samples);
-
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(mfs);
-    return mfsList;
+    return familySamplesList(Type.GAUGE, samples);
   }
 
   static class TimeProvider {

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -182,7 +182,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
     private final DoubleAdder[] cumulativeCounts;
     private final DoubleAdder sum = new DoubleAdder();
 
-    static TimeProvider timeProvider = new TimeProvider();
+    static NanoTimeProvider timeProvider = new NanoTimeProvider();
     /**
      * Observe the given amount.
      */
@@ -252,19 +252,10 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
       samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum));
     }
 
-    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.HISTOGRAM, help, samples);
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(mfs);
-    return mfsList;
+    return familySamplesList(Type.HISTOGRAM, samples);
   }
 
   double[] getBuckets() {
     return buckets;
-  }
-
-  static class TimeProvider {
-    long nanoTime() {
-      return System.nanoTime();
-    }
   }
 }

--- a/simpleclient/src/main/java/io/prometheus/client/NanoTimeProvider.java
+++ b/simpleclient/src/main/java/io/prometheus/client/NanoTimeProvider.java
@@ -1,0 +1,7 @@
+package io.prometheus.client;
+
+class NanoTimeProvider {
+  long nanoTime() {
+    return System.nanoTime();
+  }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -1,5 +1,6 @@
 package io.prometheus.client;
 
+import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.Arrays;
@@ -141,6 +142,13 @@ public abstract class SimpleCollector<Child> extends Collector {
    * Return a new child, workaround for Java generics limitations.
    */
   protected abstract Child newChild();
+
+  List<MetricFamilySamples> familySamplesList(Collector.Type type, List<MetricFamilySamples.Sample> samples) {
+    MetricFamilySamples mfs = new MetricFamilySamples(fullname, type, help, samples);
+    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>(1);
+    mfsList.add(mfs);
+    return mfsList;
+  }
 
   protected SimpleCollector(Builder b) {
     if (b.name.isEmpty()) throw new IllegalStateException("Name hasn't been set.");

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -107,7 +107,7 @@ public class Summary extends SimpleCollector<Summary.Child> {
     private final DoubleAdder count = new DoubleAdder();
     private final DoubleAdder sum = new DoubleAdder();
 
-    static TimeProvider timeProvider = new TimeProvider();
+    static NanoTimeProvider timeProvider = new NanoTimeProvider();
     /**
      * Observe the given amount.
      */
@@ -158,15 +158,6 @@ public class Summary extends SimpleCollector<Summary.Child> {
       samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum));
     }
 
-    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.SUMMARY, help, samples);
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(mfs);
-    return mfsList;
-  }
-
-  static class TimeProvider {
-    long nanoTime() {
-      return System.nanoTime();
-    }
+    return familySamplesList(Type.SUMMARY, samples);
   }
 }

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -24,7 +24,7 @@ public class HistogramTest {
 
   @After
   public void tearDown() {
-    Histogram.Child.timeProvider = new Histogram.TimeProvider();
+    Histogram.Child.timeProvider = new NanoTimeProvider();
   }
 
   private double getCount() {
@@ -100,7 +100,7 @@ public class HistogramTest {
 
   @Test
   public void testTimer() {
-    Histogram.Child.timeProvider = new Histogram.TimeProvider() {
+    Histogram.Child.timeProvider = new NanoTimeProvider() {
       long value = (long)(30 * 1e9);
       long nanoTime() {
         value += (long)(10 * 1e9);

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -23,7 +23,7 @@ public class SummaryTest {
 
   @After
   public void tearDown() {
-    Summary.Child.timeProvider = new Summary.TimeProvider();
+    Summary.Child.timeProvider = new NanoTimeProvider();
   }
 
   private double getCount() {
@@ -45,7 +45,7 @@ public class SummaryTest {
 
   @Test
   public void testTimer() {
-    Summary.Child.timeProvider = new Summary.TimeProvider() {
+    Summary.Child.timeProvider = new NanoTimeProvider() {
       long value = (long)(30 * 1e9);
       long nanoTime() {
         value += (long)(10 * 1e9);


### PR DESCRIPTION
Also save some space by precomputing capacity of some arrays.
Also de-duplicate class TimeProvider
