### PR TITLE
Add describe and autodescribe to detect dupes.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -129,6 +129,25 @@ public abstract class Collector {
     return (T)this;
   }
 
+  public interface Describable {
+    /**
+     *  Provide a list of metric families this Collector is expected to return.
+     *
+     *  These should exclude the samples. This is used by the registry to
+     *  detect collisions and duplicate registrations.
+     *
+     *  Usually custom collectors do not have to implement Describable. If
+     *  Describable is not implemented and the CollectorRegistry was created
+     *  with auto desribe enabled (which is the case for the default registry)
+     *  then {@link collect} will be called at registration time instead of
+     *  describe. If this could cause problems, either implement a proper
+     *  describe, or if that's not practical have describe return an empty
+     *  list.
+     */
+    public List<MetricFamilySamples> describe();
+  }
+
+
   /* Various utility functions for implementing Collectors. */
 
   /**

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -64,7 +64,7 @@ import java.util.Map;
  * These can be aggregated and processed together much more easily in the Promtheus 
  * server than individual metrics for each labelset.
  */
-public class Counter extends SimpleCollector<Counter.Child> {
+public class Counter extends SimpleCollector<Counter.Child> implements Collector.Describable {
 
   Counter(Builder b) {
     super(b);
@@ -146,6 +146,12 @@ public class Counter extends SimpleCollector<Counter.Child> {
 
     List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
     mfsList.add(mfs);
+    return mfsList;
+  }
+
+  public List<MetricFamilySamples> describe() {
+    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
+    mfsList.add(new CounterMetricFamily(fullname, help, labelNames));
     return mfsList;
   }
 }

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -62,7 +62,7 @@ import java.util.Map;
  * These can be aggregated and processed together much more easily in the Prometheus
  * server than individual metrics for each labelset.
  */
-public class Gauge extends SimpleCollector<Gauge.Child> {
+public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Describable {
 
   Gauge(Builder b) {
     super(b);
@@ -251,6 +251,12 @@ public class Gauge extends SimpleCollector<Gauge.Child> {
 
     List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
     mfsList.add(mfs);
+    return mfsList;
+  }
+
+  public List<MetricFamilySamples> describe() {
+    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
+    mfsList.add(new GaugeMetricFamily(fullname, help, labelNames));
     return mfsList;
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -52,7 +52,7 @@ import java.util.Map;
  * {@link Histogram.Builder#exponentialBuckets(double, double, int) exponentialBuckets}
  * offer easy ways to set common bucket patterns.
  */
-public class Histogram extends SimpleCollector<Histogram.Child> {
+public class Histogram extends SimpleCollector<Histogram.Child> implements Collector.Describable {
   private final double[] buckets;
 
   Histogram(Builder b) {
@@ -266,6 +266,12 @@ public class Histogram extends SimpleCollector<Histogram.Child> {
     MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.HISTOGRAM, help, samples);
     List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
     mfsList.add(mfs);
+    return mfsList;
+  }
+
+  public List<MetricFamilySamples> describe() {
+    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
+    mfsList.add(new MetricFamilySamples(fullname, Type.HISTOGRAM, help, new ArrayList<MetricFamilySamples.Sample>()));
     return mfsList;
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -70,7 +70,7 @@ import java.util.concurrent.TimeUnit;
  *
  * See https://prometheus.io/docs/practices/histograms/ for more info on quantiles.
  */
-public class Summary extends SimpleCollector<Summary.Child> {
+public class Summary extends SimpleCollector<Summary.Child> implements Counter.Describable {
 
   final List<Quantile> quantiles; // Can be empty, but can never be null.
   final long maxAgeSeconds;
@@ -281,6 +281,12 @@ public class Summary extends SimpleCollector<Summary.Child> {
     MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.SUMMARY, help, samples);
     List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
     mfsList.add(mfs);
+    return mfsList;
+  }
+
+  public List<MetricFamilySamples> describe() {
+    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
+    mfsList.add(new SummaryMetricFamily(fullname, help, labelNames));
     return mfsList;
   }
 

--- a/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
@@ -81,5 +81,60 @@ public class CollectorRegistryTest {
     registry.register(new EmptyCollector());
     assertFalse(registry.metricFamilySamples().hasMoreElements());
   }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testCounterAndGaugeWithSameNameThrows() {
+    Gauge.build().name("g").help("h").register(registry);
+    Counter.build().name("g").help("h").register(registry);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testCounterAndSummaryWithSameNameThrows() {
+    Counter.build().name("s").help("h").register(registry);
+    Summary.build().name("s").help("h").register(registry);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testCounterSumAndSummaryWithSameNameThrows() {
+    Counter.build().name("s_sum").help("h").register(registry);
+    Summary.build().name("s").help("h").register(registry);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testHistogramAndSummaryWithSameNameThrows() {
+    Histogram.build().name("s").help("h").register(registry);
+    Summary.build().name("s").help("h").register(registry);
+  }
+
+  @Test
+  public void testCanUnAndReregister() {
+    Histogram h = Histogram.build().name("s").help("h").create();
+    registry.register(h);
+    registry.unregister(h);
+    registry.register(h);
+  }
+
+  class MyCollector extends Collector {
+    public List<MetricFamilySamples> collect() {
+      List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+      mfs.add(new GaugeMetricFamily("g", "help", 42));
+      return mfs;
+    }
+  }
+
+  @Test
+  public void testAutoDescribeDisabledByDefault() {
+    CollectorRegistry r = new CollectorRegistry();
+    new MyCollector().register(r);
+    // This doesn't throw.
+    new MyCollector().register(r);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testAutoDescribeThrowsOnReregisteringCustomCollector() {
+    CollectorRegistry r = new CollectorRegistry(true);
+    new MyCollector().register(r);
+    new MyCollector().register(r);
+  }
   
 }

--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 /**
  * Collect Dropwizard metrics from a MetricRegistry.
  */
-public class DropwizardExports extends io.prometheus.client.Collector {
+public class DropwizardExports extends io.prometheus.client.Collector implements io.prometheus.client.Collector.Describable {
     private MetricRegistry registry;
     private static final Logger LOGGER = Logger.getLogger(DropwizardExports.class.getName());
 
@@ -145,5 +145,9 @@ public class DropwizardExports extends io.prometheus.client.Collector {
             mfSamples.addAll(fromMeter(entry.getKey(), entry.getValue()));
         }
         return mfSamples;
+    }
+
+    public List<MetricFamilySamples> describe() {
+      return new ArrayList<MetricFamilySamples>();
     }
 }

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/SpringBootMetricsCollector.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/SpringBootMetricsCollector.java
@@ -23,7 +23,7 @@ import java.util.List;
  * </code></pre>
  */
 @Component
-public class SpringBootMetricsCollector extends Collector {
+public class SpringBootMetricsCollector extends Collector implements Collector.Describable {
   private final Collection<PublicMetrics> publicMetrics;
 
   @Autowired
@@ -45,5 +45,9 @@ public class SpringBootMetricsCollector extends Collector {
       }
     }
     return samples;
+  }
+
+  public List<MetricFamilySamples> describe() {
+    return new ArrayList<MetricFamilySamples>();
   }
 }


### PR DESCRIPTION
This works largely the same as this feature in the
Python client.

This works by adding an optional Describable interface to collectors,
which returns data in the same format as collect (though hopefully
without the samples). If implemented it is called at registration time.

If describe is not present and auto describe is set on the
registry, then collect is called instead. This is enabled by default on
the default registry, but disabled elsewhere.

Put in empty describes on some custom collectors that
deal with arbitrary data.

Fixes #52