### PR TITLE
Add reset method to the counter

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -119,6 +119,8 @@ public class Counter extends SimpleCollector<Counter.Child> {
     public double get() {
       return value.sum();
     }
+
+    public void reset() { value.reset(); }
   }
 
   // Convenience methods.
@@ -134,6 +136,10 @@ public class Counter extends SimpleCollector<Counter.Child> {
    */
   public void inc(double amt) {
     noLabelsChild.inc(amt);
+  }
+
+  public void reset() {
+    noLabelsChild.reset();
   }
 
   @Override

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -3,6 +3,7 @@ package io.prometheus.client;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Counter metric, to track counts of events or running totals.
@@ -139,7 +140,7 @@ public class Counter extends SimpleCollector<Counter.Child> {
   }
 
   public void reset() {
-    noLabelsChild.reset();
+    clear();
   }
 
   @Override

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -50,7 +50,7 @@ public abstract class SimpleCollector<Child> extends Collector {
   protected final String help;
   protected final List<String> labelNames;
 
-  protected final ConcurrentMap<List<String>, Child> children = new ConcurrentHashMap<List<String>, Child>();;
+  protected final ConcurrentMap<List<String>, Child> children = new ConcurrentHashMap<List<String>, Child>();
   protected Child noLabelsChild;
 
   /**

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -71,8 +71,14 @@ public class CounterTest {
     labels.labels("b").inc(3);
     assertEquals(1.0, getLabelsValue("a").doubleValue(), .001);
     assertEquals(3.0, getLabelsValue("b").doubleValue(), .001);
+
     labels.labels("b").reset();
     assertEquals(0, getLabelsValue("b").doubleValue(), .001);
+    assertEquals(1.0, getLabelsValue("a").doubleValue(), .001);
+
+    labels.reset();
+    assertEquals(null, getLabelsValue("a"));
+    assertEquals(null, getLabelsValue("b"));
   }
 
   @Test

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -34,6 +34,18 @@ public class CounterTest {
     noLabels.labels().inc();
     assertEquals(8.0, getValue(), .001);
   }
+
+  @Test
+  public void testReset() {
+    noLabels.reset();
+    assertEquals(0, getValue(), .001);
+    noLabels.inc(2);
+    assertEquals(2.0, getValue(), .001);
+    noLabels.labels().reset();
+    assertEquals(0, getValue(), .001);
+    noLabels.labels().inc();
+    assertEquals(1.0, getValue(), .001);
+  }
     
   @Test(expected=IllegalArgumentException.class)
   public void testNegativeIncrementFails() {
@@ -59,6 +71,8 @@ public class CounterTest {
     labels.labels("b").inc(3);
     assertEquals(1.0, getLabelsValue("a").doubleValue(), .001);
     assertEquals(3.0, getLabelsValue("b").doubleValue(), .001);
+    labels.labels("b").reset();
+    assertEquals(0, getLabelsValue("b").doubleValue(), .001);
   }
 
   @Test


### PR DESCRIPTION
While I know reset should be used very rarely, I think the option should exist for building custom exporters.