### PR TITLE
allow to register default JVM collectors with the given registry

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java
@@ -1,5 +1,7 @@
 package io.prometheus.client.hotspot;
 
+import io.prometheus.client.CollectorRegistry;
+
 /**
  * Registers the default Hotspot collectors.
  * <p>
@@ -15,16 +17,24 @@ package io.prometheus.client.hotspot;
  */
 public class DefaultExports {
   private static boolean initialized = false;
+
   /**
-   * Register the default Hotspot collectors.
+   * Register the default Hotspot collectors with the default registry.
    */
   public static synchronized void initialize() {
+    initialize(CollectorRegistry.defaultRegistry);
+  }
+
+  /**
+   * Register the default Hotspot collectors with the given registry.
+   */
+  public static synchronized void initialize(CollectorRegistry registry) {
     if (!initialized) {
-      new StandardExports().register();
-      new MemoryPoolsExports().register();
-      new GarbageCollectorExports().register();
-      new ThreadExports().register();
-      new ClassLoadingExports().register();
+      new StandardExports().register(registry);
+      new MemoryPoolsExports().register(registry);
+      new GarbageCollectorExports().register(registry);
+      new ThreadExports().register(registry);
+      new ClassLoadingExports().register(registry);
       initialized = true;
     }
   }

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/DefaultExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/DefaultExportsTest.java
@@ -1,0 +1,35 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Test;
+
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+
+public class DefaultExportsTest {
+
+  @Test
+  public void shouldRegistrerDefaultExportsWithProvidedRegistry() {
+    CollectorRegistry providedCollectorRegistry = new CollectorRegistry();
+    DefaultExports.initialize(providedCollectorRegistry);
+
+    Set<String> collectors = new HashSet<String>();
+    Enumeration<Collector.MetricFamilySamples> metricFamilySamples = providedCollectorRegistry.metricFamilySamples();
+    while (metricFamilySamples.hasMoreElements()) {
+      Collector.MetricFamilySamples element = metricFamilySamples.nextElement();
+      collectors.add(element.name);
+    }
+
+    assertTrue("Contains process_cpu_seconds_total", collectors.contains("process_cpu_seconds_total"));
+    assertTrue("Contains jvm_memory_bytes_used", collectors.contains("jvm_memory_bytes_used"));
+    assertTrue("Contains jvm_gc_collection_seconds", collectors.contains("jvm_gc_collection_seconds"));
+    assertTrue("Contains jvm_threads_current", collectors.contains("jvm_threads_current"));
+    assertTrue("Contains jvm_classes_loaded", collectors.contains("jvm_classes_loaded"));
+  }
+
+}


### PR DESCRIPTION
@brian-brazil 

Prometheus Java API in general allows to do so, this is just to make DefaultExports to follow this idea.