### PR TITLE
Remove sum from Summary

### DIFF
--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -68,10 +68,6 @@ public class DropwizardExports extends io.prometheus.client.Collector {
      *
      */
     List<MetricFamilySamples> fromSnapshotAndCount(String name, Snapshot snapshot, long count, double factor, String helpMessage) {
-        long sum = 0;
-        for (long i : snapshot.getValues()) {
-            sum += i;
-        }
         List<MetricFamilySamples.Sample> samples = Arrays.asList(
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.5"), snapshot.getMedian() * factor),
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.75"), snapshot.get75thPercentile() * factor),
@@ -79,8 +75,7 @@ public class DropwizardExports extends io.prometheus.client.Collector {
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.98"), snapshot.get98thPercentile() * factor),
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.99"), snapshot.get99thPercentile() * factor),
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.999"), snapshot.get999thPercentile() * factor),
-                new MetricFamilySamples.Sample(name + "_count", new ArrayList<String>(), new ArrayList<String>(), count),
-                new MetricFamilySamples.Sample(name + "_sum", new ArrayList<String>(), new ArrayList<String>(), sum * factor)
+                new MetricFamilySamples.Sample(name + "_count", new ArrayList<String>(), new ArrayList<String>(), count)
         );
         return Arrays.asList(
                 new MetricFamilySamples(name, Type.SUMMARY, helpMessage, samples)

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
@@ -111,7 +111,6 @@ public class DropwizardExportsTest {
             i += 1;
         }
         assertEquals(new Double(100), registry.getSampleValue("hist_count"));
-        assertEquals(new Double(4950), registry.getSampleValue("hist_sum"));
         for (double b : Arrays.asList(0.75, 0.95, 0.98, 0.99)) {
             assertEquals(new Double((b - 0.01) * 100), registry.getSampleValue("hist",
                     new String[]{"quantile"}, new String[]{String.format("%.2f", b)}));
@@ -137,7 +136,6 @@ public class DropwizardExportsTest {
         // We slept for 1Ms so we ensure that all timers are above 1ms:
         assertTrue(registry.getSampleValue("timer", new String[]{"quantile"}, new String[]{"0.99"}) > 0.001);
         assertEquals(new Double(1.0D), registry.getSampleValue("timer_count"));
-        assertRegistryContainsMetrics("timer_count", "timer_sum");
     }
 
     @Test


### PR DESCRIPTION
Just summing all snapshot values does not work with dropwizard metrics, because the values array does not hold all values but only a sample of recent values.