### PR TITLE
Fix Javadoc comment for DropwizardExports#fromCounter()

### DIFF
--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -25,7 +25,7 @@ public class DropwizardExports extends io.prometheus.client.Collector {
     }
 
     /**
-     * Export counter as prometheus counter.
+     * Export counter as Prometheus <a href="https://prometheus.io/docs/concepts/metric_types/#gauge">Gauge</a>.
      */
     List<MetricFamilySamples> fromCounter(String name, Counter counter) {
         MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name, new ArrayList<String>(), new ArrayList<String>(),


### PR DESCRIPTION
This PR fixes the incorrect Javadoc comment for [`DropwizardExports#fromCounter(String, Counter)`](https://github.com/prometheus/client_java/blob/parent-0.0.14/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java#L27-L34).

Fixes #115