### PR TITLE
Use a map to store labels for samples

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -4,6 +4,7 @@ package io.prometheus.client;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 /**
@@ -111,8 +112,26 @@ public abstract class Collector {
 
       @Override
       public String toString() {
-        return "Name: " + name + " LabelNames: " + labels.keySet() + " labelValues: " + labels.values() +
-          " Value: " + value;
+        StringBuilder sb = new StringBuilder();
+        sb.append(name);
+        if (labels != null && !labels.isEmpty()) {
+          sb.append('{');
+          final Map<String, String> sortedLabels = new TreeMap<String, String>(labels);
+          for (Map.Entry<String, String> label : sortedLabels.entrySet()) {
+            sb.append(label.getKey())
+                    .append('=')
+                    .append('\"')
+                    .append(escapeLabelValue(label.getValue()))
+                    .append("\",");
+          }
+          sb.append('}');
+        }
+        sb.append(' ').append(doubleToGoString(value));
+        return sb.toString();
+      }
+
+      private String escapeLabelValue(String s) {
+        return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
       }
     }
   }

--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -1,8 +1,9 @@
 
 package io.prometheus.client;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -74,14 +75,18 @@ public abstract class Collector {
    */
     public static class Sample {
       public final String name;
-      public final List<String> labelNames;
-      public final List<String> labelValues;  // Must have same length as labelNames.
+      public final Map<String, String> labels;
       public final double value;
 
-      public Sample(String name, List<String> labelNames, List<String> labelValues, double value) {
+      public Sample(String name, double value) {
         this.name = name;
-        this.labelNames = labelNames;
-        this.labelValues = labelValues;
+        this.labels = Collections.EMPTY_MAP;
+        this.value = value;
+      }
+
+      public Sample(String name, Map<String, String> labels, double value) {
+        this.name = name;
+        this.labels = labels;
         this.value = value;
       }
 
@@ -91,16 +96,14 @@ public abstract class Collector {
           return false;
         }
         Sample other = (Sample) obj;
-        return other.name.equals(name) && other.labelNames.equals(labelNames)
-          && other.labelValues.equals(labelValues) && other.value == value;
+        return other.name.equals(name) && other.labels.equals(labels) && other.value == value;
       }
 
       @Override
       public int hashCode() {
         int hash = 1;
         hash = 37 * hash + name.hashCode();
-        hash = 37 * hash + labelNames.hashCode();
-        hash = 37 * hash + labelValues.hashCode();
+        hash = 37 * hash + labels.hashCode();
         long d = Double.doubleToLongBits(value);
         hash = 37 * hash + (int)(d ^ (d >>> 32));
         return hash;
@@ -108,7 +111,7 @@ public abstract class Collector {
 
       @Override
       public String toString() {
-        return "Name: " + name + " LabelNames: " + labelNames + " labelValues: " + labelValues +
+        return "Name: " + name + " LabelNames: " + labels.keySet() + " labelValues: " + labels.values() +
           " Value: " + value;
       }
     }

--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -1,11 +1,10 @@
 package io.prometheus.client;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Enumeration;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -100,7 +99,7 @@ public class CollectorRegistry {
    * This is inefficient, and intended only for use in unittests.
    */
   public Double getSampleValue(String name) {
-    return getSampleValue(name, new String[]{}, new String[]{});
+    return getSampleValue(name, Collections.EMPTY_MAP);
   }
 
   /**
@@ -108,12 +107,19 @@ public class CollectorRegistry {
    * <p>
    * This is inefficient, and intended only for use in unittests.
    */
-  public Double getSampleValue(String name, String[] labelNames, String[] labelValues) {
+  public Double getSampleValue(String name, String labelName, String labelValue) {
+    return getSampleValue(name, Collections.singletonMap(labelName, labelValue));
+  }
+
+  /**
+   * Returns the given value, or null if it doesn't exist.
+   * <p>
+   * This is inefficient, and intended only for use in unittests.
+   */
+  public Double getSampleValue(String name, Map<String, String> labels) {
     for (Collector.MetricFamilySamples metricFamilySamples: Collections.list(metricFamilySamples())) {
       for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
-        if (sample.name.equals(name)
-            && Arrays.equals(sample.labels.keySet().toArray(), labelNames)
-            && Arrays.equals(sample.labels.values().toArray(), labelValues)) {
+        if (sample.name.equals(name) && sample.labels.equals(labels)) {
           return sample.value;
         }
       }

--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -112,8 +112,8 @@ public class CollectorRegistry {
     for (Collector.MetricFamilySamples metricFamilySamples: Collections.list(metricFamilySamples())) {
       for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
         if (sample.name.equals(name)
-            && Arrays.equals(sample.labelNames.toArray(), labelNames)
-            && Arrays.equals(sample.labelValues.toArray(), labelValues)) {
+            && Arrays.equals(sample.labels.keySet().toArray(), labelNames)
+            && Arrays.equals(sample.labels.values().toArray(), labelValues)) {
           return sample.value;
         }
       }

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -140,7 +140,7 @@ public class Counter extends SimpleCollector<Counter.Child> {
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
-      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+      samples.add(new MetricFamilySamples.Sample(fullname, labelsMap(c.getKey()), c.getValue().get()));
     }
     MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.COUNTER, help, samples);
 

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -1,6 +1,7 @@
 package io.prometheus.client;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -234,7 +235,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> {
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
-      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+      samples.add(new MetricFamilySamples.Sample(fullname, labelsMap(c.getKey()), c.getValue().get()));
     }
     MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.GAUGE, help, samples);
 

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -1,6 +1,7 @@
 package io.prometheus.client;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -240,16 +241,15 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
+      Map<String, String> labelsMap = labelsMap(c.getKey());
       Child.Value v = c.getValue().get();
-      List<String> labelNamesWithLe = new ArrayList<String>(labelNames);
-      labelNamesWithLe.add("le");
       for (int i = 0; i < v.buckets.length; ++i) {
-        List<String> labelValuesWithLe = new ArrayList<String>(c.getKey());
-        labelValuesWithLe.add(doubleToGoString(buckets[i]));
-        samples.add(new MetricFamilySamples.Sample(fullname + "_bucket", labelNamesWithLe, labelValuesWithLe, v.buckets[i]));
+        Map<String, String> labelsMapWithLe = new HashMap<String, String>(labelsMap);
+        labelsMapWithLe.put("le", doubleToGoString(buckets[i]));
+        samples.add(new MetricFamilySamples.Sample(fullname + "_bucket", labelsMapWithLe, v.buckets[i]));
       }
-      samples.add(new MetricFamilySamples.Sample(fullname + "_count", labelNames, c.getKey(), v.buckets[buckets.length-1]));
-      samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum));
+      samples.add(new MetricFamilySamples.Sample(fullname + "_count", labelsMap, v.buckets[buckets.length-1]));
+      samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelsMap, v.sum));
     }
 
     MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.HISTOGRAM, help, samples);

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -1,5 +1,7 @@
 package io.prometheus.client;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.Arrays;
@@ -50,7 +52,7 @@ public abstract class SimpleCollector<Child> extends Collector {
   protected final String help;
   protected final List<String> labelNames;
 
-  protected final ConcurrentMap<List<String>, Child> children = new ConcurrentHashMap<List<String>, Child>();;
+  protected final ConcurrentMap<List<String>, Child> children = new ConcurrentHashMap<List<String>, Child>();
   protected Child noLabelsChild;
 
   /**
@@ -104,6 +106,17 @@ public abstract class SimpleCollector<Child> extends Collector {
     if (labelNames.size() == 0) {
       noLabelsChild = labels();
     }
+  }
+
+  /**
+   * Return label names and values as map.
+   */
+  protected Map<String, String> labelsMap(List<String> childLabels) {
+    Map<String, String> labels = new HashMap<String, String>();
+    for (int i = 0; i < labelNames.size(); i++) {
+      labels.put(labelNames.get(i), childLabels.get(i));
+    }
+    return labels;
   }
 
   /**
@@ -173,7 +186,6 @@ public abstract class SimpleCollector<Child> extends Collector {
     String namespace = "";
     String subsystem = "";
     String name = "";
-    String fullname = "";
     String help = "";
     String[] labelNames = new String[]{};
     // Some metrics require additional setup before the initialization can be done.

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -154,8 +154,9 @@ public class Summary extends SimpleCollector<Summary.Child> {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
       Child.Value v = c.getValue().get();
-      samples.add(new MetricFamilySamples.Sample(fullname + "_count", labelNames, c.getKey(), v.count));
-      samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum));
+      Map<String, String> labelsMap = labelsMap(c.getKey());
+      samples.add(new MetricFamilySamples.Sample(fullname + "_count", labelsMap, v.count));
+      samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelsMap, v.sum));
     }
 
     MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.SUMMARY, help, samples);

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -1,9 +1,9 @@
 package io.prometheus.client;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.Before;
@@ -47,7 +47,7 @@ public class CounterTest {
   }
   
   private Double getLabelsValue(String labelValue) {
-    return registry.getSampleValue("labels", new String[]{"l"}, new String[]{labelValue});
+    return registry.getSampleValue("labels", "l", labelValue);
   }
 
   @Test
@@ -68,7 +68,7 @@ public class CounterTest {
     List<Collector.MetricFamilySamples> mfs = labels.collect();
     
     ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
-    samples.add(new Collector.MetricFamilySamples.Sample("labels", Collections.singletonMap("l", "a"), 1.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels", singletonMap("l", "a"), 1.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.COUNTER, "help", samples);
 
     assertEquals(1, mfs.size());

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -3,6 +3,7 @@ package io.prometheus.client;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.Before;
@@ -67,11 +68,7 @@ public class CounterTest {
     List<Collector.MetricFamilySamples> mfs = labels.collect();
     
     ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
-    ArrayList<String> labelNames = new ArrayList<String>();
-    labelNames.add("l");
-    ArrayList<String> labelValues = new ArrayList<String>();
-    labelValues.add("a");
-    samples.add(new Collector.MetricFamilySamples.Sample("labels", labelNames, labelValues, 1.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels", Collections.singletonMap("l", "a"), 1.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.COUNTER, "help", samples);
 
     assertEquals(1, mfs.size());

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
@@ -3,6 +3,7 @@ package io.prometheus.client;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -115,11 +116,7 @@ public class GaugeTest {
     List<Collector.MetricFamilySamples> mfs = labels.collect();
     
     ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
-    ArrayList<String> labelNames = new ArrayList<String>();
-    labelNames.add("l");
-    ArrayList<String> labelValues = new ArrayList<String>();
-    labelValues.add("a");
-    samples.add(new Collector.MetricFamilySamples.Sample("labels", labelNames, labelValues, 1.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels", Collections.singletonMap("l", "a"), 1.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.GAUGE, "help", samples);
 
     assertEquals(1, mfs.size());

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
@@ -1,9 +1,9 @@
 package io.prometheus.client;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -93,9 +93,9 @@ public class GaugeTest {
   public void noLabelsDefaultZeroValue() {
     assertEquals(0.0, getValue(), .001);
   }
-  
+
   private Double getLabelsValue(String labelValue) {
-    return registry.getSampleValue("labels", new String[]{"l"}, new String[]{labelValue});
+    return registry.getSampleValue("labels", "l", labelValue);
   }
 
   @Test
@@ -116,7 +116,7 @@ public class GaugeTest {
     List<Collector.MetricFamilySamples> mfs = labels.collect();
     
     ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
-    samples.add(new Collector.MetricFamilySamples.Sample("labels", Collections.singletonMap("l", "a"), 1.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels", singletonMap("l", "a"), 1.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.GAUGE, "help", samples);
 
     assertEquals(1, mfs.size());

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -1,10 +1,10 @@
 package io.prometheus.client;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -38,9 +38,8 @@ public class HistogramTest {
     return registry.getSampleValue("nolabels_sum").doubleValue();
   }
   private double getBucket(double b) {
-    return registry.getSampleValue("nolabels_bucket", 
-        new String[]{"le"},
-        new String[]{Collector.doubleToGoString(b)}).doubleValue();
+    return registry.getSampleValue("nolabels_bucket",
+            "le", Collector.doubleToGoString(b)).doubleValue();
   }
   
   @Test
@@ -125,10 +124,10 @@ public class HistogramTest {
   }
   
   private Double getLabelsCount(String labelValue) {
-    return registry.getSampleValue("labels_count", new String[]{"l"}, new String[]{labelValue});
+    return registry.getSampleValue("labels_count", "l", labelValue);
   }
   private Double getLabelsSum(String labelValue) {
-    return registry.getSampleValue("labels_sum", new String[]{"l"}, new String[]{labelValue});
+    return registry.getSampleValue("labels_sum", "l", labelValue);
   }
 
   @Test
@@ -160,7 +159,7 @@ public class HistogramTest {
     List<Collector.MetricFamilySamples> mfs = labels.collect();
     
     List<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
-    Map<String, String> labels = Collections.singletonMap("l", "a");
+    Map<String, String> labels = singletonMap("l", "a");
     for (String bucket: new String[]{"0.005", "0.01", "0.025", "0.05", "0.075", "0.1", "0.25", "0.5", "0.75", "1.0"}) {
       Map<String, String> labelsWithLe = new HashMap<String, String>(labels);
       labelsWithLe.put("le", bucket);

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -4,7 +4,11 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -155,25 +159,20 @@ public class HistogramTest {
     labels.labels("a").observe(2);
     List<Collector.MetricFamilySamples> mfs = labels.collect();
     
-    ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
-    ArrayList<String> labelNames = new ArrayList<String>();
-    labelNames.add("l");
-    ArrayList<String> labelValues = new ArrayList<String>();
-    labelValues.add("a");
-    ArrayList<String> labelNamesLe = new ArrayList<String>(labelNames);
-    labelNamesLe.add("le");
+    List<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
+    Map<String, String> labels = Collections.singletonMap("l", "a");
     for (String bucket: new String[]{"0.005", "0.01", "0.025", "0.05", "0.075", "0.1", "0.25", "0.5", "0.75", "1.0"}) {
-      ArrayList<String> labelValuesLe = new ArrayList<String>(labelValues);
-      labelValuesLe.add(bucket);
-      samples.add(new Collector.MetricFamilySamples.Sample("labels_bucket", labelNamesLe, labelValuesLe, 0.0));
+      Map<String, String> labelsWithLe = new HashMap<String, String>(labels);
+      labelsWithLe.put("le", bucket);
+      samples.add(new Collector.MetricFamilySamples.Sample("labels_bucket", labelsWithLe, 0.0));
     }
     for (String bucket: new String[]{"2.5", "5.0", "7.5", "10.0", "+Inf"}) {
-      ArrayList<String> labelValuesLe = new ArrayList<String>(labelValues);
-      labelValuesLe.add(bucket);
-      samples.add(new Collector.MetricFamilySamples.Sample("labels_bucket", labelNamesLe, labelValuesLe, 1.0));
+      Map<String, String> labelsWithLe = new HashMap<String, String>(labels);
+      labelsWithLe.put("le", bucket);
+      samples.add(new Collector.MetricFamilySamples.Sample("labels_bucket", labelsWithLe, 1.0));
     }
-    samples.add(new Collector.MetricFamilySamples.Sample("labels_count", labelNames, labelValues, 1.0));
-    samples.add(new Collector.MetricFamilySamples.Sample("labels_sum", labelNames, labelValues, 2.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_count", labels, 1.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_sum", labels, 2.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.HISTOGRAM, "help", samples);
 
     assertEquals(1, mfs.size());

--- a/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
@@ -22,7 +22,7 @@ public class SimpleCollectorTest {
   }
   
   private Double getValue(String labelValue) {
-    return registry.getSampleValue("labels", new String[]{"l"}, new String[]{labelValue});
+    return registry.getSampleValue("labels", "l", labelValue);
   }
 
   private Double getValueNoLabels() {

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -3,7 +3,10 @@ package io.prometheus.client;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -96,12 +99,9 @@ public class SummaryTest {
     List<Collector.MetricFamilySamples> mfs = labels.collect();
     
     ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
-    ArrayList<String> labelNames = new ArrayList<String>();
-    labelNames.add("l");
-    ArrayList<String> labelValues = new ArrayList<String>();
-    labelValues.add("a");
-    samples.add(new Collector.MetricFamilySamples.Sample("labels_count", labelNames, labelValues, 1.0));
-    samples.add(new Collector.MetricFamilySamples.Sample("labels_sum", labelNames, labelValues, 2.0));
+    Map<String, String> labels = Collections.singletonMap("l", "a");
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_count", labels, 1.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_sum", labels, 2.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.SUMMARY, "help", samples);
 
     assertEquals(1, mfs.size());

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -1,9 +1,9 @@
 package io.prometheus.client;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -69,10 +69,10 @@ public class SummaryTest {
   }
   
   private Double getLabelsCount(String labelValue) {
-    return registry.getSampleValue("labels_count", new String[]{"l"}, new String[]{labelValue});
+    return registry.getSampleValue("labels_count", "l", labelValue);
   }
   private Double getLabelsSum(String labelValue) {
-    return registry.getSampleValue("labels_sum", new String[]{"l"}, new String[]{labelValue});
+    return registry.getSampleValue("labels_sum", "l", labelValue);
   }
 
   @Test
@@ -99,7 +99,7 @@ public class SummaryTest {
     List<Collector.MetricFamilySamples> mfs = labels.collect();
     
     ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
-    Map<String, String> labels = Collections.singletonMap("l", "a");
+    Map<String, String> labels = singletonMap("l", "a");
     samples.add(new Collector.MetricFamilySamples.Sample("labels_count", labels, 1.0));
     samples.add(new Collector.MetricFamilySamples.Sample("labels_sum", labels, 2.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.SUMMARY, "help", samples);

--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Map;
 
 public class TextFormat {
   /**
@@ -19,11 +20,11 @@ public class TextFormat {
       writer.write("# TYPE " + metricFamilySamples.name + " " + typeString(metricFamilySamples.type) + "\n");
       for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
         writer.write(sample.name);
-        if (sample.labelNames.size() > 0) {
+        if (sample.labels != null && !sample.labels.isEmpty()) {
           writer.write("{");
-          for (int i = 0; i < sample.labelNames.size(); ++i) {
+          for (Map.Entry<String, String> label : sample.labels.entrySet()) {
             writer.write(String.format("%s=\"%s\",",
-                sample.labelNames.get(i),  escapeLabelValue(sample.labelValues.get(i))));
+                label.getKey(), escapeLabelValue(label.getValue())));
           }
           writer.write("}");
         }

--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -19,16 +19,7 @@ public class TextFormat {
       writer.write("# HELP " + metricFamilySamples.name + " " + escapeHelp(metricFamilySamples.help) + "\n");
       writer.write("# TYPE " + metricFamilySamples.name + " " + typeString(metricFamilySamples.type) + "\n");
       for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
-        writer.write(sample.name);
-        if (sample.labels != null && !sample.labels.isEmpty()) {
-          writer.write("{");
-          for (Map.Entry<String, String> label : sample.labels.entrySet()) {
-            writer.write(String.format("%s=\"%s\",",
-                label.getKey(), escapeLabelValue(label.getValue())));
-          }
-          writer.write("}");
-        }
-        writer.write(" " + Collector.doubleToGoString(sample.value) + "\n");
+        writer.write(sample.toString() + "\n");
       }
     }
   }

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
@@ -76,6 +76,16 @@ public class TextFormatTest {
   }
 
   @Test
+  public void testSortedLabelsOutput() throws IOException {
+    Gauge labels = (Gauge) Gauge.build().name("labels").help("help").labelNames("m", "s", "l").register(registry);
+    labels.labels("a", "b", "c").inc();
+    TextFormat.write004(writer, registry.metricFamilySamples());
+    assertEquals("# HELP labels help\n"
+            + "# TYPE labels gauge\n"
+            + "labels{l=\"c\",m=\"a\",s=\"b\",} 1.0\n", writer.toString());
+  }
+
+  @Test
   public void testLabelValuesEscaped() throws IOException {
     Gauge labels = (Gauge) Gauge.build().name("labels").help("help").labelNames("l").register(registry);
     labels.labels("a\nb\\c\"d").inc();

--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -2,8 +2,11 @@ package io.prometheus.client.dropwizard;
 
 import com.codahale.metrics.*;
 
+import io.prometheus.client.Collector;
+
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
@@ -13,7 +16,7 @@ import java.util.logging.Logger;
 /**
  * Collect dropwizard metrics from a MetricRegistry.
  */
-public class DropwizardExports extends io.prometheus.client.Collector {
+public class DropwizardExports extends Collector {
     private MetricRegistry registry;
     private static final Logger LOGGER = Logger.getLogger(DropwizardExports.class.getName());
 
@@ -28,7 +31,7 @@ public class DropwizardExports extends io.prometheus.client.Collector {
      * Export counter as prometheus counter.
      */
     List<MetricFamilySamples> fromCounter(String name, Counter counter) {
-        MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name, new ArrayList<String>(), new ArrayList<String>(),
+        MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name,
                 new Long(counter.getCount()).doubleValue());
         return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(name, counter), Arrays.asList(sample)));
     }
@@ -53,8 +56,7 @@ public class DropwizardExports extends io.prometheus.client.Collector {
                     obj.getClass().getName()));
             return new ArrayList<MetricFamilySamples>();
         }
-        MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name,
-                new ArrayList<String>(), new ArrayList<String>(), value);
+        MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name, value);
         return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(name, gauge), Arrays.asList(sample)));
     }
 
@@ -73,14 +75,14 @@ public class DropwizardExports extends io.prometheus.client.Collector {
             sum += i;
         }
         List<MetricFamilySamples.Sample> samples = Arrays.asList(
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.5"), snapshot.getMedian() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.75"), snapshot.get75thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.95"), snapshot.get95thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.98"), snapshot.get98thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.99"), snapshot.get99thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.999"), snapshot.get999thPercentile() * factor),
-                new MetricFamilySamples.Sample(name + "_count", new ArrayList<String>(), new ArrayList<String>(), count),
-                new MetricFamilySamples.Sample(name + "_sum", new ArrayList<String>(), new ArrayList<String>(), sum * factor)
+                new MetricFamilySamples.Sample(name, Collections.singletonMap("quantile", "0.5"), snapshot.getMedian() * factor),
+                new MetricFamilySamples.Sample(name, Collections.singletonMap("quantile", "0.75"), snapshot.get75thPercentile() * factor),
+                new MetricFamilySamples.Sample(name, Collections.singletonMap("quantile", "0.95"), snapshot.get95thPercentile() * factor),
+                new MetricFamilySamples.Sample(name, Collections.singletonMap("quantile", "0.98"), snapshot.get98thPercentile() * factor),
+                new MetricFamilySamples.Sample(name, Collections.singletonMap("quantile", "0.99"), snapshot.get99thPercentile() * factor),
+                new MetricFamilySamples.Sample(name, Collections.singletonMap("quantile", "0.999"), snapshot.get999thPercentile() * factor),
+                new MetricFamilySamples.Sample(name + "_count", count),
+                new MetricFamilySamples.Sample(name + "_sum", sum * factor)
         );
         return Arrays.asList(
                 new MetricFamilySamples(name, Type.SUMMARY, helpMessage, samples)
@@ -110,8 +112,6 @@ public class DropwizardExports extends io.prometheus.client.Collector {
         return Arrays.asList(
                 new MetricFamilySamples(name + "_total", Type.COUNTER, getHelpMessage(name, meter),
                         Arrays.asList(new MetricFamilySamples.Sample(name + "_total",
-                                new ArrayList<String>(),
-                                new ArrayList<String>(),
                                 meter.getCount())))
 
         );

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
@@ -1,6 +1,5 @@
 package io.prometheus.client.dropwizard;
 
-
 import com.codahale.metrics.*;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.Before;
@@ -71,16 +70,11 @@ public class DropwizardExportsTest {
         metricRegistry.register("float_gauge", floatGauge);
         metricRegistry.register("boolean_gauge", booleanGauge);
 
-        assertEquals(new Double(1234),
-                registry.getSampleValue("integer_gauge", new String[]{}, new String[]{}));
-        assertEquals(new Double(1234),
-                registry.getSampleValue("long_gauge", new String[]{}, new String[]{}));
-        assertEquals(new Double(1.234),
-                registry.getSampleValue("double_gauge", new String[]{}, new String[]{}));
-        assertEquals(new Double(0.1234F),
-                registry.getSampleValue("float_gauge", new String[]{}, new String[]{}));
-        assertEquals(new Double(1),
-                registry.getSampleValue("boolean_gauge", new String[]{}, new String[]{}));
+        assertEquals(new Double(1234), registry.getSampleValue("integer_gauge"));
+        assertEquals(new Double(1234), registry.getSampleValue("long_gauge"));
+        assertEquals(new Double(1.234), registry.getSampleValue("double_gauge"));
+        assertEquals(new Double(0.1234F), registry.getSampleValue("float_gauge"));
+        assertEquals(new Double(1), registry.getSampleValue("boolean_gauge"));
     }
 
     @Test
@@ -98,7 +92,7 @@ public class DropwizardExportsTest {
     void assertRegistryContainsMetrics(String... metrics) {
         for (String metric : metrics) {
             assertNotEquals(String.format("Metric %s should exist", metric), null,
-                    registry.getSampleValue(metric, new String[]{}, new String[]{}));
+                    registry.getSampleValue(metric));
         }
     }
 
@@ -114,10 +108,10 @@ public class DropwizardExportsTest {
         assertEquals(new Double(4950), registry.getSampleValue("hist_sum"));
         for (double b : Arrays.asList(0.75, 0.95, 0.98, 0.99)) {
             assertEquals(new Double((b - 0.01) * 100), registry.getSampleValue("hist",
-                    new String[]{"quantile"}, new String[]{String.format("%.2f", b)}));
+                    "quantile", String.format("%.2f", b)));
         }
-        assertEquals(new Double(99), registry.getSampleValue("hist", new String[]{"quantile"},
-                new String[]{"0.999"}));
+        assertEquals(new Double(99), registry.getSampleValue("hist",
+                "quantile", "0.999"));
     }
 
     @Test
@@ -135,7 +129,7 @@ public class DropwizardExportsTest {
         Thread.sleep(1L);
         time.stop();
         // We slept for 1Ms so we ensure that all timers are above 1ms:
-        assertTrue(registry.getSampleValue("timer", new String[]{"quantile"}, new String[]{"0.99"}) > 0.001);
+        assertTrue(registry.getSampleValue("timer", "quantile", "0.99") > 0.001);
         assertEquals(new Double(1.0D), registry.getSampleValue("timer_count"));
         assertRegistryContainsMetrics("timer_count", "timer_sum");
     }

--- a/simpleclient_graphite_bridge/src/main/java/io/prometheus/client/bridge/Graphite.java
+++ b/simpleclient_graphite_bridge/src/main/java/io/prometheus/client/bridge/Graphite.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.util.Collections;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -57,9 +58,11 @@ public class Graphite {
       for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
         m.reset(sample.name);
         writer.write(m.replaceAll("_"));
-        for (int i = 0; i < sample.labelNames.size(); ++i) {
-          m.reset(sample.labelValues.get(i));
-          writer.write("." + sample.labelNames.get(i) + "." + m.replaceAll("_"));
+        if (sample.labels != null && !sample.labels.isEmpty()) {
+          for (Map.Entry<String, String> label : sample.labels.entrySet()) {
+            m.reset(label.getValue());
+            writer.write("." + label.getKey() + "." + m.replaceAll("_"));
+          }
         }
         writer.write(" " + sample.value + " " + now + "\n");
       }

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/GarbageCollectorExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/GarbageCollectorExports.java
@@ -7,6 +7,7 @@ import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Exports metrics about JVM garbage collectors.
@@ -37,17 +38,16 @@ public class GarbageCollectorExports extends Collector {
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
     for (final GarbageCollectorMXBean gc : garbageCollectors) {
+      Map<String, String> labelsGcName = Collections.singletonMap("gc", gc.getName());
       samples.add(
           new MetricFamilySamples.Sample(
               "jvm_gc_collection_seconds_sum",
-              Collections.singletonList("gc"),
-              Collections.singletonList(gc.getName()),
+              labelsGcName,
               gc.getCollectionTime() / MILLISECONDS_PER_SECOND));
       samples.add(
           new MetricFamilySamples.Sample(
               "jvm_gc_collection_seconds_count",
-              Collections.singletonList("gc"),
-              Collections.singletonList(gc.getName()),
+              labelsGcName,
               gc.getCollectionCount()));
     }
     List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
@@ -9,6 +9,7 @@ import java.lang.management.MemoryUsage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Exports metrics about JVM memory areas.
@@ -46,18 +47,20 @@ public class MemoryPoolsExports extends Collector {
   void addMemoryAreaMetrics(List<MetricFamilySamples> sampleFamilies) {
     MemoryUsage heapUsage = memoryBean.getHeapMemoryUsage();
     MemoryUsage nonHeapUsage = memoryBean.getNonHeapMemoryUsage();
-    ArrayList<MetricFamilySamples.Sample> usedSamples = new ArrayList<MetricFamilySamples.Sample>();
+    List<MetricFamilySamples.Sample> usedSamples = new ArrayList<MetricFamilySamples.Sample>();
+
+    final Map<String, String> labelsAreaHeap = Collections.singletonMap("area", "heap");
+    final Map<String, String> labelsAreaNonHeap = Collections.singletonMap("area", "nonheap");
+
     usedSamples.add(
         new MetricFamilySamples.Sample(
             "jvm_memory_bytes_used",
-            Collections.singletonList("area"),
-            Collections.singletonList("heap"),
+            labelsAreaHeap,
             heapUsage.getUsed()));
     usedSamples.add(
         new MetricFamilySamples.Sample(
             "jvm_memory_bytes_used",
-            Collections.singletonList("area"),
-            Collections.singletonList("nonheap"),
+            labelsAreaNonHeap,
             nonHeapUsage.getUsed()));
     sampleFamilies.add(
         new MetricFamilySamples(
@@ -65,18 +68,17 @@ public class MemoryPoolsExports extends Collector {
             Type.GAUGE,
             "Used bytes of a given JVM memory area.",
             usedSamples));
-    ArrayList<MetricFamilySamples.Sample> committedSamples = new ArrayList<MetricFamilySamples.Sample>();
+
+    List<MetricFamilySamples.Sample> committedSamples = new ArrayList<MetricFamilySamples.Sample>();
     committedSamples.add(
         new MetricFamilySamples.Sample(
             "jvm_memory_bytes_committed",
-            Collections.singletonList("area"),
-            Collections.singletonList("heap"),
+            labelsAreaHeap,
             heapUsage.getCommitted()));
     committedSamples.add(
         new MetricFamilySamples.Sample(
             "jvm_memory_bytes_committed",
-            Collections.singletonList("area"),
-            Collections.singletonList("nonheap"),
+            labelsAreaNonHeap,
             nonHeapUsage.getCommitted()));
     sampleFamilies.add(
         new MetricFamilySamples(
@@ -84,18 +86,17 @@ public class MemoryPoolsExports extends Collector {
             Type.GAUGE,
             "Committed (bytes) of a given JVM memory area.",
             committedSamples));
-    ArrayList<MetricFamilySamples.Sample> maxSamples = new ArrayList<MetricFamilySamples.Sample>();
+
+    List<MetricFamilySamples.Sample> maxSamples = new ArrayList<MetricFamilySamples.Sample>();
     maxSamples.add(
         new MetricFamilySamples.Sample(
             "jvm_memory_bytes_max",
-            Collections.singletonList("area"),
-            Collections.singletonList("heap"),
+            labelsAreaHeap,
             heapUsage.getMax()));
     maxSamples.add(
         new MetricFamilySamples.Sample(
             "jvm_memory_bytes_max",
-            Collections.singletonList("area"),
-            Collections.singletonList("nonheap"),
+            labelsAreaNonHeap,
             nonHeapUsage.getMax()));
     sampleFamilies.add(
         new MetricFamilySamples(
@@ -111,23 +112,21 @@ public class MemoryPoolsExports extends Collector {
     List<MetricFamilySamples.Sample> maxSamples = new ArrayList<MetricFamilySamples.Sample>();
     for (final MemoryPoolMXBean pool : poolBeans) {
       MemoryUsage poolUsage = pool.getUsage();
+      Map<String, String> labelsPoolName = Collections.singletonMap("pool", pool.getName());
       usedSamples.add(
           new MetricFamilySamples.Sample(
               "jvm_memory_pool_bytes_used",
-              Collections.singletonList("pool"),
-              Collections.singletonList(pool.getName()),
+              labelsPoolName,
               poolUsage.getUsed()));
       committedSamples.add(
           new MetricFamilySamples.Sample(
               "jvm_memory_pool_bytes_committed",
-              Collections.singletonList("pool"),
-              Collections.singletonList(pool.getName()),
+              labelsPoolName,
               poolUsage.getCommitted()));
       maxSamples.add(
           new MetricFamilySamples.Sample(
               "jvm_memory_pool_bytes_max",
-              Collections.singletonList("pool"),
-              Collections.singletonList(pool.getName()),
+              labelsPoolName,
               poolUsage.getMax()));
     }
     sampleFamilies.add(

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
@@ -52,7 +52,7 @@ public class StandardExports extends Collector {
 
   private static MetricFamilySamples singleMetric(String name, Type type, String help, double value) {
     List<MetricFamilySamples.Sample> samples = Collections.singletonList(
-        new MetricFamilySamples.Sample(name, Collections.<String>emptyList(), Collections.<String>emptyList(), value));
+        new MetricFamilySamples.Sample(name, value));
     return new MetricFamilySamples(name, type, help, samples);
   }
 

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -26,7 +26,6 @@ import java.util.List;
  * </pre>
  */
 public class ThreadExports extends Collector {
-  private static final List<String> EMPTY_LABEL = Collections.emptyList();
 
   private final ThreadMXBean threadBean;
 
@@ -46,7 +45,7 @@ public class ThreadExports extends Collector {
                     "Current thread count of a JVM",
                     Collections.singletonList(
                             new MetricFamilySamples.Sample(
-                                    "jvm_threads_current", EMPTY_LABEL, EMPTY_LABEL,
+                                    "jvm_threads_current",
                                     threadBean.getThreadCount()))));
 
     sampleFamilies.add(
@@ -56,7 +55,7 @@ public class ThreadExports extends Collector {
                     "Daemon thread count of a JVM",
                     Collections.singletonList(
                             new MetricFamilySamples.Sample(
-                                    "jvm_threads_daemon", EMPTY_LABEL, EMPTY_LABEL,
+                                    "jvm_threads_daemon",
                                     threadBean.getDaemonThreadCount()))));
 
     sampleFamilies.add(
@@ -66,7 +65,7 @@ public class ThreadExports extends Collector {
                     "Peak thread count of a JVM",
                     Collections.singletonList(
                             new MetricFamilySamples.Sample(
-                                    "jvm_threads_peak", EMPTY_LABEL, EMPTY_LABEL,
+                                    "jvm_threads_peak",
                                     threadBean.getPeakThreadCount()))));
 
     sampleFamilies.add(
@@ -76,7 +75,7 @@ public class ThreadExports extends Collector {
                     "Started thread count of a JVM",
                     Collections.singletonList(
                             new MetricFamilySamples.Sample(
-                                    "jvm_threads_started_total", EMPTY_LABEL, EMPTY_LABEL,
+                                    "jvm_threads_started_total",
                                     threadBean.getTotalStartedThreadCount()))));
   }
 

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/GarbageCollectorExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/GarbageCollectorExportsTest.java
@@ -38,30 +38,22 @@ public class GarbageCollectorExportsTest {
     assertEquals(
         100L,
         registry.getSampleValue(
-            "jvm_gc_collection_seconds_count",
-            new String[]{"gc"},
-            new String[]{"MyGC1"}),
+            "jvm_gc_collection_seconds_count", "gc", "MyGC1"),
         .0000001);
     assertEquals(
         10d,
         registry.getSampleValue(
-            "jvm_gc_collection_seconds_sum",
-            new String[]{"gc"},
-            new String[]{"MyGC1"}),
+            "jvm_gc_collection_seconds_sum", "gc", "MyGC1"),
         .0000001);
     assertEquals(
         200L,
         registry.getSampleValue(
-            "jvm_gc_collection_seconds_count",
-            new String[]{"gc"},
-            new String[]{"MyGC2"}),
+            "jvm_gc_collection_seconds_count", "gc", "MyGC2"),
         .0000001);
     assertEquals(
         20d,
         registry.getSampleValue(
-            "jvm_gc_collection_seconds_sum",
-            new String[]{"gc"},
-            new String[]{"MyGC2"}),
+            "jvm_gc_collection_seconds_sum", "gc", "MyGC2"),
         .0000001);
   }
 }

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/MemoryPoolsExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/MemoryPoolsExportsTest.java
@@ -47,44 +47,32 @@ public class MemoryPoolsExportsTest {
     assertEquals(
         500000L,
         registry.getSampleValue(
-            "jvm_memory_pool_bytes_used",
-            new String[]{"pool"},
-            new String[]{"PS Eden Space"}),
+            "jvm_memory_pool_bytes_used", "pool", "PS Eden Space"),
         .0000001);
     assertEquals(
         1000000L,
         registry.getSampleValue(
-            "jvm_memory_pool_bytes_committed",
-            new String[]{"pool"},
-            new String[]{"PS Eden Space"}),
+            "jvm_memory_pool_bytes_committed", "pool", "PS Eden Space"),
         .0000001);
     assertEquals(
         2000000L,
         registry.getSampleValue(
-            "jvm_memory_pool_bytes_max",
-            new String[]{"pool"},
-            new String[]{"PS Eden Space"}),
+            "jvm_memory_pool_bytes_max", "pool", "PS Eden Space"),
         .0000001);
     assertEquals(
         10000L,
         registry.getSampleValue(
-            "jvm_memory_pool_bytes_used",
-            new String[]{"pool"},
-            new String[]{"PS Old Gen"}),
+            "jvm_memory_pool_bytes_used", "pool", "PS Old Gen"),
         .0000001);
     assertEquals(
         20000L,
         registry.getSampleValue(
-            "jvm_memory_pool_bytes_committed",
-            new String[]{"pool"},
-            new String[]{"PS Old Gen"}),
+            "jvm_memory_pool_bytes_committed", "pool", "PS Old Gen"),
         .0000001);
     assertEquals(
         3000000L,
         registry.getSampleValue(
-            "jvm_memory_pool_bytes_max",
-            new String[]{"pool"},
-            new String[]{"PS Old Gen"}),
+            "jvm_memory_pool_bytes_max", "pool", "PS Old Gen"),
         .0000001);
   }
 
@@ -93,44 +81,32 @@ public class MemoryPoolsExportsTest {
     assertEquals(
         500000L,
         registry.getSampleValue(
-            "jvm_memory_bytes_used",
-            new String[]{"area"},
-            new String[]{"heap"}),
+            "jvm_memory_bytes_used", "area", "heap"),
         .0000001);
     assertEquals(
         1000000L,
         registry.getSampleValue(
-            "jvm_memory_bytes_committed",
-            new String[]{"area"},
-            new String[]{"heap"}),
+            "jvm_memory_bytes_committed", "area", "heap"),
         .0000001);
     assertEquals(
         2000000L,
         registry.getSampleValue(
-            "jvm_memory_bytes_max",
-            new String[]{"area"},
-            new String[]{"heap"}),
+            "jvm_memory_bytes_max", "area", "heap"),
         .0000001);
     assertEquals(
         10000L,
         registry.getSampleValue(
-            "jvm_memory_bytes_used",
-            new String[]{"area"},
-            new String[]{"nonheap"}),
+            "jvm_memory_bytes_used", "area", "nonheap"),
         .0000001);
     assertEquals(
         20000L,
         registry.getSampleValue(
-            "jvm_memory_bytes_committed",
-            new String[]{"area"},
-            new String[]{"nonheap"}),
+            "jvm_memory_bytes_committed", "area", "nonheap"),
         .0000001);
     assertEquals(
         3000000L,
         registry.getSampleValue(
-            "jvm_memory_bytes_max",
-            new String[]{"area"},
-            new String[]{"nonheap"}),
+            "jvm_memory_bytes_max", "area", "nonheap"),
         .0000001);
   }
 }

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/StandardExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/StandardExportsTest.java
@@ -44,17 +44,17 @@ public class StandardExportsTest {
     new StandardExports(new StatusReaderTest(), osBean, runtimeBean).register(registry);
 
     assertEquals(123 / 1.0E9,
-        registry.getSampleValue("process_cpu_seconds_total", new String[]{}, new String[]{}), .0000001);
+        registry.getSampleValue("process_cpu_seconds_total"), .0000001);
     assertEquals(10,
-        registry.getSampleValue("process_open_fds", new String[]{}, new String[]{}), .001);
+        registry.getSampleValue("process_open_fds"), .001);
     assertEquals(20,
-        registry.getSampleValue("process_max_fds", new String[]{}, new String[]{}), .001);
+        registry.getSampleValue("process_max_fds"), .001);
     assertEquals(456 / 1.0E3,
-        registry.getSampleValue("process_start_time_seconds", new String[]{}, new String[]{}), .0000001);
+        registry.getSampleValue("process_start_time_seconds"), .0000001);
     assertEquals(5900 * 1024,
-        registry.getSampleValue("process_virtual_memory_bytes", new String[]{}, new String[]{}), .001);
+        registry.getSampleValue("process_virtual_memory_bytes"), .001);
     assertEquals(360 * 1024,
-        registry.getSampleValue("process_resident_memory_bytes", new String[]{}, new String[]{}), .001);
+        registry.getSampleValue("process_resident_memory_bytes"), .001);
   }
 
   @Test
@@ -69,7 +69,7 @@ public class StandardExportsTest {
     new StandardExports(new StatusReaderBroken(), osBean, runtimeBean).register(registry);
 
     assertEquals(123 / 1.0E9,
-      registry.getSampleValue("process_cpu_seconds_total", new String[]{}, new String[]{}), .0000001);
-    assertNull(registry.getSampleValue("process_resident_memory_bytes", new String[]{}, new String[]{}));
+      registry.getSampleValue("process_cpu_seconds_total"), .0000001);
+    assertNull(registry.getSampleValue("process_resident_memory_bytes"));
   }
 }

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/ThreadExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/ThreadExportsTest.java
@@ -31,23 +31,19 @@ public class ThreadExportsTest {
   public void testThreadPools() {
     assertEquals(
             300L,
-            registry.getSampleValue(
-                    "jvm_threads_current", EMPTY_LABEL, EMPTY_LABEL),
+            registry.getSampleValue("jvm_threads_current"),
             .0000001);
     assertEquals(
             200L,
-            registry.getSampleValue(
-                    "jvm_threads_daemon", EMPTY_LABEL, EMPTY_LABEL),
+            registry.getSampleValue("jvm_threads_daemon"),
             .0000001);
     assertEquals(
             301L,
-            registry.getSampleValue(
-                    "jvm_threads_peak", EMPTY_LABEL, EMPTY_LABEL),
+            registry.getSampleValue("jvm_threads_peak"),
             .0000001);
     assertEquals(
             503L,
-            registry.getSampleValue(
-                    "jvm_threads_started_total", EMPTY_LABEL, EMPTY_LABEL),
+            registry.getSampleValue("jvm_threads_started_total"),
             .0000001);
   }
 }

--- a/simpleclient_log4j/src/test/java/io/prometheus/client/log4j/InstrumentedAppenderTest.java
+++ b/simpleclient_log4j/src/test/java/io/prometheus/client/log4j/InstrumentedAppenderTest.java
@@ -79,7 +79,6 @@ public class InstrumentedAppenderTest {
   }
 
   private int getLogLevelCount(String level) {
-    return CollectorRegistry.defaultRegistry.getSampleValue(COUNTER_NAME, 
-            new String[]{"level"}, new String[]{level}).intValue();
+    return CollectorRegistry.defaultRegistry.getSampleValue(COUNTER_NAME, "level", level).intValue();
   }
 }

--- a/simpleclient_logback/src/test/java/io/prometheus/client/logback/InstrumentedAppenderTest.java
+++ b/simpleclient_logback/src/test/java/io/prometheus/client/logback/InstrumentedAppenderTest.java
@@ -70,7 +70,6 @@ public class InstrumentedAppenderTest {
   }
 
   private int getLogLevelCount(String level) {
-    return CollectorRegistry.defaultRegistry.getSampleValue(COUNTER_NAME, 
-            new String[]{"level"}, new String[]{level}).intValue();
+    return CollectorRegistry.defaultRegistry.getSampleValue(COUNTER_NAME, "level", level).intValue();
   }
 }


### PR DESCRIPTION
This PR refactors the Sample class in order to store labels into a Map instead of two distinct Lists for names and values.

By reducing the creation of small, short-lived objects (especially in DropwizardExports), this change could potentially improve memory efficiency by putting less pressure on gc.

There are other places in the codebase where labels could be stored as a Map instead of Lists, but I tried to keep this PR small in order to get it merged easily. :-)