### PR TITLE
Changed visibility of Summary.Child.Value back to public.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -166,7 +166,7 @@ public class Summary extends SimpleCollector<Summary.Child> {
    * {@link SimpleCollector#remove} or {@link SimpleCollector#clear}.
    */
   public static class Child {
-    private static class Value {
+    public static class Value {
       public final double count;
       public final double sum;
       public final SortedMap<Double, Double> quantiles;

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -2,7 +2,10 @@ package io.prometheus.client;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
@@ -178,6 +181,19 @@ public class HistogramTest {
 
     assertEquals(1, mfs.size());
     assertEquals(mfsFixture, mfs.get(0));
+  }
+
+  @Test
+  public void testChildAndValuePublicApi() throws Exception {
+    assertTrue(Modifier.isPublic(Histogram.Child.class.getModifiers()));
+
+    final Method getMethod = Histogram.Child.class.getMethod("get");
+    assertTrue(Modifier.isPublic(getMethod.getModifiers()));
+    assertEquals(Histogram.Child.Value.class, getMethod.getReturnType());
+
+    assertTrue(Modifier.isPublic(Histogram.Child.Value.class.getModifiers()));
+    assertTrue(Modifier.isPublic(Histogram.Child.Value.class.getField("sum").getModifiers()));
+    assertTrue(Modifier.isPublic(Histogram.Child.Value.class.getField("buckets").getModifiers()));
   }
 
 }

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -4,11 +4,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class SummaryTest {
@@ -179,5 +182,19 @@ public class SummaryTest {
 
     assertEquals(1, mfs.size());
     assertEquals(mfsFixture, mfs.get(0));
+  }
+
+  @Test
+  public void testChildAndValuePublicApi() throws Exception {
+    assertTrue(Modifier.isPublic(Summary.Child.class.getModifiers()));
+
+    final Method getMethod = Summary.Child.class.getMethod("get");
+    assertTrue(Modifier.isPublic(getMethod.getModifiers()));
+    assertEquals(Summary.Child.Value.class, getMethod.getReturnType());
+
+    assertTrue(Modifier.isPublic(Summary.Child.Value.class.getModifiers()));
+    assertTrue(Modifier.isPublic(Summary.Child.Value.class.getField("count").getModifiers()));
+    assertTrue(Modifier.isPublic(Summary.Child.Value.class.getField("sum").getModifiers()));
+    assertTrue(Modifier.isPublic(Summary.Child.Value.class.getField("quantiles").getModifiers()));
   }
 }


### PR DESCRIPTION
This gives clients access to current values of summary, if they need it.
Also added simple tests to avoid breaking this API in Summary and Histogram classes in the future.