### PR TITLE
added /prometheus as a Spring Boot Endpoint

### DIFF
--- a/simpleclient_spring_boot/pom.xml
+++ b/simpleclient_spring_boot/pom.xml
@@ -31,6 +31,17 @@
             <name>Tokuhiro Matsuno</name>
             <email>tokuhirom@gmail.com</email>
         </developer>
+        <developer>
+            <name>Marco Aust</name>
+            <email>github@marcoaust.de</email>
+            <organization>private</organization>
+            <organizationUrl>https://github.com/maust</organizationUrl>
+        </developer>
+        <developer>
+            <id>eliezio</id>
+            <name>Eliezio Oliveira</name>
+            <email>eliezio.oliveira@gmail.com</email>
+        </developer>
     </developers>
 
     <properties>
@@ -49,6 +60,11 @@
             <version>0.0.18-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>4.2.5.RELEASE</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator</artifactId>
             <version>1.3.3.RELEASE</version>
@@ -62,6 +78,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.cthul</groupId>
+            <artifactId>cthul-matchers</artifactId>
+            <version>1.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>1.3.3.RELEASE</version>
@@ -69,7 +91,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
+            <artifactId>spring-boot-starter-web</artifactId>
             <version>1.3.3.RELEASE</version>
             <scope>test</scope>
         </dependency>

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/EnablePrometheusEndpoint.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/EnablePrometheusEndpoint.java
@@ -1,0 +1,35 @@
+package io.prometheus.client.spring.boot;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Enable an endpoint to expose Prometheus metrics from its default collector.
+ *
+ * <p/>
+ * Usage:
+ * <br/>Just add this annotation to your main Spring Boot Application.
+ *
+ * <p/>
+ * Configuration:
+ * <br/>This endpoint is configurable through the following environment variables:
+ * <li>
+ *   <ul>{@code endpoints.prometheus.id} (default: "prometheus")</ul>
+ *   <ul>{@code endpoints.prometheus.enabled} (default: {@code true})</ul>
+ *   <ul>{@code endpoints.prometheus.sensitive} (default: {@code true})</ul>
+ * </li>
+ * @author Marco Aust
+ * @author Eliezio Oliveira
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(PrometheusConfiguration.class)
+public @interface EnablePrometheusEndpoint {
+
+}

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusConfiguration.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusConfiguration.java
@@ -1,0 +1,14 @@
+package io.prometheus.client.spring.boot;
+
+import io.prometheus.client.CollectorRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class PrometheusConfiguration {
+
+  @Bean
+  public PrometheusEndpoint prometheusEndpoint() {
+    return new PrometheusEndpoint(CollectorRegistry.defaultRegistry);
+  }
+}

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusEndpoint.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusEndpoint.java
@@ -1,0 +1,42 @@
+package io.prometheus.client.spring.boot;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
+/**
+ * @author Marco Aust
+ * @author Eliezio Oliveira
+ */
+@ConfigurationProperties("endpoints.prometheus")
+class PrometheusEndpoint extends AbstractEndpoint<ResponseEntity<String>> {
+
+  private final CollectorRegistry collectorRegistry;
+
+  PrometheusEndpoint(CollectorRegistry collectorRegistry) {
+    super("prometheus");
+    this.collectorRegistry = collectorRegistry;
+  }
+
+  @Override
+  public ResponseEntity<String> invoke() {
+    try {
+      Writer writer = new StringWriter();
+      TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
+      return ResponseEntity.ok()
+          .header(CONTENT_TYPE, TextFormat.CONTENT_TYPE_004)
+          .body(writer.toString());
+    } catch (IOException e) {
+      // This actually never happens since StringWriter::write() doesn't throw any IOException
+      throw new RuntimeException("Writing metrics failed", e);
+    }
+  }
+}

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/matchers/CustomMatchers.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/matchers/CustomMatchers.java
@@ -1,0 +1,45 @@
+package io.prometheus.client.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.IsCollectionContaining;
+
+/**
+ * @author <a href="http://stackoverflow.com/users/4483548/bretc">BretC</a>
+ *
+ * @see <a href="http://stackoverflow.com/a/29610402/346545">this StackOverflow answer</a>
+ *
+ * Licensed under Creative Commons BY-SA 3.0
+ */
+public final class CustomMatchers {
+
+  private CustomMatchers() {
+  }
+
+  public static <T> Matcher<Iterable<? super T>> exactlyNItems(final int n, final Matcher<? super T> elementMatcher) {
+    return new IsCollectionContaining<T>(elementMatcher) {
+      @Override
+      protected boolean matchesSafely(Iterable<? super T> collection, Description mismatchDescription) {
+        int count = 0;
+        boolean isPastFirst = false;
+
+        for (Object item : collection) {
+
+          if (elementMatcher.matches(item)) {
+            count++;
+          }
+          if (isPastFirst) {
+            mismatchDescription.appendText(", ");
+          }
+          elementMatcher.describeMismatch(item, mismatchDescription);
+          isPastFirst = true;
+        }
+
+        if (count != n) {
+          mismatchDescription.appendText(". Expected exactly " + n + " but got " + count);
+        }
+        return count == n;
+      }
+    };
+  }
+}

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/DummyBootApplication.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/DummyBootApplication.java
@@ -1,0 +1,12 @@
+package io.prometheus.client.spring.boot;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Dummy class to satisfy Spring Boot Test requirement of a class annotated either with {code @SpringBootApplication} or
+ * {code @SpringBootConfiguration}.
+ */
+@SpringBootApplication
+class DummyBootApplication {
+
+}

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusEndpointTest.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusEndpointTest.java
@@ -1,0 +1,61 @@
+package io.prometheus.client.spring.boot;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.matchers.CustomMatchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.cthul.matchers.CthulMatchers.matchesPattern;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(DummyBootApplication.class)
+@WebIntegrationTest(randomPort = true)
+@EnablePrometheusEndpoint
+public class PrometheusEndpointTest {
+
+  @Value("${local.server.port}")
+  int localServerPort;
+
+  RestTemplate template = new TestRestTemplate();
+
+  @Test
+  public void testMetricsExportedThroughPrometheusEndpoint() {
+    // given:
+    final Counter promCounter = Counter.build()
+        .name("foo_bar")
+        .help("a simple prometheus counter")
+        .labelNames("attr1", "attr2")
+        .register();
+
+    // when:
+    promCounter.labels("val1", "val2").inc(3);
+    ResponseEntity<String> metricsResponse = template.getForEntity(getBaseUrl() + "/prometheus", String.class);
+
+    // then:
+    assertEquals(HttpStatus.OK, metricsResponse.getStatusCode());
+    assertTrue(MediaType.TEXT_PLAIN.isCompatibleWith(metricsResponse.getHeaders().getContentType()));
+
+    List<String> responseLines = Arrays.asList(metricsResponse.getBody().split("\n"));
+    assertThat(responseLines, CustomMatchers.<String>exactlyNItems(1,
+        matchesPattern("foo_bar\\{attr1=\"val1\",attr2=\"val2\",?\\} 3.0")));
+  }
+
+  private String getBaseUrl() {
+    return "http://localhost:" + localServerPort;
+  }
+}


### PR DESCRIPTION
Changes since the previous PR:

1. Spring Boot reverted to 1.3.3;
2. Spring Framework reverted to 4.2.5;
3. Added copyright notice to CustomMatchers
4. Added documentation to EnablePrometheusEndpoint explaining how to use it.


