### PR TITLE
Add Gauge/Counter/SummaryMetricFamily to make custom collectors easier.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -23,10 +23,11 @@ public abstract class Collector {
     GAUGE,
     SUMMARY,
     HISTOGRAM,
+    UNTYPED,
   }
 
   /**
-   * A metric, and all of it's samples.
+   * A metric, and all of its samples.
    */
   static public class MetricFamilySamples {
     public final String name;
@@ -177,7 +178,7 @@ public abstract class Collector {
   }
 
   /**
-   * Convert a double to it's string representation in Go.
+   * Convert a double to its string representation in Go.
    */
   public static String doubleToGoString(double d) {
     if (d == Double.POSITIVE_INFINITY) {

--- a/simpleclient/src/main/java/io/prometheus/client/CounterMetricFamily.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CounterMetricFamily.java
@@ -1,0 +1,57 @@
+package io.prometheus.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collections;
+
+/**
+ * Counter metric family, for custom collectors and exporters.
+ * <p>
+ * Most users want a normal {@link Counter} instead.
+ *
+ * Example usage:
+ * <pre>
+ * {@code
+ *   class YourCustomCollector extends Collector {
+ *     List<MetricFamilySamples> collect() {
+ *       List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+ *       // With no labels.
+ *       mfs.add(new CounterMetricFamily("my_counter_total", "help", 42));
+ *       // With labels
+ *       CounterMetricFamily labeledCounter = new CounterMetricFamily("my_other_counter_total", "help", Arrays.asList("labelname"));
+ *       labeledCounter.addMetric(Arrays.asList("foo"), 4);
+ *       labeledCounter.addMetric(Arrays.asList("bar"), 5);
+ *       mfs.add(labeledCounter);
+ *       return mfs;
+ *     }
+ *   }
+ * }
+ * </pre>
+ */
+public class CounterMetricFamily extends Collector.MetricFamilySamples {
+
+  private List<String> labelNames;
+
+  public CounterMetricFamily(String name, String help, double value) {
+    super(name, Collector.Type.COUNTER, help, new ArrayList<Sample>());
+    labelNames = Collections.emptyList();
+    samples.add(
+        new Sample(
+          name,
+          labelNames, 
+          Collections.<String>emptyList(),
+          value));
+  }
+
+  public CounterMetricFamily(String name, String help, List<String> labelNames) {
+    super(name, Collector.Type.COUNTER, help, new ArrayList<Sample>());
+    this.labelNames = labelNames;
+  }
+
+  public void addMetric(List<String> labelValues, double value) {
+    if (labelValues.size() != labelNames.size()) {
+      throw new IllegalArgumentException("Incorrect number of labels.");
+    }
+    samples.add(new Sample(name, labelNames, labelValues, value));
+  }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/GaugeMetricFamily.java
+++ b/simpleclient/src/main/java/io/prometheus/client/GaugeMetricFamily.java
@@ -1,0 +1,57 @@
+package io.prometheus.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collections;
+
+/**
+ * Gauge metric family, for custom collectors and exporters.
+ * <p>
+ * Most users want a normal {@link Gauge} instead.
+ *
+ * Example usage:
+ * <pre>
+ * {@code
+ *   class YourCustomCollector extends Collector {
+ *     List<MetricFamilySamples> collect() {
+ *       List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+ *       // With no labels.
+ *       mfs.add(new GaugeMetricFamily("my_gauge", "help", 42));
+ *       // With labels
+ *       GaugeMetricFamily labeledGauge = new GaugeMetricFamily("my_other_gauge", "help", Arrays.asList("labelname"));
+ *       labeledGauge.addMetric(Arrays.asList("foo"), 4);
+ *       labeledGauge.addMetric(Arrays.asList("bar"), 5);
+ *       mfs.add(labeledGauge);
+ *       return mfs;
+ *     }
+ *   }
+ * }
+ * </pre>
+ */
+public class GaugeMetricFamily extends Collector.MetricFamilySamples {
+
+  private List<String> labelNames;
+
+  public GaugeMetricFamily(String name, String help, double value) {
+    super(name, Collector.Type.GAUGE, help, new ArrayList<Sample>());
+    labelNames = Collections.emptyList();
+    samples.add(
+        new Sample(
+          name,
+          labelNames, 
+          Collections.<String>emptyList(),
+          value));
+  }
+
+  public GaugeMetricFamily(String name, String help, List<String> labelNames) {
+    super(name, Collector.Type.GAUGE, help, new ArrayList<Sample>());
+    this.labelNames = labelNames;
+  }
+
+  public void addMetric(List<String> labelValues, double value) {
+    if (labelValues.size() != labelNames.size()) {
+      throw new IllegalArgumentException("Incorrect number of labels.");
+    }
+    samples.add(new Sample(name, labelNames, labelValues, value));
+  }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/SummaryMetricFamily.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SummaryMetricFamily.java
@@ -1,0 +1,72 @@
+package io.prometheus.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collections;
+
+/**
+ * Summary metric family, for custom collectors and exporters.
+ * <p>
+ * Most users want a normal {@link Summary} instead.
+ *
+ * Example usage:
+ * <pre>
+ * {@code
+ *   class YourCustomCollector extends Collector {
+ *     List<MetricFamilySamples> collect() {
+ *       List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+ *       // With no labels.
+ *       mfs.add(new SummaryMetricFamily("my_summary", "help", 1, 42));
+ *       // With labels. Record 95th percentile as 3, and 99th percentile as 5.
+ *       SummaryMetricFamily labeledSummary = new SummaryMetricFamily("my_other_summary", "help", 
+ *           Arrays.asList("labelname"), Arrays.asList(.95, .99));
+ *       labeledSummary.addMetric(Arrays.asList("foo"), 2, 10, Arrays.asList(3.0, 5.0));
+ *       mfs.add(labeledSummary);
+ *       return mfs;
+ *     }
+ *   }
+ * }
+ * </pre>
+ */
+public class SummaryMetricFamily extends Collector.MetricFamilySamples {
+
+  private List<String> labelNames;
+  private List<Double> quantiles;
+
+  public SummaryMetricFamily(String name, String help, double count, double sum) {
+    super(name, Collector.Type.SUMMARY, help, new ArrayList<Sample>());
+    this.labelNames = Collections.emptyList();
+    this.quantiles = Collections.emptyList();
+    addMetric(Collections.<String>emptyList(), count, sum);
+  }
+
+  public SummaryMetricFamily(String name, String help, List<String> labelNames) {
+    this(name, help, labelNames, Collections.<Double>emptyList());
+  }
+  public SummaryMetricFamily(String name, String help, List<String> labelNames, List<Double>quantiles) {
+    super(name, Collector.Type.SUMMARY, help, new ArrayList<Sample>());
+    this.labelNames = labelNames;
+    this.quantiles = quantiles;
+  }
+
+  public void addMetric(List<String> labelValues, double count, double sum) {
+    addMetric(labelValues, count, sum, Collections.<Double>emptyList());
+  }
+  public void addMetric(List<String> labelValues, double count, double sum, List<Double> quantiles) {
+    if (labelValues.size() != labelNames.size()) {
+      throw new IllegalArgumentException("Incorrect number of labels.");
+    }
+    if (this.quantiles.size() != quantiles.size()) {
+      throw new IllegalArgumentException("Incorrect number of quantiles.");
+    }
+    samples.add(new Sample(name + "_count", labelNames, labelValues, count));
+    samples.add(new Sample(name + "_sum", labelNames, labelValues, sum));
+    List<String> labelNamesWithQuantile = new ArrayList<String>(labelNames);
+    labelNamesWithQuantile.add("quantile");
+    for (int i = 0; i < quantiles.size(); i++) {
+      List<String> labelValuesWithQuantile = new ArrayList<String>(labelValues);
+      labelValuesWithQuantile.add(Collector.doubleToGoString(this.quantiles.get(i)));
+      samples.add(new Sample(name, labelNamesWithQuantile, labelValuesWithQuantile, quantiles.get(i)));
+    }
+  }
+}

--- a/simpleclient/src/test/java/io/prometheus/client/CounterMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterMetricFamilyTest.java
@@ -1,0 +1,45 @@
+package io.prometheus.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class CounterMetricFamilyTest {
+
+  CollectorRegistry registry;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+  }
+
+  @Test
+  public void testJavadocExample() {
+    class YourCustomCollector extends Collector {
+      public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+        // With no labels.
+        mfs.add(new CounterMetricFamily("my_counter", "help", 42));
+        // With labels
+        CounterMetricFamily labeledCounter = new CounterMetricFamily("my_other_counter", "help", Arrays.asList("labelname"));
+        labeledCounter.addMetric(Arrays.asList("foo"), 4);
+        labeledCounter.addMetric(Arrays.asList("bar"), 5);
+        mfs.add(labeledCounter);
+        return mfs;
+      }
+    }
+    new YourCustomCollector().register(registry);
+
+    assertEquals(42.0, registry.getSampleValue("my_counter").doubleValue(), .001);
+    assertEquals(null, registry.getSampleValue("my_other_counter"));
+    assertEquals(4.0, registry.getSampleValue("my_other_counter", new String[]{"labelname"}, new String[]{"foo"}).doubleValue(), .001);
+    assertEquals(5.0, registry.getSampleValue("my_other_counter", new String[]{"labelname"}, new String[]{"bar"}).doubleValue(), .001);
+  }
+
+}

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeMetricFamilyTest.java
@@ -1,0 +1,45 @@
+package io.prometheus.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class GaugeMetricFamilyTest {
+
+  CollectorRegistry registry;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+  }
+
+  @Test
+  public void testJavadocExample() {
+    class YourCustomCollector extends Collector {
+      public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+        // With no labels.
+        mfs.add(new GaugeMetricFamily("my_gauge", "help", 42));
+        // With labels
+        GaugeMetricFamily labeledGauge = new GaugeMetricFamily("my_other_gauge", "help", Arrays.asList("labelname"));
+        labeledGauge.addMetric(Arrays.asList("foo"), 4);
+        labeledGauge.addMetric(Arrays.asList("bar"), 5);
+        mfs.add(labeledGauge);
+        return mfs;
+      }
+    }
+    new YourCustomCollector().register(registry);
+
+    assertEquals(42.0, registry.getSampleValue("my_gauge").doubleValue(), .001);
+    assertEquals(null, registry.getSampleValue("my_other_gauge"));
+    assertEquals(4.0, registry.getSampleValue("my_other_gauge", new String[]{"labelname"}, new String[]{"foo"}).doubleValue(), .001);
+    assertEquals(5.0, registry.getSampleValue("my_other_gauge", new String[]{"labelname"}, new String[]{"bar"}).doubleValue(), .001);
+  }
+
+}

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryMetricFamilyTest.java
@@ -1,0 +1,48 @@
+package io.prometheus.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class SummaryMetricFamilyTest {
+
+  CollectorRegistry registry;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+  }
+
+  @Test
+  public void testJavadocExample() {
+		class YourCustomCollector extends Collector {
+			public List<MetricFamilySamples> collect() {
+				List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+				// With no labels.
+				mfs.add(new SummaryMetricFamily("my_summary", "help", 1, 42));
+				// With labels. Record 95th percentile as 3, and 99th percentile as 5.
+				SummaryMetricFamily labeledSummary = new SummaryMetricFamily("my_other_summary", "help", 
+						Arrays.asList("labelname"), Arrays.asList(.95, .99));
+				labeledSummary.addMetric(Arrays.asList("foo"), 2, 10, Arrays.asList(3.0, 5.0));
+				mfs.add(labeledSummary);
+				return mfs;
+			}
+		}
+		new YourCustomCollector().register(registry);
+
+		assertEquals(1.0, registry.getSampleValue("my_summary_count").doubleValue(), .001);
+		assertEquals(42.0, registry.getSampleValue("my_summary_sum").doubleValue(), .001);
+
+		assertEquals(2.0, registry.getSampleValue("my_other_summary_count", new String[]{"labelname"}, new String[]{"foo"}).doubleValue(), .001);
+		assertEquals(10.0, registry.getSampleValue("my_other_summary_sum", new String[]{"labelname"}, new String[]{"foo"}).doubleValue(), .001);
+		assertEquals(3.0, registry.getSampleValue("my_other_summary", new String[]{"labelname", "quantile"}, new String[]{"foo", "0.95"}).doubleValue(), .001);
+		assertEquals(5.0, registry.getSampleValue("my_other_summary", new String[]{"labelname", "quantile"}, new String[]{"foo", "0.99"}).doubleValue(), .001);
+	}
+
+}

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ClassLoadingExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ClassLoadingExports.java
@@ -1,11 +1,12 @@
 package io.prometheus.client.hotspot;
 
 import io.prometheus.client.Collector;
+import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.GaugeMetricFamily;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ClassLoadingMXBean;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -25,8 +26,6 @@ import java.util.List;
  * </pre>
  */
 public class ClassLoadingExports extends Collector {
-  private static final List<String> EMPTY_LABEL = Collections.emptyList();
-
   private final ClassLoadingMXBean clBean;
 
   public ClassLoadingExports() {
@@ -38,35 +37,18 @@ public class ClassLoadingExports extends Collector {
   }
 
   void addClassLoadingMetrics(List<MetricFamilySamples> sampleFamilies) {
-    sampleFamilies.add(
-            new MetricFamilySamples(
-                    "jvm_classes_loaded",
-                    Type.GAUGE,
-                    "The number of classes that are currently loaded in the JVM",
-                    Collections.singletonList(
-                            new MetricFamilySamples.Sample(
-                                    "jvm_classes_loaded", EMPTY_LABEL, EMPTY_LABEL,
-                                    clBean.getLoadedClassCount()))));
-
-    sampleFamilies.add(
-            new MetricFamilySamples(
-                    "jvm_classes_loaded_total",
-                    Type.COUNTER,
-                    "The total number of classes that have been loaded since the JVM has started execution",
-                    Collections.singletonList(
-                            new MetricFamilySamples.Sample(
-                                    "jvm_classes_loaded_total", EMPTY_LABEL, EMPTY_LABEL,
-                                    clBean.getTotalLoadedClassCount()))));
-
-    sampleFamilies.add(
-            new MetricFamilySamples(
-                    "jvm_classes_unloaded_total",
-                    Type.COUNTER,
-                    "The total number of classes that have been unloaded since the JVM has started execution",
-                    Collections.singletonList(
-                            new MetricFamilySamples.Sample(
-                                    "jvm_classes_unloaded_total", EMPTY_LABEL, EMPTY_LABEL,
-                                    clBean.getUnloadedClassCount()))));
+    sampleFamilies.add(new GaugeMetricFamily(
+          "jvm_classes_loaded",
+          "The number of classes that are currently loaded in the JVM",
+          clBean.getLoadedClassCount()));
+    sampleFamilies.add(new CounterMetricFamily(
+          "jvm_classes_loaded_total",
+          "The total number of classes that have been loaded since the JVM has started execution",
+          clBean.getTotalLoadedClassCount()));
+    sampleFamilies.add(new CounterMetricFamily(
+          "jvm_classes_unloaded_total",
+          "The total number of classes that have been unloaded since the JVM has started execution",
+          clBean.getUnloadedClassCount()));
   }
 
 

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/GarbageCollectorExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/GarbageCollectorExports.java
@@ -1,6 +1,7 @@
 package io.prometheus.client.hotspot;
 
 import io.prometheus.client.Collector;
+import io.prometheus.client.SummaryMetricFamily;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
@@ -35,28 +36,18 @@ public class GarbageCollectorExports extends Collector {
   }
 
   public List<MetricFamilySamples> collect() {
-    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+    SummaryMetricFamily gcCollection = new SummaryMetricFamily(
+        "jvm_gc_collection_seconds",
+        "Time spent in a given JVM garbage collector in seconds.",
+        Collections.singletonList("gc"));
     for (final GarbageCollectorMXBean gc : garbageCollectors) {
-      samples.add(
-          new MetricFamilySamples.Sample(
-              "jvm_gc_collection_seconds_sum",
-              Collections.singletonList("gc"),
-              Collections.singletonList(gc.getName()),
-              gc.getCollectionTime() / MILLISECONDS_PER_SECOND));
-      samples.add(
-          new MetricFamilySamples.Sample(
-              "jvm_gc_collection_seconds_count",
-              Collections.singletonList("gc"),
-              Collections.singletonList(gc.getName()),
-              gc.getCollectionCount()));
+        gcCollection.addMetric(
+            Collections.singletonList(gc.getName()),
+            gc.getCollectionCount(),
+            gc.getCollectionTime() / MILLISECONDS_PER_SECOND);
     }
     List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
-    mfs.add(new MetricFamilySamples(
-        "jvm_gc_collection_seconds",
-        Type.SUMMARY,
-        "Time spent in a given JVM garbage collector in seconds.",
-        samples));
-
+    mfs.add(gcCollection);
     return mfs;
   }
 }

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
@@ -1,6 +1,7 @@
 package io.prometheus.client.hotspot;
 
 import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
@@ -46,112 +47,61 @@ public class MemoryPoolsExports extends Collector {
   void addMemoryAreaMetrics(List<MetricFamilySamples> sampleFamilies) {
     MemoryUsage heapUsage = memoryBean.getHeapMemoryUsage();
     MemoryUsage nonHeapUsage = memoryBean.getNonHeapMemoryUsage();
-    ArrayList<MetricFamilySamples.Sample> usedSamples = new ArrayList<MetricFamilySamples.Sample>();
-    usedSamples.add(
-        new MetricFamilySamples.Sample(
-            "jvm_memory_bytes_used",
-            Collections.singletonList("area"),
-            Collections.singletonList("heap"),
-            heapUsage.getUsed()));
-    usedSamples.add(
-        new MetricFamilySamples.Sample(
-            "jvm_memory_bytes_used",
-            Collections.singletonList("area"),
-            Collections.singletonList("nonheap"),
-            nonHeapUsage.getUsed()));
-    sampleFamilies.add(
-        new MetricFamilySamples(
-            "jvm_memory_bytes_used",
-            Type.GAUGE,
-            "Used bytes of a given JVM memory area.",
-            usedSamples));
-    ArrayList<MetricFamilySamples.Sample> committedSamples = new ArrayList<MetricFamilySamples.Sample>();
-    committedSamples.add(
-        new MetricFamilySamples.Sample(
-            "jvm_memory_bytes_committed",
-            Collections.singletonList("area"),
-            Collections.singletonList("heap"),
-            heapUsage.getCommitted()));
-    committedSamples.add(
-        new MetricFamilySamples.Sample(
-            "jvm_memory_bytes_committed",
-            Collections.singletonList("area"),
-            Collections.singletonList("nonheap"),
-            nonHeapUsage.getCommitted()));
-    sampleFamilies.add(
-        new MetricFamilySamples(
-            "jvm_memory_bytes_committed",
-            Type.GAUGE,
-            "Committed (bytes) of a given JVM memory area.",
-            committedSamples));
-    ArrayList<MetricFamilySamples.Sample> maxSamples = new ArrayList<MetricFamilySamples.Sample>();
-    maxSamples.add(
-        new MetricFamilySamples.Sample(
-            "jvm_memory_bytes_max",
-            Collections.singletonList("area"),
-            Collections.singletonList("heap"),
-            heapUsage.getMax()));
-    maxSamples.add(
-        new MetricFamilySamples.Sample(
-            "jvm_memory_bytes_max",
-            Collections.singletonList("area"),
-            Collections.singletonList("nonheap"),
-            nonHeapUsage.getMax()));
-    sampleFamilies.add(
-        new MetricFamilySamples(
-            "jvm_memory_bytes_max",
-            Type.GAUGE,
-            "Maximum (bytes) of a given JVM memory area.",
-            maxSamples));
+
+    GaugeMetricFamily used = new GaugeMetricFamily(
+        "jvm_memory_bytes_used",
+        "Used bytes of a given JVM memory area.",
+        Collections.singletonList("area"));
+    used.addMetric(Collections.singletonList("heap"), heapUsage.getUsed());
+    used.addMetric(Collections.singletonList("nonheap"), nonHeapUsage.getUsed());
+    sampleFamilies.add(used);
+
+    GaugeMetricFamily committed = new GaugeMetricFamily(
+        "jvm_memory_bytes_committed",
+        "Committed (bytes) of a given JVM memory area.",
+        Collections.singletonList("area"));
+    committed.addMetric(Collections.singletonList("heap"), heapUsage.getCommitted());
+    committed.addMetric(Collections.singletonList("nonheap"), nonHeapUsage.getCommitted());
+    sampleFamilies.add(committed);
+
+    GaugeMetricFamily max = new GaugeMetricFamily(
+        "jvm_memory_bytes_max",
+        "Max (bytes) of a given JVM memory area.",
+        Collections.singletonList("area"));
+    max.addMetric(Collections.singletonList("heap"), heapUsage.getMax());
+    max.addMetric(Collections.singletonList("nonheap"), nonHeapUsage.getMax());
+    sampleFamilies.add(max);
   }
 
   void addMemoryPoolMetrics(List<MetricFamilySamples> sampleFamilies) {
-    List<MetricFamilySamples.Sample> usedSamples = new ArrayList<MetricFamilySamples.Sample>();
-    List<MetricFamilySamples.Sample> committedSamples = new ArrayList<MetricFamilySamples.Sample>();
-    List<MetricFamilySamples.Sample> maxSamples = new ArrayList<MetricFamilySamples.Sample>();
+    GaugeMetricFamily used = new GaugeMetricFamily(
+        "jvm_memory_pool_bytes_used",
+        "Used bytes of a given JVM memory pool.",
+        Collections.singletonList("pool"));
+    sampleFamilies.add(used);
+    GaugeMetricFamily committed = new GaugeMetricFamily(
+        "jvm_memory_pool_bytes_committed",
+        "Committed bytes of a given JVM memory pool.",
+        Collections.singletonList("pool"));
+    sampleFamilies.add(committed);
+    GaugeMetricFamily max = new GaugeMetricFamily(
+        "jvm_memory_pool_bytes_max",
+        "Max bytes of a given JVM memory pool.",
+        Collections.singletonList("pool"));
+    sampleFamilies.add(max);
     for (final MemoryPoolMXBean pool : poolBeans) {
       MemoryUsage poolUsage = pool.getUsage();
-      usedSamples.add(
-          new MetricFamilySamples.Sample(
-              "jvm_memory_pool_bytes_used",
-              Collections.singletonList("pool"),
-              Collections.singletonList(pool.getName()),
-              poolUsage.getUsed()));
-      committedSamples.add(
-          new MetricFamilySamples.Sample(
-              "jvm_memory_pool_bytes_committed",
-              Collections.singletonList("pool"),
-              Collections.singletonList(pool.getName()),
-              poolUsage.getCommitted()));
-      maxSamples.add(
-          new MetricFamilySamples.Sample(
-              "jvm_memory_pool_bytes_max",
-              Collections.singletonList("pool"),
-              Collections.singletonList(pool.getName()),
-              poolUsage.getMax()));
+      used.addMetric(
+          Collections.singletonList(pool.getName()),
+          poolUsage.getUsed());
+      committed.addMetric(
+          Collections.singletonList(pool.getName()),
+          poolUsage.getCommitted());
+      max.addMetric(
+          Collections.singletonList(pool.getName()),
+          poolUsage.getMax());
     }
-    sampleFamilies.add(
-        new MetricFamilySamples(
-            "jvm_memory_pool_bytes_used",
-            Type.GAUGE,
-            "Used bytes of a given JVM memory pool.",
-            usedSamples));
-
-    sampleFamilies.add(
-        new MetricFamilySamples(
-            "jvm_memory_pool_bytes_committed",
-            Type.GAUGE,
-            "Limit (bytes) of a given JVM memory pool.",
-            committedSamples));
-
-    sampleFamilies.add(
-        new MetricFamilySamples(
-            "jvm_memory_pool_bytes_max",
-            Type.GAUGE,
-            "Max (bytes) of a given JVM memory pool.",
-            maxSamples));
   }
-
 
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import io.prometheus.client.Collector;
+import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.GaugeMetricFamily;
 
 /**
  * Exports the standard exports common across all prometheus clients.
@@ -50,28 +52,22 @@ public class StandardExports extends Collector {
       this.linux = (osBean.getName().indexOf("Linux") == 0);
   }
 
-  private static MetricFamilySamples singleMetric(String name, Type type, String help, double value) {
-    List<MetricFamilySamples.Sample> samples = Collections.singletonList(
-        new MetricFamilySamples.Sample(name, Collections.<String>emptyList(), Collections.<String>emptyList(), value));
-    return new MetricFamilySamples(name, type, help, samples);
-  }
-
   private final static double KB = 1024;
 
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
 
-    mfs.add(singleMetric("process_cpu_seconds_total", Type.COUNTER, "Total user and system CPU time spent in seconds.",
+    mfs.add(new CounterMetricFamily("process_cpu_seconds_total", "Total user and system CPU time spent in seconds.",
         osBean.getProcessCpuTime() / NANOSECONDS_PER_SECOND));
 
-    mfs.add(singleMetric("process_start_time_seconds", Type.GAUGE, "Start time of the process since unix epoch in seconds.",
+    mfs.add(new GaugeMetricFamily("process_start_time_seconds","Start time of the process since unix epoch in seconds.",
         runtimeBean.getStartTime() / MILLISECONDS_PER_SECOND));
 
     if (unix) {
       UnixOperatingSystemMXBean unixBean = (UnixOperatingSystemMXBean) osBean;
-      mfs.add(singleMetric("process_open_fds", Type.GAUGE, "Number of open file descriptors.",
+      mfs.add(new GaugeMetricFamily("process_open_fds", "Number of open file descriptors.",
           unixBean.getOpenFileDescriptorCount()));
-      mfs.add(singleMetric("process_max_fds", Type.GAUGE, "Maximum number of open file descriptors.",
+      mfs.add(new GaugeMetricFamily("process_max_fds", "Maximum number of open file descriptors.",
           unixBean.getMaxFileDescriptorCount()));
     }
 
@@ -97,11 +93,11 @@ public class StandardExports extends Collector {
       String line;
       while ((line = br.readLine()) != null) {
         if (line.startsWith("VmSize:")) {
-          mfs.add(singleMetric("process_virtual_memory_bytes", Type.GAUGE,
+          mfs.add(new GaugeMetricFamily("process_virtual_memory_bytes",
               "Virtual memory size in bytes.",
               Float.parseFloat(line.split("\\s+")[1]) * KB));
         } else if (line.startsWith("VmRSS:")) {
-          mfs.add(singleMetric("process_resident_memory_bytes", Type.GAUGE,
+          mfs.add(new GaugeMetricFamily("process_resident_memory_bytes",
               "Resident memory size in bytes.",
               Float.parseFloat(line.split("\\s+")[1]) * KB));
         }

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -1,11 +1,12 @@
 package io.prometheus.client.hotspot;
 
 import io.prometheus.client.Collector;
+import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.GaugeMetricFamily;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,8 +27,6 @@ import java.util.List;
  * </pre>
  */
 public class ThreadExports extends Collector {
-  private static final List<String> EMPTY_LABEL = Collections.emptyList();
-
   private final ThreadMXBean threadBean;
 
   public ThreadExports() {
@@ -40,44 +39,28 @@ public class ThreadExports extends Collector {
 
   void addThreadMetrics(List<MetricFamilySamples> sampleFamilies) {
     sampleFamilies.add(
-            new MetricFamilySamples(
-                    "jvm_threads_current",
-                    Type.GAUGE,
-                    "Current thread count of a JVM",
-                    Collections.singletonList(
-                            new MetricFamilySamples.Sample(
-                                    "jvm_threads_current", EMPTY_LABEL, EMPTY_LABEL,
-                                    threadBean.getThreadCount()))));
+        new GaugeMetricFamily(
+          "jvm_threads_current",
+          "Current thread count of a JVM",
+          threadBean.getThreadCount()));
 
     sampleFamilies.add(
-            new MetricFamilySamples(
-                    "jvm_threads_daemon",
-                    Type.GAUGE,
-                    "Daemon thread count of a JVM",
-                    Collections.singletonList(
-                            new MetricFamilySamples.Sample(
-                                    "jvm_threads_daemon", EMPTY_LABEL, EMPTY_LABEL,
-                                    threadBean.getDaemonThreadCount()))));
+        new GaugeMetricFamily(
+          "jvm_threads_daemon",
+          "Daemon thread count of a JVM",
+          threadBean.getDaemonThreadCount()));
 
     sampleFamilies.add(
-            new MetricFamilySamples(
-                    "jvm_peak_threads",
-                    Type.GAUGE,
-                    "Peak thread count of a JVM",
-                    Collections.singletonList(
-                            new MetricFamilySamples.Sample(
-                                    "jvm_threads_peak", EMPTY_LABEL, EMPTY_LABEL,
-                                    threadBean.getPeakThreadCount()))));
+        new GaugeMetricFamily(
+          "jvm_threads_peak",
+          "Peak thread count of a JVM",
+          threadBean.getPeakThreadCount()));
 
     sampleFamilies.add(
-            new MetricFamilySamples(
-                    "jvm_threads_started_total",
-                    Type.COUNTER,
-                    "Started thread count of a JVM",
-                    Collections.singletonList(
-                            new MetricFamilySamples.Sample(
-                                    "jvm_threads_started_total", EMPTY_LABEL, EMPTY_LABEL,
-                                    threadBean.getTotalStartedThreadCount()))));
+        new CounterMetricFamily(
+          "jvm_threads_started_total",
+          "Started thread count of a JVM",
+          threadBean.getTotalStartedThreadCount()));
   }
 
 


### PR DESCRIPTION
Following from the Python client, add these as convenience functions
to make writing custom collectors easier by reducing boilerplate.

Histogram is excluded, as it'd not save much.

Switch all hotspot metrics to use these.

Fix family name of jvm_threads_peak.

@beorn7 This is something I've done in Python that's worked out well for custom collectors. This is needed before the describe work is sane to do in Java.