### PR TITLE
Add a method to fetch all the samples starting with a given prefix

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -1,10 +1,12 @@
 package io.prometheus.client;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -108,16 +110,31 @@ public class CollectorRegistry {
    * This is inefficient, and intended only for use in unittests.
    */
   public Double getSampleValue(String name, String[] labelNames, String[] labelValues) {
-    for (Collector.MetricFamilySamples metricFamilySamples: Collections.list(metricFamilySamples())) {
-      for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
-        if (sample.name.equals(name)
-            && Arrays.equals(sample.labelNames.toArray(), labelNames)
-            && Arrays.equals(sample.labelValues.toArray(), labelValues)) {
-          return sample.value;
-        }
+    for (Collector.MetricFamilySamples.Sample sample: listSampleValuesOfPrefix(name)) {
+      if (sample.name.equals(name)
+          && Arrays.equals(sample.labelNames.toArray(), labelNames)
+          && Arrays.equals(sample.labelValues.toArray(), labelValues)) {
+        return sample.value;
       }
     }
     return null;
   }
 
+  /**
+   * Returns the samples whose name starts with the given prefix.
+   * <p>
+   * This is inefficient, and intended only for use in unittests.
+   */
+  public List<Collector.MetricFamilySamples.Sample> listSampleValuesOfPrefix(String prefix) {
+    List<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
+
+    for (Collector.MetricFamilySamples metricFamilySamples: Collections.list(metricFamilySamples())) {
+      for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
+        if (sample.name.startsWith(prefix)) {
+          samples.add(sample);
+        }
+      }
+    }
+    return samples;
+  }
 }

--- a/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
@@ -81,5 +81,26 @@ public class CollectorRegistryTest {
     registry.register(new EmptyCollector());
     assertFalse(registry.metricFamilySamples().hasMoreElements());
   }
+
+  @Test
+  public void testGettingSamples() {
+    Gauge g = Gauge.build().name("g").help("h").labelNames("l1", "l2").register(registry);
+    g.labels("l1Value", "l2Value").inc();
+
+    Counter c = Counter.build().name("c").help("h").labelNames("l1", "l2").register(registry);
+    c.labels("l1Value", "l2Value").inc();
+
+    Summary s = Summary.build().name("s").help("h").labelNames("l1", "l2").register(registry);
+    s.labels("l1Value", "l2Value").observe(5);
+
+    assertEquals(1, registry.listSampleValuesOfPrefix("g").size());
+    assertEquals(1, registry.listSampleValuesOfPrefix("c").size());
+    assertEquals(2, registry.listSampleValuesOfPrefix("s").size());
+
+    assertEquals((Double)1.0, registry.getSampleValue("g", new String[]{"l1", "l2"}, new String[]{"l1Value", "l2Value"}));
+    assertEquals((Double)1.0, registry.getSampleValue("c", new String[]{"l1", "l2"}, new String[]{"l1Value", "l2Value"}));
+    assertEquals((Double)1.0, registry.getSampleValue("s_count", new String[]{"l1", "l2"}, new String[]{"l1Value", "l2Value"}));
+    assertEquals((Double)5.0, registry.getSampleValue("s_sum", new String[]{"l1", "l2"}, new String[]{"l1Value", "l2Value"}));
+  }
   
 }


### PR DESCRIPTION
This pr makes testing on CollectorRegistry easier for new developers who are not familiar with internals of different collectors.

The problem we have at SoundCloud is that when new developers want to do assertions on various collectors with the existing `getSampleValue` methods, they need know the details of how each collector works. For example summaries suffix the given name, and histograms adds the `le` label. Even our internal library is adding a label to every collector by default. These are abstracted away from the application developer but when it comes to testing they need to be known.

The method introduced in this pr is a step towards an easier set up. In `listSampleValuesOfPrefix` by Using the collectors name as a prefix developers can access to all samples without having to know the labels and exact metric names. At least this can help developers do the right assertions, or in some cases we can do assertions on the return value of this method.

cc @brian-brazil @beorn7 