### PR TITLE
push and pushAdd logic reversed. #137, #138.

### DIFF
--- a/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
+++ b/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
@@ -66,12 +66,12 @@ public class PushGateway {
   }
 
   /**
-   * Pushes all metrics in a registry, replacing all those with the same job as the grouping key.
+   * Pushes all metrics in a registry, replacing all those with the same job and no grouping key.
    * <p>
-   * This uses the POST HTTP method.
+   * This uses the PUT HTTP method.
   */
   public void push(CollectorRegistry registry, String job) throws IOException {
-    doRequest(registry, job, null, "POST");
+    doRequest(registry, job, null, "PUT");
   }
 
   /**
@@ -79,7 +79,7 @@ public class PushGateway {
    * <p>
    * This is useful for pushing a single Gauge.
    * <p>
-   * This uses the POST HTTP method.
+   * This uses the PUT HTTP method.
   */
   public void push(Collector collector, String job) throws IOException {
     CollectorRegistry registry = new CollectorRegistry();
@@ -88,14 +88,12 @@ public class PushGateway {
   }
 
   /**
-   * Pushes all metrics in a Collector, replacing all those with the same job and grouping key.
+   * Pushes all metrics in a registry, replacing all those with the same job and grouping key.
    * <p>
-   * This is useful for pushing a single Gauge.
-   * <p>
-   * This uses the POST HTTP method.
+   * This uses the PUT HTTP method.
   */
   public void push(CollectorRegistry registry, String job, Map<String, String> groupingKey) throws IOException {
-    doRequest(registry, job, groupingKey, "POST");
+    doRequest(registry, job, groupingKey, "PUT");
   }
 
   /**
@@ -103,7 +101,7 @@ public class PushGateway {
    * <p>
    * This is useful for pushing a single Gauge.
    * <p>
-   * This uses the POST HTTP method.
+   * This uses the PUT HTTP method.
   */
   public void push(Collector collector, String job, Map<String, String> groupingKey) throws IOException {
     CollectorRegistry registry = new CollectorRegistry();
@@ -114,10 +112,10 @@ public class PushGateway {
   /**
    * Pushes all metrics in a registry, replacing only previously pushed metrics of the same name and job and no grouping key.
    * <p>
-   * This uses the PUT HTTP method.
+   * This uses the POST HTTP method.
   */
   public void pushAdd(CollectorRegistry registry, String job) throws IOException {
-    doRequest(registry, job, null, "PUT");
+    doRequest(registry, job, null, "POST");
   }
 
   /**
@@ -125,7 +123,7 @@ public class PushGateway {
    * <p>
    * This is useful for pushing a single Gauge.
    * <p>
-   * This uses the PUT HTTP method.
+   * This uses the POST HTTP method.
   */
   public void pushAdd(Collector collector, String job) throws IOException {
     CollectorRegistry registry = new CollectorRegistry();
@@ -134,14 +132,12 @@ public class PushGateway {
   }
 
   /**
-   * Pushes all metrics in a Collector, replacing only previously pushed metrics of the same name, job and grouping key.
+   * Pushes all metrics in a registry, replacing only previously pushed metrics of the same name, job and grouping key.
    * <p>
-   * This is useful for pushing a single Gauge.
-   * <p>
-   * This uses the PUT HTTP method.
+   * This uses the POST HTTP method.
   */
   public void pushAdd(CollectorRegistry registry, String job, Map<String, String> groupingKey) throws IOException {
-    doRequest(registry, job, groupingKey, "PUT");
+    doRequest(registry, job, groupingKey, "POST");
   }
 
   /**
@@ -149,7 +145,7 @@ public class PushGateway {
    * <p>
    * This is useful for pushing a single Gauge.
    * <p>
-   * This uses the PUT HTTP method.
+   * This uses the POST HTTP method.
   */
   public void pushAdd(Collector collector, String job, Map<String, String> groupingKey) throws IOException {
     CollectorRegistry registry = new CollectorRegistry();
@@ -182,7 +178,7 @@ public class PushGateway {
   /**
    * Pushes all metrics in a registry, replacing all those with the same job and instance.
    * <p>
-   * This uses the POST HTTP method.
+   * This uses the PUT HTTP method.
    * @deprecated use {@link #push(CollectorRegistry, String, Map)}
   */
   @Deprecated
@@ -195,7 +191,7 @@ public class PushGateway {
    * <p>
    * This is useful for pushing a single Gauge.
    * <p>
-   * This uses the POST HTTP method.
+   * This uses the PUT HTTP method.
    * @deprecated use {@link #push(Collector, String, Map)}
   */
   @Deprecated
@@ -206,7 +202,7 @@ public class PushGateway {
   /**
    * Pushes all metrics in a registry, replacing only previously pushed metrics of the same name.
    * <p>
-   * This uses the PUT HTTP method.
+   * This uses the POST HTTP method.
    * @deprecated use {@link #pushAdd(CollectorRegistry, String, Map)}
   */
   @Deprecated
@@ -219,7 +215,7 @@ public class PushGateway {
    * <p>
    * This is useful for pushing a single Gauge.
    * <p>
-   * This uses the PUT HTTP method.
+   * This uses the POST HTTP method.
    * @deprecated use {@link #pushAdd(Collector, String, Map)}
   */
   @Deprecated

--- a/simpleclient_pushgateway/src/test/java/io/prometheus/client/exporter/PushGatewayTest.java
+++ b/simpleclient_pushgateway/src/test/java/io/prometheus/client/exporter/PushGatewayTest.java
@@ -40,7 +40,7 @@ public class PushGatewayTest {
   public void testPush() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/j")
       ).respond(response().withStatusCode(202));
     pg.push(registry, "j");
@@ -50,7 +50,7 @@ public class PushGatewayTest {
   public void testNon202ResponseThrows() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/j")
       ).respond(response().withStatusCode(500));
     pg.push(registry, "j");
@@ -60,7 +60,7 @@ public class PushGatewayTest {
   public void testPushCollector() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/j")
       ).respond(response().withStatusCode(202));
     pg.push(gauge, "j");
@@ -70,7 +70,7 @@ public class PushGatewayTest {
   public void testPushWithGroupingKey() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/j/l/v")
       ).respond(response().withStatusCode(202));
     pg.push(registry, "j", groupingKey);
@@ -80,7 +80,7 @@ public class PushGatewayTest {
   public void testPushWithMultiGroupingKey() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/j/l/v/l2/v2")
       ).respond(response().withStatusCode(202));
     groupingKey.put("l2", "v2");
@@ -91,7 +91,7 @@ public class PushGatewayTest {
   public void testPushWithGroupingKeyWithSlashes() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/a%2Fb/l/v/l2/v%2F2")
       ).respond(response().withStatusCode(202));
     groupingKey.put("l2", "v/2");
@@ -102,7 +102,7 @@ public class PushGatewayTest {
   public void testPushCollectorWithGroupingKey() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/j/l/v")
       ).respond(response().withStatusCode(202));
     pg.push(gauge, "j", groupingKey);
@@ -112,7 +112,7 @@ public class PushGatewayTest {
   public void testPushAdd() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("PUT")
+          .withMethod("POST")
           .withPath("/metrics/job/j")
       ).respond(response().withStatusCode(202));
     pg.pushAdd(registry, "j");
@@ -122,7 +122,7 @@ public class PushGatewayTest {
   public void testPushAddCollector() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("PUT")
+          .withMethod("POST")
           .withPath("/metrics/job/j")
       ).respond(response().withStatusCode(202));
     pg.pushAdd(gauge, "j");
@@ -132,7 +132,7 @@ public class PushGatewayTest {
   public void testPushAddWithGroupingKey() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("PUT")
+          .withMethod("POST")
           .withPath("/metrics/job/j/l/v")
       ).respond(response().withStatusCode(202));
     pg.pushAdd(registry, "j", groupingKey);
@@ -142,7 +142,7 @@ public class PushGatewayTest {
   public void testPushAddCollectorWithGroupingKey() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("PUT")
+          .withMethod("POST")
           .withPath("/metrics/job/j/l/v")
       ).respond(response().withStatusCode(202));
     pg.pushAdd(gauge, "j", groupingKey);
@@ -174,7 +174,7 @@ public class PushGatewayTest {
   public void testOldPushWithoutInstance() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/j/instance/")
       ).respond(response().withStatusCode(202));
     pg.push(registry, "j", "");
@@ -184,7 +184,7 @@ public class PushGatewayTest {
   public void testOldPushWithInstance() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/j/instance/i")
       ).respond(response().withStatusCode(202));
     pg.push(registry, "j", "i");
@@ -194,7 +194,7 @@ public class PushGatewayTest {
   public void testOldNon202ResponseThrows() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/j/instance/i")
       ).respond(response().withStatusCode(500));
     pg.push(registry,"j", "i");
@@ -204,7 +204,7 @@ public class PushGatewayTest {
   public void testOldPushWithSlashes() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/a%2Fb/instance/c%2Fd")
       ).respond(response().withStatusCode(202));
     pg.push(registry, "a/b", "c/d");
@@ -214,7 +214,7 @@ public class PushGatewayTest {
   public void testOldPushCollector() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("POST")
+          .withMethod("PUT")
           .withPath("/metrics/job/j/instance/i")
       ).respond(response().withStatusCode(202));
     pg.push(gauge, "j", "i");
@@ -224,7 +224,7 @@ public class PushGatewayTest {
   public void testOldPushAdd() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("PUT")
+          .withMethod("POST")
           .withPath("/metrics/job/j/instance/i")
       ).respond(response().withStatusCode(202));
     pg.pushAdd(registry, "j", "i");
@@ -234,7 +234,7 @@ public class PushGatewayTest {
   public void testOldPushAddCollector() throws IOException {
     mockServerClient.when(
         request()
-          .withMethod("PUT")
+          .withMethod("POST")
           .withPath("/metrics/job/j/instance/i")
       ).respond(response().withStatusCode(202));
     pg.pushAdd(gauge, "j", "i");


### PR DESCRIPTION
According to https://github.com/prometheus/pushgateway/blob/0.3.0/README.md#post-method

> POST works exactly like the PUT method but only metrics with the same name
as the newly pushed metrics are replaced (among those with the same grouping
key).