### PR TITLE
Make Timer classes Closeable

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -1,5 +1,7 @@
 package io.prometheus.client;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -57,11 +59,11 @@ import java.util.Map;
  * }
  * </pre>
  * <p>
- * These can be aggregated and processed together much more easily in the Prometheus 
+ * These can be aggregated and processed together much more easily in the Prometheus
  * server than individual metrics for each labelset.
  */
 public class Gauge extends SimpleCollector<Gauge.Child> {
-  
+
   Gauge(Builder b) {
     super(b);
   }
@@ -88,7 +90,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> {
    /**
     * Represents an event being timed.
     */
-   public static class Timer {
+   public static class Timer implements Closeable {
      private final Child child;
      private final long start;
      private Timer(Child child) {
@@ -103,6 +105,15 @@ public class Gauge extends SimpleCollector<Gauge.Child> {
        double elapsed = (Child.timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND;
        child.set(elapsed);
        return elapsed;
+     }
+
+     /**
+      * Equivalent to calling {@link #setDuration()}.
+      * @throws IOException
+      */
+     @Override
+     public void close() throws IOException {
+       setDuration();
      }
    }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -1,5 +1,7 @@
 package io.prometheus.client;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +17,7 @@ import java.util.Map;
  * <p>
  * <em>Note:</em> Each bucket is one timeseries. Many buckets and/or many dimensions with labels
  * can produce large amount of time series, that may cause performance problems.
- * 
+ *
  * <p>
  * The default buckets are intended to cover a typical web/rpc request from milliseconds to seconds.
  * <p>
@@ -26,7 +28,7 @@ import java.util.Map;
  *     static final Histogram requestLatency = Histogram.build()
  *         .name("requests_latency_seconds").help("Request latency in seconds.").register();
  *
- *     void processRequest(Request req) {  
+ *     void processRequest(Request req) {
  *        Histogram.Timer requestTimer = requestLatency.startTimer();
  *        try {
  *          // Your code here.
@@ -89,7 +91,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
       dontInitializeNoLabelsChild = true;
       return new Histogram(this);
     }
-   
+
     /**
       * Set the upper bounds of buckets for the histogram.
       */
@@ -118,7 +120,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
       }
       return this;
     }
-    
+
   }
 
   /**
@@ -136,7 +138,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
   /**
    * Represents an event being timed.
    */
-  public static class Timer {
+  public static class Timer implements Closeable {
     private final Child child;
     private final long start;
     private Timer(Child child) {
@@ -151,6 +153,15 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
         double elapsed = (Child.timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND;
         child.observe(elapsed);
         return elapsed;
+    }
+
+    /**
+     * Equivalent to calling {@link #observeDuration()}.
+     * @throws IOException
+     */
+    @Override
+    public void close() throws IOException {
+      observeDuration();
     }
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -1,6 +1,9 @@
 package io.prometheus.client;
 
 import io.prometheus.client.CKMSQuantiles.Quantile;
+
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -141,7 +144,7 @@ public class Summary extends SimpleCollector<Summary.Child> {
   /**
    * Represents an event being timed.
    */
-  public static class Timer {
+  public static class Timer implements Closeable {
     private final Child child;
     private final long start;
     private Timer(Child child) {
@@ -156,6 +159,15 @@ public class Summary extends SimpleCollector<Summary.Child> {
       double elapsed = (Child.timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND;
       child.observe(elapsed);
       return elapsed;
+    }
+
+    /**
+     * Equivalent to calling {@link #observeDuration()}.
+     * @throws IOException
+     */
+    @Override
+    public void close() throws IOException {
+      observeDuration();
     }
   }
 


### PR DESCRIPTION
If the timer classes are closeable they can be used with java8's
try-with-resources, which allows for slightly more concise code as you don't
need to write the finally block.

No tests here because a) the new method directly delegates to an existing method
with no new logic, and b) because the test project doesn't target java8 and so
cannot use try-with-resources anyway.

@brian-brazil @beorn7 