### PR TITLE
Make *buckets method of Builder add buckets, not replace them.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -54,6 +54,9 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
   Histogram(Builder b) {
     super(b);
     buckets = b.getBuckets();
+    if (buckets.length < 1) {
+      throw new IllegalStateException("Histogram must have at least one bucket.");
+    }
     initializeNoLabelsChild();
   }
 
@@ -63,9 +66,6 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
 
     @Override
     public Histogram create() {
-      if (bucketsList.isEmpty()) {
-          throw new IllegalStateException("Histogram must have at least one bucket.");
-      }
       for (String label: labelNames) {
         if (label.equals("le")) {
             throw new IllegalStateException("Histogram cannot have a label named 'le'.");

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -27,16 +27,16 @@ public class HistogramTest {
     Histogram.Child.timeProvider = new Histogram.TimeProvider();
   }
 
-  private double getCount() {
-    return registry.getSampleValue("nolabels_count").doubleValue();
+  private Double getCount() {
+    return registry.getSampleValue("nolabels_count");
   }
-  private double getSum() {
-    return registry.getSampleValue("nolabels_sum").doubleValue();
+  private Double getSum() {
+    return registry.getSampleValue("nolabels_sum");
   }
-  private double getBucket(double b) {
+  private Double getBucket(Double b) {
     return registry.getSampleValue("nolabels_bucket", 
         new String[]{"le"},
-        new String[]{Collector.doubleToGoString(b)}).doubleValue();
+        new String[]{Collector.doubleToGoString(b.doubleValue())}).doubleValue();
   }
   
   @Test
@@ -44,16 +44,16 @@ public class HistogramTest {
     noLabels.observe(2);
     assertEquals(1.0, getCount(), .001);
     assertEquals(2.0, getSum(), .001);
-    assertEquals(0.0, getBucket(1), .001);
+    assertEquals(0.0, getBucket(1.0), .001);
     assertEquals(1.0, getBucket(2.5), .001);
     noLabels.labels().observe(4);
     assertEquals(2.0, getCount(), .001);
     assertEquals(6.0, getSum(), .001);
-    assertEquals(0.0, getBucket(1), .001);
+    assertEquals(0.0, getBucket(1.0), .001);
     assertEquals(1.0, getBucket(2.5), .001);
-    assertEquals(2.0, getBucket(5), .001);
+    assertEquals(2.0, getBucket(5.0), .001);
     assertEquals(2.0, getBucket(7.5), .001);
-    assertEquals(2.0, getBucket(10), .001);
+    assertEquals(2.0, getBucket(10.0), .001);
     assertEquals(2.0, getBucket(Double.POSITIVE_INFINITY), .001);
   }
 
@@ -61,41 +61,41 @@ public class HistogramTest {
   public void testBoundaryConditions() {
     // Equal to a bucket.
     noLabels.observe(2.5);
-    assertEquals(0.0, getBucket(1), .001);
+    assertEquals(0.0, getBucket(1.0), .001);
     assertEquals(1.0, getBucket(2.5), .001);
     noLabels.labels().observe(Double.POSITIVE_INFINITY);
 
     // Infinity.
-    assertEquals(0.0, getBucket(1), .001);
+    assertEquals(0.0, getBucket(1.0), .001);
     assertEquals(1.0, getBucket(2.5), .001);
-    assertEquals(1.0, getBucket(5), .001);
+    assertEquals(1.0, getBucket(5.0), .001);
     assertEquals(1.0, getBucket(7.5), .001);
-    assertEquals(1.0, getBucket(10), .001);
+    assertEquals(1.0, getBucket(10.0), .001);
     assertEquals(2.0, getBucket(Double.POSITIVE_INFINITY), .001);
   }
 
   @Test
   public void testManualBuckets() {
-    Histogram h = Histogram.build().name("h").help("help").buckets(1, 2).create();
-    assertArrayEquals(new double[]{1, 2, Double.POSITIVE_INFINITY}, h.getBuckets(), .001);
+    Histogram h = Histogram.build().name("h").help("help").buckets(1.0, 2.0).create();
+    assertArrayEquals(new Double[]{1.0, 2.0, Double.POSITIVE_INFINITY}, h.getBuckets());
   }
 
   @Test
   public void testManualBucketsInfinityAlreadyIncluded() {
-    Histogram h = Histogram.build().buckets(1, 2, Double.POSITIVE_INFINITY).name("h").help("help").create();
-    assertArrayEquals(new double[]{1, 2, Double.POSITIVE_INFINITY}, h.getBuckets(), .001);
+    Histogram h = Histogram.build().buckets(1.0, 2.0, Double.POSITIVE_INFINITY).name("h").help("help").create();
+    assertArrayEquals(new Double[]{1.0, 2.0, Double.POSITIVE_INFINITY}, h.getBuckets());
   }
 
   @Test
   public void testLinearBuckets() {
     Histogram h = Histogram.build().name("h").help("help").linearBuckets(1, 2, 3).create();
-    assertArrayEquals(new double[]{1, 3, 5, Double.POSITIVE_INFINITY}, h.getBuckets(), .001);
+    assertArrayEquals(new Double[]{1.0, 3.0, 5.0, Double.POSITIVE_INFINITY}, h.getBuckets());
   }
 
   @Test
   public void testExponentialBuckets() {
     Histogram h = Histogram.build().name("h").help("help").exponentialBuckets(2, 2.5, 3).create();
-    assertArrayEquals(new double[]{2, 5, 12.5, Double.POSITIVE_INFINITY}, h.getBuckets(), .001);
+    assertArrayEquals(new Double[]{2.0, 5.0, 12.5, Double.POSITIVE_INFINITY}, h.getBuckets());
   }
 
   @Test
@@ -108,7 +108,7 @@ public class HistogramTest {
       }
     };
     Histogram.Timer timer = noLabels.startTimer();
-    double elapsed = timer.observeDuration();
+    Double elapsed = timer.observeDuration();
     assertEquals(1, getCount(), .001);
     assertEquals(10, getSum(), .001);
     assertEquals(10, elapsed, .001);
@@ -134,15 +134,15 @@ public class HistogramTest {
     assertEquals(null, getLabelsCount("b"));
     assertEquals(null, getLabelsSum("b"));
     labels.labels("a").observe(2);
-    assertEquals(1.0, getLabelsCount("a").doubleValue(), .001);
-    assertEquals(2.0, getLabelsSum("a").doubleValue(), .001);
+    assertEquals(1.0, getLabelsCount("a"), .001);
+    assertEquals(2.0, getLabelsSum("a"), .001);
     assertEquals(null, getLabelsCount("b"));
     assertEquals(null, getLabelsSum("b"));
     labels.labels("b").observe(3);
-    assertEquals(1.0, getLabelsCount("a").doubleValue(), .001);
-    assertEquals(2.0, getLabelsSum("a").doubleValue(), .001);
-    assertEquals(1.0, getLabelsCount("b").doubleValue(), .001);
-    assertEquals(3.0, getLabelsSum("b").doubleValue(), .001);
+    assertEquals(1.0, getLabelsCount("a"), .001);
+    assertEquals(2.0, getLabelsSum("a"), .001);
+    assertEquals(1.0, getLabelsCount("b"), .001);
+    assertEquals(3.0, getLabelsSum("b"), .001);
   }
 
   @Test(expected=IllegalStateException.class)
@@ -179,5 +179,4 @@ public class HistogramTest {
     assertEquals(1, mfs.size());
     assertEquals(mfsFixture, mfs.get(0));
   }
-
 }

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -1,13 +1,14 @@
 package io.prometheus.client;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 
 public class HistogramTest {
@@ -72,6 +73,25 @@ public class HistogramTest {
     assertEquals(1.0, getBucket(7.5), .001);
     assertEquals(1.0, getBucket(10.0), .001);
     assertEquals(2.0, getBucket(Double.POSITIVE_INFINITY), .001);
+  }
+
+  @Test
+  public void testExpenentialAndManualBucketsAtOnce() {
+    Histogram h = Histogram.build().name("h").help("help")
+        .exponentialBuckets(16, 4, 6)
+        .buckets(32768d)
+        .create();
+    assertArrayEquals(new Double[]{16d, 64d, 256d, 1024d, 4096d, 16384d, 32768d, Double.POSITIVE_INFINITY}, h.getBuckets());
+  }
+
+  @Test
+  public void testExpenentialLinearAndManualBucketsAtOnce() {
+    Histogram h = Histogram.build().name("h").help("help")
+        .exponentialBuckets(16, 4, 6)
+        .linearBuckets(1, 2, 3)
+        .buckets(32768d)
+        .create();
+    assertArrayEquals(new Double[]{1d, 3d, 5d, 16d, 64d, 256d, 1024d, 4096d, 16384d, 32768d, Double.POSITIVE_INFINITY}, h.getBuckets());
   }
 
   @Test


### PR DESCRIPTION
Now exponentialBuckets, linearBuckets and also buckets of Histogram.Builder adds buckets instead of replacing them.

Changed buckets type from double[] to Double[] due to simplicity and introduced collection usage in process of building them.
Moved sanitizing of buckets from builders create method into separate get method. Now is not possible to use Histogram constructor with builder without sanitized buckets.
Added sorting to buckets as part of build process.
Buckets with equal boundary does not make sense, co modified check function to do not allow them.
This code now does make sense:
```
Histogram h = new Histogram.Builder()
            .exponentialBuckets(16, 4, 6) // 16, 64, 256, 1024, 4096, 16384
            .buckets(32768) // adds one more bound
            .labelNames("rpcCommand")
            .help("Histogram of message sizes. It serves also as counter of incoming/outgoing messages and you can use it for making difference to see" +
                "how many messages are in processing stage.")
            .name(this.name + "_size")
            .namespace(this.namespace)
            .create();
```