### PR TITLE
export of Dropwizard metrics should use original name in help message

### DIFF
--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -11,7 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Collect dropwizard metrics from a MetricRegistry.
+ * Collect Dropwizard metrics from a MetricRegistry.
  */
 public class DropwizardExports extends io.prometheus.client.Collector {
     private MetricRegistry registry;
@@ -27,21 +27,23 @@ public class DropwizardExports extends io.prometheus.client.Collector {
     /**
      * Export counter as Prometheus <a href="https://prometheus.io/docs/concepts/metric_types/#gauge">Gauge</a>.
      */
-    List<MetricFamilySamples> fromCounter(String name, Counter counter) {
+    List<MetricFamilySamples> fromCounter(String dropwizardName, Counter counter) {
+        String name = sanitizeMetricName(dropwizardName);
         MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name, new ArrayList<String>(), new ArrayList<String>(),
                 new Long(counter.getCount()).doubleValue());
-        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(name, counter), Arrays.asList(sample)));
+        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(dropwizardName, counter), Arrays.asList(sample)));
     }
 
     private static String getHelpMessage(String metricName, Metric metric){
-        return String.format("Generated from dropwizard metric import (metric=%s, type=%s)",
+        return String.format("Generated from Dropwizard metric import (metric=%s, type=%s)",
                 metricName, metric.getClass().getName());
     }
 
     /**
      * Export gauge as a prometheus gauge.
      */
-    List<MetricFamilySamples> fromGauge(String name, Gauge gauge) {
+    List<MetricFamilySamples> fromGauge(String dropwizardName, Gauge gauge) {
+        String name = sanitizeMetricName(dropwizardName);
         Object obj = gauge.getValue();
         double value;
         if (obj instanceof Number) {
@@ -55,19 +57,20 @@ public class DropwizardExports extends io.prometheus.client.Collector {
         }
         MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name,
                 new ArrayList<String>(), new ArrayList<String>(), value);
-        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(name, gauge), Arrays.asList(sample)));
+        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(dropwizardName, gauge), Arrays.asList(sample)));
     }
 
     /**
      * Export a histogram snapshot as a prometheus SUMMARY.
      *
-     * @param name metric name.
+     * @param dropwizardName metric name.
      * @param snapshot the histogram snapshot.
      * @param count the total sample count for this snapshot.
      * @param factor a factor to apply to histogram values.
      *
      */
-    List<MetricFamilySamples> fromSnapshotAndCount(String name, Snapshot snapshot, long count, double factor, String helpMessage) {
+    List<MetricFamilySamples> fromSnapshotAndCount(String dropwizardName, Snapshot snapshot, long count, double factor, String helpMessage) {
+        String name = sanitizeMetricName(dropwizardName);
         List<MetricFamilySamples.Sample> samples = Arrays.asList(
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.5"), snapshot.getMedian() * factor),
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.75"), snapshot.get75thPercentile() * factor),
@@ -85,25 +88,26 @@ public class DropwizardExports extends io.prometheus.client.Collector {
     /**
      * Convert histogram snapshot.
      */
-    List<MetricFamilySamples> fromHistogram(String name, Histogram histogram) {
-        return fromSnapshotAndCount(name, histogram.getSnapshot(), histogram.getCount(), 1.0,
-                getHelpMessage(name, histogram));
+    List<MetricFamilySamples> fromHistogram(String dropwizardName, Histogram histogram) {
+        return fromSnapshotAndCount(dropwizardName, histogram.getSnapshot(), histogram.getCount(), 1.0,
+                getHelpMessage(dropwizardName, histogram));
     }
 
     /**
-     * Export dropwizard Timer as a histogram. Use TIME_UNIT as time unit.
+     * Export Dropwizard Timer as a histogram. Use TIME_UNIT as time unit.
      */
-    List<MetricFamilySamples> fromTimer(String name, Timer timer) {
-        return fromSnapshotAndCount(name, timer.getSnapshot(), timer.getCount(),
-                1.0D / TimeUnit.SECONDS.toNanos(1L), getHelpMessage(name, timer));
+    List<MetricFamilySamples> fromTimer(String dropwizardName, Timer timer) {
+        return fromSnapshotAndCount(dropwizardName, timer.getSnapshot(), timer.getCount(),
+                1.0D / TimeUnit.SECONDS.toNanos(1L), getHelpMessage(dropwizardName, timer));
     }
 
     /**
      * Export a Meter as as prometheus COUNTER.
      */
-    List<MetricFamilySamples> fromMeter(String name, Meter meter) {
+    List<MetricFamilySamples> fromMeter(String dropwizardName, Meter meter) {
+        String name = sanitizeMetricName(dropwizardName);
         return Arrays.asList(
-                new MetricFamilySamples(name + "_total", Type.COUNTER, getHelpMessage(name, meter),
+                new MetricFamilySamples(name + "_total", Type.COUNTER, getHelpMessage(dropwizardName, meter),
                         Arrays.asList(new MetricFamilySamples.Sample(name + "_total",
                                 new ArrayList<String>(),
                                 new ArrayList<String>(),
@@ -115,30 +119,30 @@ public class DropwizardExports extends io.prometheus.client.Collector {
     /**
      * Replace all unsupported chars with '_'.
      *
-     * @param name metric name.
+     * @param dropwizardName original metric name.
      * @return the sanitized metric name.
      */
-    public static String sanitizeMetricName(String name){
-        return name.replaceAll("[^a-zA-Z0-9:_]", "_");
+    public static String sanitizeMetricName(String dropwizardName){
+        return dropwizardName.replaceAll("[^a-zA-Z0-9:_]", "_");
     }
 
     @Override
     public List<MetricFamilySamples> collect() {
         ArrayList<MetricFamilySamples> mfSamples = new ArrayList<MetricFamilySamples>();
         for (SortedMap.Entry<String, Gauge> entry : registry.getGauges().entrySet()) {
-            mfSamples.addAll(fromGauge(sanitizeMetricName(entry.getKey()), entry.getValue()));
+            mfSamples.addAll(fromGauge(entry.getKey(), entry.getValue()));
         }
         for (SortedMap.Entry<String, Counter> entry : registry.getCounters().entrySet()) {
-            mfSamples.addAll(fromCounter(sanitizeMetricName(entry.getKey()), entry.getValue()));
+            mfSamples.addAll(fromCounter(entry.getKey(), entry.getValue()));
         }
         for (SortedMap.Entry<String, Histogram> entry : registry.getHistograms().entrySet()) {
-            mfSamples.addAll(fromHistogram(sanitizeMetricName(entry.getKey()), entry.getValue()));
+            mfSamples.addAll(fromHistogram(entry.getKey(), entry.getValue()));
         }
         for (SortedMap.Entry<String, Timer> entry : registry.getTimers().entrySet()) {
-            mfSamples.addAll(fromTimer(sanitizeMetricName(entry.getKey()), entry.getValue()));
+            mfSamples.addAll(fromTimer(entry.getKey(), entry.getValue()));
         }
         for (SortedMap.Entry<String, Meter> entry : registry.getMeters().entrySet()) {
-            mfSamples.addAll(fromMeter(sanitizeMetricName(entry.getKey()), entry.getValue()));
+            mfSamples.addAll(fromMeter(entry.getKey(), entry.getValue()));
         }
         return mfSamples;
     }

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
@@ -2,15 +2,21 @@ package io.prometheus.client.dropwizard;
 
 
 import com.codahale.metrics.*;
+import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DropwizardExportsTest {
@@ -141,5 +147,55 @@ public class DropwizardExportsTest {
     @Test
     public void testSanitizeMetricName() {
         assertEquals("Foo_Bar_metric_mame", DropwizardExports.sanitizeMetricName("Foo.Bar-metric,mame"));
+    }
+
+    @Test
+    public void testThatMetricHelpUsesOriginalDropwizardName() {
+        metricRegistry.timer("my.application.namedTimer1");
+        metricRegistry.counter("my.application.namedCounter1");
+        metricRegistry.meter("my.application.namedMeter1");
+        metricRegistry.histogram("my.application.namedHistogram1");
+        metricRegistry.register("my.application.namedGauge1", new ExampleDoubleGauge());
+
+        Enumeration<Collector.MetricFamilySamples> metricFamilySamples = registry.metricFamilySamples();
+
+
+        Map<String, Collector.MetricFamilySamples> elements = new HashMap<String, Collector.MetricFamilySamples>();
+
+        while (metricFamilySamples.hasMoreElements()) {
+            Collector.MetricFamilySamples element =  metricFamilySamples.nextElement();
+            elements.put(element.name, element);
+        }
+        assertEquals(5, elements.size());
+
+        assertTrue(elements.keySet().contains("my_application_namedTimer1"));
+        assertTrue(elements.keySet().contains("my_application_namedCounter1"));
+        assertTrue(elements.keySet().contains("my_application_namedMeter1_total"));
+        assertTrue(elements.keySet().contains("my_application_namedHistogram1"));
+        assertTrue(elements.keySet().contains("my_application_namedGauge1"));
+
+        assertThat(elements.get("my_application_namedTimer1").help,
+                is("Generated from Dropwizard metric import (metric=my.application.namedTimer1, type=com.codahale.metrics.Timer)"));
+
+        assertThat(elements.get("my_application_namedCounter1").help,
+                is("Generated from Dropwizard metric import (metric=my.application.namedCounter1, type=com.codahale.metrics.Counter)"));
+
+        assertThat(elements.get("my_application_namedMeter1_total").help,
+                is("Generated from Dropwizard metric import (metric=my.application.namedMeter1, type=com.codahale.metrics.Meter)"));
+
+        assertThat(elements.get("my_application_namedHistogram1").help,
+                is("Generated from Dropwizard metric import (metric=my.application.namedHistogram1, type=com.codahale.metrics.Histogram)"));
+
+        assertThat(elements.get("my_application_namedGauge1").help,
+                is("Generated from Dropwizard metric import (metric=my.application.namedGauge1, type=io.prometheus.client.dropwizard.DropwizardExportsTest$ExampleDoubleGauge)"));
+
+    }
+
+
+    private static class ExampleDoubleGauge implements Gauge<Double> {
+        @Override
+        public Double getValue() {
+            return 0.0;
+        }
     }
 }


### PR DESCRIPTION
@brian-brazil : small cleanup in Dropwizard export help message

Dropwizard metric name can contain characters which are not allowed in Prometheus metrics name. For example `my.application.namedTimer1`. This name is then sanitized to `my_application_namedTimer1`.

The change is that help message should provide original metric name:

 `Generated from Dropwizard metric import (metric=my.application.namedTimer1, type=com.codahale.metrics.Timer)`

instead of

`Generated from dropwizard metric import (metric=my_application_namedTimer1, type=com.codahale.metrics.Timer)`

 Metric name in help message was not  correct.