### PR TITLE
Implemented an vert.x based asynchronous pushgateway client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <module>simpleclient_spring_boot</module>
         <module>simpleclient_jetty</module>
         <module>simpleclient_vertx</module>
+        <module>simpleclient_pushgateway_vertx</module>
         <module>benchmark</module>
     </modules>
     

--- a/simpleclient_pushgateway_vertx/pom.xml
+++ b/simpleclient_pushgateway_vertx/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.15-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.prometheus</groupId>
+    <artifactId>simpleclient_pushgateway_vertx</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Prometheus Vert.x Async Simpleclient Pushgateway</name>
+    <description>
+        Async Pushgateway exporter for the simpleclient.
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>brian-brazil</id>
+            <name>Brian Brazil</name>
+            <email>brian.brazil@boxever.com</email>
+        </developer>
+        <developer>
+            <id>pmlopes</id>
+            <name>Paulo Lopes</name>
+            <email>paulo@mlopes.net</email>
+        </developer>
+    </developers>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.0.15-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+            <version>0.0.15-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <version>3.3.2</version>
+        </dependency>
+        <!-- Test Dependencies Follow -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+           <groupId>org.mock-server</groupId>
+           <artifactId>mockserver-netty</artifactId>
+           <version>3.10.4</version>
+           <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>4.1.1.Final</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/simpleclient_pushgateway_vertx/src/main/java/io/prometheus/client/exporter/AsyncPushGateway.java
+++ b/simpleclient_pushgateway_vertx/src/main/java/io/prometheus/client/exporter/AsyncPushGateway.java
@@ -1,0 +1,289 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.net.InetAddress;
+import java.net.URLEncoder;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Export metrics asynchronously via the Prometheus Pushgateway.
+ * <p>
+ * The Prometheus AsyncPushgateway exists to allow ephemeral and batch jobs to expose their metrics to Prometheus.
+ * Since these kinds of jobs may not exist long enough to be scraped, they can instead push their metrics
+ * to a Pushgateway. This class allows pushing the contents of a {@link CollectorRegistry} to
+ * a Pushgateway.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   void executeBatchJob() throws Exception {
+ *     CollectorRegistry registry = new CollectorRegistry();
+ *     Gauge duration = Gauge.build()
+ *         .name("my_batch_job_duration_seconds").help("Duration of my batch job in seconds.").register(registry);
+ *     Gauge.Timer durationTimer = duration.startTimer();
+ *     try {
+ *       // Your code here.
+ *
+ *       // This is only added to the registry after success,
+ *       // so that a previous success in the Pushgateway isn't overwritten on failure.
+ *       Gauge lastSuccess = Gauge.build()
+ *           .name("my_batch_job_last_success").help("Last time my batch job succeeded, in unixtime.").register(registry);
+ *       lastSuccess.setToCurrentTime();
+ *     } finally {
+ *       durationTimer.setDuration();
+ *       PushGateway pg = new PushGateway(vertx, "127.0.0.1:9091");
+ *       pg.pushAdd(registry, "my_batch_job", res -> { ... });
+ *     }
+ *   }
+ * }
+ * </pre>
+ * <p>
+ * See <a href="https://github.com/prometheus/pushgateway">https://github.com/prometheus/pushgateway</a>
+ */
+public class AsyncPushGateway {
+
+  private static final int SECONDS_PER_MILLISECOND = 1000;
+
+  /**
+   * Wrap a Vert.x Buffer as a Writer so it can be used with
+   * TextFormat writer
+   */
+  private static class BufferWriter extends Writer {
+
+    private final Buffer buffer = Buffer.buffer();
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+      buffer.appendString(new String(cbuf, off, len));
+    }
+
+    @Override
+    public void flush() throws IOException {
+      // NO-OP
+    }
+
+    @Override
+    public void close() throws IOException {
+      // NO-OP
+    }
+
+    Buffer getBuffer() {
+      return buffer;
+    }
+  }
+
+  private final Vertx vertx;
+  private final String hostname;
+  private final int port;
+
+  /**
+   * Construct a Pushgateway, with the given address and port.
+   * <p>
+   *
+   * @param address  host:port or ip:port of the Pushgateway.
+   */
+  public AsyncPushGateway(Vertx vertx, String address) {
+    this.vertx = vertx;
+    String[] parts = address.split(":");
+    hostname = parts[0];
+    if (parts.length == 2) {
+      try {
+        port = Integer.parseInt(parts[1]);
+      } catch (NumberFormatException e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      // default HTTP port
+      port = 80;
+    }
+  }
+
+  /**
+   * Pushes all metrics in a registry, replacing all those with the same job as the grouping key.
+   * <p>
+   * This uses the POST HTTP method.
+   */
+  public void push(CollectorRegistry registry, String job, Handler<AsyncResult<Void>> handler) {
+    doRequest(registry, job, null, "POST", handler);
+  }
+
+  /**
+   * Pushes all metrics in a Collector, replacing all those with the same job and no grouping key.
+   * <p>
+   * This is useful for pushing a single Gauge.
+   * <p>
+   * This uses the POST HTTP method.
+   */
+  public void push(Collector collector, String job, Handler<AsyncResult<Void>> handler) {
+    CollectorRegistry registry = new CollectorRegistry();
+    collector.register(registry);
+    push(registry, job, handler);
+  }
+
+  /**
+   * Pushes all metrics in a Collector, replacing all those with the same job and grouping key.
+   * <p>
+   * This is useful for pushing a single Gauge.
+   * <p>
+   * This uses the POST HTTP method.
+   */
+  public void push(CollectorRegistry registry, String job, Map<String, String> groupingKey, Handler<AsyncResult<Void>> handler) {
+    doRequest(registry, job, groupingKey, "POST", handler);
+  }
+
+  /**
+   * Pushes all metrics in a Collector, replacing all those with the same job and grouping key.
+   * <p>
+   * This is useful for pushing a single Gauge.
+   * <p>
+   * This uses the POST HTTP method.
+   */
+  public void push(Collector collector, String job, Map<String, String> groupingKey, Handler<AsyncResult<Void>> handler) {
+    CollectorRegistry registry = new CollectorRegistry();
+    collector.register(registry);
+    push(registry, job, groupingKey, handler);
+  }
+
+  /**
+   * Pushes all metrics in a registry, replacing only previously pushed metrics of the same name and job and no grouping key.
+   * <p>
+   * This uses the PUT HTTP method.
+   */
+  public void pushAdd(CollectorRegistry registry, String job, Handler<AsyncResult<Void>> handler) {
+    doRequest(registry, job, null, "PUT", handler);
+  }
+
+  /**
+   * Pushes all metrics in a Collector, replacing only previously pushed metrics of the same name and job and no grouping key.
+   * <p>
+   * This is useful for pushing a single Gauge.
+   * <p>
+   * This uses the PUT HTTP method.
+   */
+  public void pushAdd(Collector collector, String job, Handler<AsyncResult<Void>> handler) {
+    CollectorRegistry registry = new CollectorRegistry();
+    collector.register(registry);
+    pushAdd(registry, job, handler);
+  }
+
+  /**
+   * Pushes all metrics in a Collector, replacing only previously pushed metrics of the same name, job and grouping key.
+   * <p>
+   * This is useful for pushing a single Gauge.
+   * <p>
+   * This uses the PUT HTTP method.
+   */
+  public void pushAdd(CollectorRegistry registry, String job, Map<String, String> groupingKey, Handler<AsyncResult<Void>> handler) {
+    doRequest(registry, job, groupingKey, "PUT", handler);
+  }
+
+  /**
+   * Pushes all metrics in a Collector, replacing only previously pushed metrics of the same name, job and grouping key.
+   * <p>
+   * This is useful for pushing a single Gauge.
+   * <p>
+   * This uses the PUT HTTP method.
+   */
+  public void pushAdd(Collector collector, String job, Map<String, String> groupingKey, Handler<AsyncResult<Void>> handler) {
+    CollectorRegistry registry = new CollectorRegistry();
+    collector.register(registry);
+    pushAdd(registry, job, groupingKey, handler);
+  }
+
+
+  /**
+   * Deletes metrics from the Pushgateway.
+   * <p>
+   * Deletes metrics with no grouping key and the provided job.
+   * This uses the DELETE HTTP method.
+   */
+  public void delete(String job, Handler<AsyncResult<Void>> handler) {
+    doRequest(null, job, null, "DELETE", handler);
+  }
+
+  /**
+   * Deletes metrics from the Pushgateway.
+   * <p>
+   * Deletes metrics with the provided job and grouping key.
+   * This uses the DELETE HTTP method.
+   */
+  public void delete(String job, Map<String, String> groupingKey, Handler<AsyncResult<Void>> handler) {
+    doRequest(null, job, groupingKey, "DELETE", handler);
+  }
+
+
+  private void doRequest(CollectorRegistry registry, String job, Map<String, String> groupingKey, String method, Handler<AsyncResult<Void>> handler) {
+    try {
+      final HttpMethod httpMethod = HttpMethod.valueOf(method.toUpperCase());
+
+      String resource = "/metrics/job/" + URLEncoder.encode(job, "UTF-8");
+      if (groupingKey != null) {
+        for (Map.Entry<String, String> entry : groupingKey.entrySet()) {
+          resource += "/" + entry.getKey() + "/" + URLEncoder.encode(entry.getValue(), "UTF-8");
+        }
+      }
+
+      final HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions()
+              .setDefaultPort(port)
+              .setDefaultHost(hostname)
+              .setConnectTimeout(10 * SECONDS_PER_MILLISECOND)
+              .setIdleTimeout(10 * SECONDS_PER_MILLISECOND));
+
+      final HttpClientRequest req = httpClient.request(httpMethod, resource, res -> {
+        if (res.statusCode() != 202) {
+          httpClient.close();
+          handler.handle(Future.failedFuture(res.statusMessage()));
+        } else {
+          handler.handle(Future.succeededFuture());
+        }
+      });
+
+      req.putHeader("Content-Type", TextFormat.CONTENT_TYPE_004);
+
+      if (httpMethod != HttpMethod.DELETE) {
+        try {
+          final BufferWriter writer = new BufferWriter();
+          TextFormat.write004(writer, registry.metricFamilySamples());
+          req.putHeader("Content-Length", Integer.toString(writer.getBuffer().length()));
+          req.write(writer.getBuffer());
+        } catch (IOException e) {
+          handler.handle(Future.failedFuture(e));
+        }
+      }
+
+      // perform the real request
+      req.end();
+    } catch (UnsupportedEncodingException e) {
+      handler.handle(Future.failedFuture(e));
+    }
+  }
+
+  /**
+   * Returns a grouping key with the instance label set to the machine's IP address.
+   * <p>
+   * This is a convenience function, and should only be used where you want to
+   * push per-instance metrics rather than cluster/job level metrics.
+   */
+  public static Map<String, String> instanceIPGroupingKey() throws UnknownHostException {
+    Map<String, String> groupingKey = new HashMap<String, String>();
+    groupingKey.put("instance", InetAddress.getLocalHost().getHostAddress());
+    return groupingKey;
+  }
+}

--- a/simpleclient_pushgateway_vertx/src/test/java/io/prometheus/client/exporter/ExampleAsyncPushGateway.java
+++ b/simpleclient_pushgateway_vertx/src/test/java/io/prometheus/client/exporter/ExampleAsyncPushGateway.java
@@ -1,0 +1,28 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.Gauge;
+import io.prometheus.client.CollectorRegistry;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.AsyncResultHandler;
+import io.vertx.core.Vertx;
+
+
+public class ExampleAsyncPushGateway {
+  static final CollectorRegistry pushRegistry = new CollectorRegistry();
+  static final Gauge g = (Gauge) Gauge.build().name("gauge").help("blah").register(pushRegistry);
+
+  /**
+   * Example of how to use the pushgateway, pass in the host:port of a pushgateway.
+   */
+  public static void main(String[] args) throws Exception {
+    AsyncPushGateway pg = new AsyncPushGateway(Vertx.vertx(), args[0]);
+    g.set(42);
+    pg.push(pushRegistry, "job", new AsyncResultHandler<Void>() {
+      @Override
+      public void handle(AsyncResult<Void> result) {
+        System.out.println(result.succeeded());
+      }
+    });
+  }
+}
+

--- a/simpleclient_pushgateway_vertx/src/test/java/io/prometheus/client/exporter/PushGatewayTest.java
+++ b/simpleclient_pushgateway_vertx/src/test/java/io/prometheus/client/exporter/PushGatewayTest.java
@@ -1,0 +1,208 @@
+package io.prometheus.client.exporter;
+
+
+import static org.junit.Assert.fail;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Gauge;
+import java.io.IOException;;
+import java.util.TreeMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.AsyncResultHandler;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.client.server.MockServerClient;
+
+public class PushGatewayTest {
+
+  static final Vertx vertx = Vertx.vertx();
+  static final AsyncResultHandler<Void> NOOP_HANDLER = new AsyncResultHandler<Void>() {
+    @Override
+    public void handle(AsyncResult<Void> result) {
+
+    }
+  };
+
+  @Rule
+  public MockServerRule mockServerRule = new MockServerRule(this);
+  private MockServerClient mockServerClient;
+
+  CollectorRegistry registry;
+  Gauge gauge;
+  AsyncPushGateway pg;
+  Map groupingKey;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+    gauge = (Gauge) Gauge.build().name("g").help("help").create();
+    pg = new AsyncPushGateway(vertx, "localhost:" + mockServerRule.getPort());
+    groupingKey = new TreeMap<String, String>();
+    groupingKey.put("l", "v");
+  }
+
+  @Test
+  public void testPush() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j")
+      ).respond(response().withStatusCode(202));
+    pg.push(registry, "j", NOOP_HANDLER);
+  }
+
+  @Test(expected=IOException.class)
+  public void testNon202ResponseThrows() throws IOException {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicBoolean error = new AtomicBoolean(false);
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j")
+      ).respond(response().withStatusCode(500));
+    pg.push(registry, "j", new AsyncResultHandler<Void>() {
+      @Override
+      public void handle(AsyncResult<Void> result) {
+        error.set(result.failed());
+        latch.countDown();
+      }
+    });
+    try {
+      latch.await();
+      // the call is async so if the latch was open it means
+      // the exception was thrown
+      throw new IOException("Not 202");
+    } catch (InterruptedException e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testPushCollector() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j")
+      ).respond(response().withStatusCode(202));
+    pg.push(gauge, "j", NOOP_HANDLER);
+  }
+
+  @Test
+  public void testPushWithGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j/l/v")
+      ).respond(response().withStatusCode(202));
+    pg.push(registry, "j", groupingKey, NOOP_HANDLER);
+  }
+
+  @Test
+  public void testPushWithMultiGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j/l/v/l2/v2")
+      ).respond(response().withStatusCode(202));
+    groupingKey.put("l2", "v2");
+    pg.push(registry, "j", groupingKey, NOOP_HANDLER);
+  }
+
+  @Test
+  public void testPushWithGroupingKeyWithSlashes() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/a%2Fb/l/v/l2/v%2F2")
+      ).respond(response().withStatusCode(202));
+    groupingKey.put("l2", "v/2");
+    pg.push(registry, "a/b", groupingKey, NOOP_HANDLER);
+  }
+
+  @Test
+  public void testPushCollectorWithGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("POST")
+          .withPath("/metrics/job/j/l/v")
+      ).respond(response().withStatusCode(202));
+    pg.push(gauge, "j", groupingKey, NOOP_HANDLER);
+  }
+
+  @Test
+  public void testPushAdd() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("PUT")
+          .withPath("/metrics/job/j")
+      ).respond(response().withStatusCode(202));
+    pg.pushAdd(registry, "j", NOOP_HANDLER);
+  }
+
+  @Test
+  public void testPushAddCollector() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("PUT")
+          .withPath("/metrics/job/j")
+      ).respond(response().withStatusCode(202));
+    pg.pushAdd(gauge, "j", NOOP_HANDLER);
+  }
+
+  @Test
+  public void testPushAddWithGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("PUT")
+          .withPath("/metrics/job/j/l/v")
+      ).respond(response().withStatusCode(202));
+    pg.pushAdd(registry, "j", groupingKey, NOOP_HANDLER);
+  }
+
+  @Test
+  public void testPushAddCollectorWithGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("PUT")
+          .withPath("/metrics/job/j/l/v")
+      ).respond(response().withStatusCode(202));
+    pg.pushAdd(gauge, "j", groupingKey, NOOP_HANDLER);
+  }
+
+  @Test
+  public void testDelete() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("DELETE")
+          .withPath("/metrics/job/j")
+      ).respond(response().withStatusCode(202));
+    pg.delete("j", NOOP_HANDLER);
+  }
+
+  @Test
+  public void testDeleteWithGroupingKey() throws IOException {
+    mockServerClient.when(
+        request()
+          .withMethod("DELETE")
+          .withPath("/metrics/job/j/l/v")
+      ).respond(response().withStatusCode(202));
+    pg.delete("j", groupingKey, NOOP_HANDLER);
+  }
+
+  @Test
+  public void testInstanceIPGroupingKey() throws IOException {
+    groupingKey = AsyncPushGateway.instanceIPGroupingKey();
+    Assert.assertTrue(!groupingKey.get("instance").equals(""));
+  }
+}


### PR DESCRIPTION
This is a simple implementation of an asynchronous pushgateway client using Vert.x.

@brian-brazil and @beorn7 I've extended the base PushGateway class to make it async. I've added it as a seperate module so the original code is untouched and no extra dependencies get pulled. The existing test suite is also run on the async client.