### PR TITLE
dropwizard histogram: export min, max, mean, median, stdDev

### DIFF
--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -78,6 +78,11 @@ public class DropwizardExports extends io.prometheus.client.Collector implements
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.98"), snapshot.get98thPercentile() * factor),
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.99"), snapshot.get99thPercentile() * factor),
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.999"), snapshot.get999thPercentile() * factor),
+                new MetricFamilySamples.Sample(name + "_min", new ArrayList<String>(), new ArrayList<String>(), snapshot.getMin()),
+                new MetricFamilySamples.Sample(name + "_max", new ArrayList<String>(), new ArrayList<String>(), snapshot.getMax()),
+                new MetricFamilySamples.Sample(name + "_mean", new ArrayList<String>(), new ArrayList<String>(), snapshot.getMean()),
+                new MetricFamilySamples.Sample(name + "_median", new ArrayList<String>(), new ArrayList<String>(), snapshot.getMedian()),
+                new MetricFamilySamples.Sample(name + "_stdDev", new ArrayList<String>(), new ArrayList<String>(), snapshot.getStdDev()),
                 new MetricFamilySamples.Sample(name + "_count", new ArrayList<String>(), new ArrayList<String>(), count)
         );
         return Arrays.asList(

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
@@ -118,6 +118,11 @@ public class DropwizardExportsTest {
             i += 1;
         }
         assertEquals(new Double(100), registry.getSampleValue("hist_count"));
+        assertEquals(new Double(0), registry.getSampleValue("hist_min"));
+        assertEquals(new Double(99), registry.getSampleValue("hist_max"));
+        assertEquals(new Double(49.5), registry.getSampleValue("hist_mean"));
+        assertEquals(new Double(49), registry.getSampleValue("hist_median"));
+        assertEquals(new Double(28.86607004772212), registry.getSampleValue("hist_stdDev"));
         for (Double d : Arrays.asList(0.75, 0.95, 0.98, 0.99)) {
             assertEquals(new Double((d - 0.01) * 100), registry.getSampleValue("hist",
                     new String[]{"quantile"}, new String[]{d.toString()}));


### PR DESCRIPTION
I noticed that some stats from Dropwizard histograms weren't exported, and simply added them. I was primarily interested in the historical extremes (min, max), but added the others while at it. 