### PR TITLE
Add quantile support to Summary

### DIFF
--- a/simpleclient/pom.xml
+++ b/simpleclient/pom.xml
@@ -45,5 +45,11 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/simpleclient/src/main/java/io/prometheus/client/AtomicDoubleArray.java
+++ b/simpleclient/src/main/java/io/prometheus/client/AtomicDoubleArray.java
@@ -1,0 +1,329 @@
+package io.prometheus.client;
+
+import static java.lang.Double.doubleToRawLongBits;
+import static java.lang.Double.longBitsToDouble;
+
+/*
+ * Source: http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/jsr166e/extra/AtomicDoubleArray.java?revision=1.11
+ *
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+/**
+ * A {@code double} array in which elements may be updated atomically.
+ * See the {@link java.util.concurrent.atomic} package specification
+ * for description of the properties of atomic variables.
+ *
+ * <p id="bitEquals">This class compares primitive {@code double}
+ * values in methods such as {@link #compareAndSet} by comparing their
+ * bitwise representation using {@link Double#doubleToRawLongBits},
+ * which differs from both the primitive double {@code ==} operator
+ * and from {@link Double#equals}, as if implemented by:
+ *  <pre> {@code
+ * static boolean bitEquals(double x, double y) {
+ *   long xBits = Double.doubleToRawLongBits(x);
+ *   long yBits = Double.doubleToRawLongBits(y);
+ *   return xBits == yBits;
+ * }}</pre>
+ *
+ * @author Doug Lea
+ * @author Martin Buchholz
+ */
+public class AtomicDoubleArray implements java.io.Serializable {
+    private static final long serialVersionUID = -2308431214976778248L;
+
+    private final transient long[] array;
+
+    private long checkedByteOffset(int i) {
+        if (i < 0 || i >= array.length)
+            throw new IndexOutOfBoundsException("index " + i);
+
+        return byteOffset(i);
+    }
+
+    private static long byteOffset(int i) {
+        return ((long) i << shift) + base;
+    }
+
+    /**
+     * Creates a new {@code AtomicDoubleArray} of the given length,
+     * with all elements initially zero.
+     *
+     * @param length the length of the array
+     */
+    public AtomicDoubleArray(int length) {
+        array = new long[length];
+    }
+
+    /**
+     * Creates a new {@code AtomicDoubleArray} with the same length
+     * as, and all elements copied from, the given array.
+     *
+     * @param array the array to copy elements from
+     * @throws NullPointerException if array is null
+     */
+    public AtomicDoubleArray(double[] array) {
+        // Visibility guaranteed by final field guarantees
+        final int len = array.length;
+        final long[] a = new long[len];
+        for (int i = 0; i < len; i++)
+            a[i] = doubleToRawLongBits(array[i]);
+        this.array = a;
+    }
+
+    /**
+     * Returns the length of the array.
+     *
+     * @return the length of the array
+     */
+    public final int length() {
+        return array.length;
+    }
+
+    /**
+     * Gets the current value at position {@code i}.
+     *
+     * @param i the index
+     * @return the current value
+     */
+    public final double get(int i) {
+        return longBitsToDouble(getRaw(checkedByteOffset(i)));
+    }
+
+    private long getRaw(long offset) {
+        return unsafe.getLongVolatile(array, offset);
+    }
+
+    /**
+     * Sets the element at position {@code i} to the given value.
+     *
+     * @param i the index
+     * @param newValue the new value
+     */
+    public final void set(int i, double newValue) {
+        long next = doubleToRawLongBits(newValue);
+        unsafe.putLongVolatile(array, checkedByteOffset(i), next);
+    }
+
+    /**
+     * Eventually sets the element at position {@code i} to the given value.
+     *
+     * @param i the index
+     * @param newValue the new value
+     */
+    public final void lazySet(int i, double newValue) {
+        long next = doubleToRawLongBits(newValue);
+        unsafe.putOrderedLong(array, checkedByteOffset(i), next);
+    }
+
+    /**
+     * Atomically sets the element at position {@code i} to the given value
+     * and returns the old value.
+     *
+     * @param i the index
+     * @param newValue the new value
+     * @return the previous value
+     */
+    public final double getAndSet(int i, double newValue) {
+        long next = doubleToRawLongBits(newValue);
+        long offset = checkedByteOffset(i);
+        while (true) {
+            long current = getRaw(offset);
+            if (compareAndSetRaw(offset, current, next))
+                return longBitsToDouble(current);
+        }
+    }
+
+    /**
+     * Atomically sets the element at position {@code i} to the given
+     * updated value
+     * if the current value is <a href="#bitEquals">bitwise equal</a>
+     * to the expected value.
+     *
+     * @param i the index
+     * @param expect the expected value
+     * @param update the new value
+     * @return true if successful. False return indicates that
+     * the actual value was not equal to the expected value.
+     */
+    public final boolean compareAndSet(int i, double expect, double update) {
+        return compareAndSetRaw(checkedByteOffset(i),
+                doubleToRawLongBits(expect),
+                doubleToRawLongBits(update));
+    }
+
+    private boolean compareAndSetRaw(long offset, long expect, long update) {
+        return unsafe.compareAndSwapLong(array, offset, expect, update);
+    }
+
+    /**
+     * Atomically sets the element at position {@code i} to the given
+     * updated value
+     * if the current value is <a href="#bitEquals">bitwise equal</a>
+     * to the expected value.
+     *
+     * <p><a
+     * href="http://download.oracle.com/javase/7/docs/api/java/util/concurrent/atomic/package-summary.html#Spurious">
+     * May fail spuriously and does not provide ordering guarantees</a>,
+     * so is only rarely an appropriate alternative to {@code compareAndSet}.
+     *
+     * @param i the index
+     * @param expect the expected value
+     * @param update the new value
+     * @return true if successful
+     */
+    public final boolean weakCompareAndSet(int i, double expect, double update) {
+        return compareAndSet(i, expect, update);
+    }
+
+    /**
+     * Atomically adds the given value to the element at index {@code i}.
+     *
+     * @param i the index
+     * @param delta the value to add
+     * @return the previous value
+     */
+    public final double getAndAdd(int i, double delta) {
+        long offset = checkedByteOffset(i);
+        while (true) {
+            long current = getRaw(offset);
+            double currentVal = longBitsToDouble(current);
+            double nextVal = currentVal + delta;
+            long next = doubleToRawLongBits(nextVal);
+            if (compareAndSetRaw(offset, current, next))
+                return currentVal;
+        }
+    }
+
+    /**
+     * Atomically adds the given value to the element at index {@code i}.
+     *
+     * @param i the index
+     * @param delta the value to add
+     * @return the updated value
+     */
+    public double addAndGet(int i, double delta) {
+        long offset = checkedByteOffset(i);
+        while (true) {
+            long current = getRaw(offset);
+            double currentVal = longBitsToDouble(current);
+            double nextVal = currentVal + delta;
+            long next = doubleToRawLongBits(nextVal);
+            if (compareAndSetRaw(offset, current, next))
+                return nextVal;
+        }
+    }
+
+    /**
+     * Returns the String representation of the current values of array.
+     * @return the String representation of the current values of array
+     */
+    public String toString() {
+        int iMax = array.length - 1;
+        if (iMax == -1)
+            return "[]";
+
+        // Double.toString(Math.PI).length() == 17
+        StringBuilder b = new StringBuilder((17 + 2) * (iMax + 1));
+        b.append('[');
+        for (int i = 0;; i++) {
+            b.append(longBitsToDouble(getRaw(byteOffset(i))));
+            if (i == iMax)
+                return b.append(']').toString();
+            b.append(',').append(' ');
+        }
+    }
+
+    /**
+     * Saves the state to a stream (that is, serializes it).
+     *
+     * @param s the stream
+     * @throws java.io.IOException if an I/O error occurs
+     * @serialData The length of the array is emitted (int), followed by all
+     *             of its elements (each a {@code double}) in the proper order.
+     */
+    private void writeObject(java.io.ObjectOutputStream s)
+            throws java.io.IOException {
+        s.defaultWriteObject();
+
+        // Write out array length
+        int length = length();
+        s.writeInt(length);
+
+        // Write out all elements in the proper order.
+        for (int i = 0; i < length; i++)
+            s.writeDouble(get(i));
+    }
+
+    /**
+     * Reconstitutes the instance from a stream (that is, deserializes it).
+     * @param s the stream
+     * @throws ClassNotFoundException if the class of a serialized object
+     *         could not be found
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    private void readObject(java.io.ObjectInputStream s)
+            throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+
+        // Read in array length and allocate array
+        int length = s.readInt();
+        unsafe.putObjectVolatile(this, arrayOffset, new long[length]);
+
+        // Read in all elements in the proper order.
+        for (int i = 0; i < length; i++)
+            set(i, s.readDouble());
+    }
+
+    // Unsafe mechanics
+    private static final sun.misc.Unsafe unsafe = getUnsafe();
+    private static final long arrayOffset;
+    private static final int base = unsafe.arrayBaseOffset(long[].class);
+    private static final int shift;
+
+    static {
+        try {
+            Class<?> k = AtomicDoubleArray.class;
+            arrayOffset = unsafe.objectFieldOffset
+                    (k.getDeclaredField("array"));
+            int scale = unsafe.arrayIndexScale(long[].class);
+            if ((scale & (scale - 1)) != 0)
+                throw new Error("data type scale not a power of two");
+            shift = 31 - Integer.numberOfLeadingZeros(scale);
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    /**
+     * Returns a sun.misc.Unsafe.  Suitable for use in a 3rd party package.
+     * Replace with a simple call to Unsafe.getUnsafe when integrating
+     * into a jdk.
+     *
+     * @return a sun.misc.Unsafe
+     */
+    private static sun.misc.Unsafe getUnsafe() {
+        try {
+            return sun.misc.Unsafe.getUnsafe();
+        } catch (SecurityException tryReflectionInstead) {}
+        try {
+            return java.security.AccessController.doPrivileged
+                    (new java.security.PrivilegedExceptionAction<sun.misc.Unsafe>() {
+                        public sun.misc.Unsafe run() throws Exception {
+                            Class<sun.misc.Unsafe> k = sun.misc.Unsafe.class;
+                            for (java.lang.reflect.Field f : k.getDeclaredFields()) {
+                                f.setAccessible(true);
+                                Object x = f.get(null);
+                                if (k.isInstance(x))
+                                    return k.cast(x);
+                            }
+                            throw new NoSuchFieldError("the Unsafe");
+                        }});
+        } catch (java.security.PrivilegedActionException e) {
+            throw new RuntimeException("Could not initialize intrinsics",
+                    e.getCause());
+        }
+    }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/UniformSampling.java
+++ b/simpleclient/src/main/java/io/prometheus/client/UniformSampling.java
@@ -1,0 +1,80 @@
+package io.prometheus.client;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * An algorithm for selecting a (fixed-size) random sample of elements
+ * (with replacement) from a stream whose size is unknown beforehand.
+ *
+ * @author Cristian Greco
+ */
+class UniformSampling {
+
+  // the fixed size of the random sample
+  private final int size;
+
+  // a prng to generate uniformly distributed values
+  private final Random rand;
+
+  // the number of elements observed so far
+  private final AtomicLong count;
+
+  // the candidate elements of the random sample
+  private final AtomicDoubleArray values;
+
+  public UniformSampling() {
+    this(1024);
+  }
+
+  public UniformSampling(int size) {
+    this(size, new Random());
+  }
+
+  public UniformSampling(int size, Random rand) {
+    this.size = size;
+    this.rand = rand;
+    this.count = new AtomicLong(0);
+    this.values = new AtomicDoubleArray(size);
+  }
+
+  /**
+   * Process a new element.
+   * The first {@code size} elements observed are
+   * immediately elected as candidates for the random
+   * sample. Then, each subsequent observed element gets
+   * a chance to replace an existing candidate.
+   *
+   * @param value the observed element
+   */
+  public void add(double value) {
+    final int c = (int) count.incrementAndGet();
+    if (c <= size) {
+      values.set(c - 1, value);
+    } else {
+      final int m = (int) (c * rand.nextDouble()); // 0 <= m <= c-1
+      if (m < size) {
+        values.set(m, value);
+      }
+    }
+  }
+
+  /**
+   * Return the array of elements which form a random
+   * sample of all the elements observed so far.
+   * The length of the returned array is at most {@code size}.
+   *
+   * @return the random sample of values
+   */
+  public double[] getValues() {
+    final long c = count.get();
+    final int intSize = c >= size ? size : (int) c;
+
+    final double[] sample = new double[intSize];
+    for (int i = 0; i < intSize; i++) {
+      sample[i] = values.get(i);
+    }
+    return sample;
+  }
+
+}

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -91,6 +91,24 @@ public class SummaryTest {
   }
 
   @Test
+  public void testQuantiles() {
+    for (double d : new double[] { 1.0, 2.0 }) {
+      noLabels.observe(d);
+    }
+
+    assertEquals(2.0, getCount(), .0);
+    assertEquals(3.0, getSum(), .001);
+
+    assertEquals(1.0, noLabels.labels().get().getQuantile(0), .001);
+    assertEquals(1.0, noLabels.labels().get().getQuantile(0.25), .001);
+    assertEquals(1.5, noLabels.labels().get().getQuantile(0.50), .001);
+    assertEquals(2.0, noLabels.labels().get().getQuantile(0.98), .001);
+    assertEquals(2.0, noLabels.labels().get().getQuantile(0.99), .001);
+    assertEquals(2.0, noLabels.labels().get().getQuantile(0.999), .001);
+    assertEquals(2.0, noLabels.labels().get().getQuantile(1), .001);
+  }
+
+  @Test
   public void testCollect() {
     labels.labels("a").observe(2);
     List<Collector.MetricFamilySamples> mfs = labels.collect();
@@ -100,6 +118,13 @@ public class SummaryTest {
     labelNames.add("l");
     ArrayList<String> labelValues = new ArrayList<String>();
     labelValues.add("a");
+    ArrayList<String> labelNamesWithQuantile = new ArrayList<String>(labelNames);
+    labelNamesWithQuantile.add(Summary.QUANTILE_LABEL);
+    for (double q : Summary.DEFAULT_QUANTILE_VALUES) {
+      List<String> labelValuesWithQuantile = new ArrayList<String>(labelValues);
+      labelValuesWithQuantile.add(String.valueOf(q));
+      samples.add(new Collector.MetricFamilySamples.Sample("labels", labelNamesWithQuantile, labelValuesWithQuantile, 2.0));
+    }
     samples.add(new Collector.MetricFamilySamples.Sample("labels_count", labelNames, labelValues, 1.0));
     samples.add(new Collector.MetricFamilySamples.Sample("labels_sum", labelNames, labelValues, 2.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.SUMMARY, "help", samples);

--- a/simpleclient/src/test/java/io/prometheus/client/UniformSamplingTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/UniformSamplingTest.java
@@ -1,0 +1,56 @@
+package io.prometheus.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Random;
+
+import org.junit.Test;
+
+public class UniformSamplingTest {
+
+    @Test
+    public void testMaxSize() {
+        UniformSampling s = new UniformSampling(1);
+
+        double[] values = s.getValues();
+        assertEquals(0, values.length);
+
+        s.add(1.0);
+        values = s.getValues();
+        assertEquals(1, values.length);
+
+        s.add(2.0);
+        values = s.getValues();
+        assertEquals(1, values.length);
+    }
+
+    @Test
+    public void testRepeatedValues() {
+        UniformSampling s = new UniformSampling(2);
+
+        s.add(1.0);
+        s.add(1.0);
+        double[] values = s.getValues();
+        assertEquals(2, values.length);
+    }
+
+    @Test
+    public void testReplacement() {
+        Random rand = mock(Random.class);
+        when(rand.nextDouble()).thenReturn(0.0);
+
+        UniformSampling s = new UniformSampling(1, rand);
+
+        s.add(1.0);
+        double[] values = s.getValues();
+        assertEquals(1, values.length);
+
+        s.add(2.0);
+        values = s.getValues();
+        assertEquals(1, values.length);
+        assertEquals(2.0, values[0], .0);
+    }
+
+}

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
@@ -61,11 +61,6 @@ public class TextFormatTest {
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP nolabels help\n"
                  + "# TYPE nolabels summary\n"
-                 + "nolabels{quantile=\"0.5\",} 2.0\n"
-                 + "nolabels{quantile=\"0.95\",} 2.0\n"
-                 + "nolabels{quantile=\"0.98\",} 2.0\n"
-                 + "nolabels{quantile=\"0.99\",} 2.0\n"
-                 + "nolabels{quantile=\"0.999\",} 2.0\n"
                  + "nolabels_count 1.0\n"
                  + "nolabels_sum 2.0\n", writer.toString());
   }

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
@@ -61,6 +61,11 @@ public class TextFormatTest {
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP nolabels help\n"
                  + "# TYPE nolabels summary\n"
+                 + "nolabels{quantile=\"0.5\",} 2.0\n"
+                 + "nolabels{quantile=\"0.95\",} 2.0\n"
+                 + "nolabels{quantile=\"0.98\",} 2.0\n"
+                 + "nolabels{quantile=\"0.99\",} 2.0\n"
+                 + "nolabels{quantile=\"0.999\",} 2.0\n"
                  + "nolabels_count 1.0\n"
                  + "nolabels_sum 2.0\n", writer.toString());
   }


### PR DESCRIPTION
This adds support for quantile calculation in Summaries without extra dependencies.

Basic unit tests are included. Benchmarks may be added if needed.