### PR TITLE
Expose `SimpleTimer` to keep timing logic that returns elapsed seconds

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -141,16 +141,16 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
   public static class Timer implements Closeable {
     private final Child child;
     private final long start;
-    private Timer(Child child) {
+    private Timer(Child child, long start) {
       this.child = child;
-      start = Child.timeProvider.nanoTime();
+      this.start = start;
     }
     /**
      * Observe the amount of time in seconds since {@link Child#startTimer} was called.
      * @return Measured duration in seconds since {@link Child#startTimer} was called.
      */
     public double observeDuration() {
-        double elapsed = (Child.timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND;
+        double elapsed = SimpleTimer.elapsedSecondsFromNanos(start, SimpleTimer.defaultTimeProvider.nanoTime());
         child.observe(elapsed);
         return elapsed;
     }
@@ -193,7 +193,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
     private final DoubleAdder[] cumulativeCounts;
     private final DoubleAdder sum = new DoubleAdder();
 
-    static TimeProvider timeProvider = new TimeProvider();
+
     /**
      * Observe the given amount.
      */
@@ -213,7 +213,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
      * Call {@link Timer#observeDuration} at the end of what you want to measure the duration of.
      */
     public Timer startTimer() {
-      return new Timer(this);
+      return new Timer(this, SimpleTimer.defaultTimeProvider.nanoTime());
     }
     /**
      * Get the value of the Histogram.
@@ -279,9 +279,5 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
     return buckets;
   }
 
-  static class TimeProvider {
-    long nanoTime() {
-      return System.nanoTime();
-    }
-  }
+
 }

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -32,11 +32,11 @@ import java.util.List;
  * {@link #remove} and {@link #clear} can be used to remove children.
  * <p>
  * <em>Warning #1:</em> Metrics that don't always export something are difficult to monitor, if you know in advance
- * what labels will be in use you should initilise them be calling {@link #labels}.
+ * what labels will be in use you should initialise them be calling {@link #labels}.
  * This is done for you for metrics with no labels.
  * <p>
  * <em>Warning #2:</em> While labels are very powerful, avoid overly granular metric labels. 
- * The combinatorial explosion of breaking out a metric in many dimensions can produce huge numberts
+ * The combinatorial explosion of breaking out a metric in many dimensions can produce huge numbers
  * of timeseries, which will then take longer and more resources to process.
  * <p>
  * As a rule of thumb aim to keep the cardinality of metrics below ten, and limit where the

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleTimer.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleTimer.java
@@ -1,0 +1,69 @@
+package io.prometheus.client;
+
+/**
+ * SimpleTimer, to measure elapsed duration in seconds as a double.
+ *
+ * <p>
+ * This is a helper class intended to measure latencies and encapsulate the conversion to seconds without losing precision.
+ *
+ * <p>
+ * Keep in mind that preferred approaches avoid using this mechanism if possible, since latency metrics broken out by
+ * outcome should be minimized; {@link Summary#startTimer()} and {@link Histogram#startTimer()} are preferred.
+ * Consider moving outcome labels to a separate metric like a counter.
+ *
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   class YourClass {
+ *     static final Summary requestLatency = Summary.build()
+ *         .name("requests_latency_seconds")
+ *         .help("Request latency in seconds.")
+ *         .labelNames("aLabel")
+ *         .register();
+ *
+ *     void processRequest(Request req) {
+ *        SimpleTimer requestTimer = new SimpleTimer();
+ *        try {
+ *          // Your code here.
+ *        } finally {
+ *          requestTimer.labels("aLabelValue").observe(requestTimer.elapsedSeconds());
+ *        }
+ *     }
+ *   }
+ * }
+ * </pre>
+ *
+ */
+public class SimpleTimer {
+  private final long start;
+  static TimeProvider defaultTimeProvider = new TimeProvider();
+  private final TimeProvider timeProvider;
+
+  static class TimeProvider {
+    long nanoTime() {
+      return System.nanoTime();
+    }
+  }
+
+  // Visible for testing.
+  SimpleTimer(TimeProvider timeProvider) {
+    this.timeProvider = timeProvider;
+    start = timeProvider.nanoTime();
+  }
+
+  public SimpleTimer() {
+    this(defaultTimeProvider);
+  }
+
+  /**
+   * @return Measured duration in seconds since {@link SimpleTimer} was constructed.
+   */
+  public double elapsedSeconds() {
+    return elapsedSecondsFromNanos(start, timeProvider.nanoTime());
+  }
+
+  public static double elapsedSecondsFromNanos(long startNanos, long endNanos) {
+      return (endNanos - startNanos) / Collector.NANOSECONDS_PER_SECOND;
+  }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -142,43 +142,22 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
   }
 
 
-  public static class SimpleTimer {
-    private final long start;
-    private final TimeProvider timeProvider;
-
-    public SimpleTimer(TimeProvider timeProvider) {
-      this.timeProvider = timeProvider;
-      start = timeProvider.nanoTime();
-    }
-
-    public SimpleTimer() {
-      this(Child.timeProvider);
-    }
-
-    /**
-     * @return Measured duration in seconds since {@link SimpleTimer} was constructed.
-     */
-    public double elapsedSeconds() {
-      return (timeProvider.nanoTime() - start) / NANOSECONDS_PER_SECOND;
-    }
-  }
-
   /**
    * Represents an event being timed.
    */
   public static class Timer implements Closeable {
     private final Child child;
-    private final SimpleTimer innerTimer;
-    private Timer(Child child) {
+    private final long start;
+    private Timer(Child child, long start) {
       this.child = child;
-      innerTimer = new SimpleTimer(Child.timeProvider);
+      this.start = start;
     }
     /**
      * Observe the amount of time in seconds since {@link Child#startTimer} was called.
      * @return Measured duration in seconds since {@link Child#startTimer} was called.
      */
     public double observeDuration() {
-      double elapsed = innerTimer.elapsedSeconds();
+      double elapsed = SimpleTimer.elapsedSecondsFromNanos(start, SimpleTimer.defaultTimeProvider.nanoTime());
       child.observe(elapsed);
       return elapsed;
     }
@@ -229,8 +208,6 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
     private final List<Quantile> quantiles;
     private final TimeWindowQuantiles quantileValues;
 
-    static TimeProvider timeProvider = new TimeProvider();
-
     private Child(List<Quantile> quantiles, long maxAgeSeconds, int ageBuckets) {
       this.quantiles = quantiles;
       if (quantiles.size() > 0) {
@@ -256,7 +233,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
      * Call {@link Timer#observeDuration} at the end of what you want to measure the duration of.
      */
     public Timer startTimer() {
-      return new Timer(this);
+      return new Timer(this, SimpleTimer.defaultTimeProvider.nanoTime());
     }
     /**
      * Get the value of the Summary.
@@ -312,9 +289,4 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
     return mfsList;
   }
 
-  static class TimeProvider {
-    long nanoTime() {
-      return System.nanoTime();
-    }
-  }
 }

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -27,7 +27,7 @@ public class HistogramTest {
 
   @After
   public void tearDown() {
-    Histogram.Child.timeProvider = new Histogram.TimeProvider();
+    SimpleTimer.defaultTimeProvider = new SimpleTimer.TimeProvider();
   }
 
   private double getCount() {
@@ -103,7 +103,7 @@ public class HistogramTest {
 
   @Test
   public void testTimer() {
-    Histogram.Child.timeProvider = new Histogram.TimeProvider() {
+    SimpleTimer.defaultTimeProvider = new SimpleTimer.TimeProvider() {
       long value = (long)(30 * 1e9);
       long nanoTime() {
         value += (long)(10 * 1e9);

--- a/simpleclient/src/test/java/io/prometheus/client/SimpleTimerTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SimpleTimerTest.java
@@ -1,0 +1,23 @@
+package io.prometheus.client;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SimpleTimerTest {
+    @Test
+    public void elapsedSeconds() throws Exception {
+        SimpleTimer.TimeProvider provider = new SimpleTimer.TimeProvider() {
+            long value = (long)(30 * 1e9);
+            long nanoTime() {
+                value += (long)(10 * 1e9);
+                return value;
+            }
+        };
+
+        SimpleTimer timer = new SimpleTimer(provider);
+        assertEquals(10, timer.elapsedSeconds(), .001);
+
+    }
+
+}

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -39,7 +39,7 @@ public class SummaryTest {
 
   @After
   public void tearDown() {
-    Summary.Child.timeProvider = new Summary.TimeProvider();
+    SimpleTimer.defaultTimeProvider = new SimpleTimer.TimeProvider();
   }
 
   private double getCount() {
@@ -104,7 +104,7 @@ public class SummaryTest {
 
   @Test
   public void testTimer() {
-    Summary.Child.timeProvider = new Summary.TimeProvider() {
+    SimpleTimer.defaultTimeProvider = new SimpleTimer.TimeProvider() {
       long value = (long)(30 * 1e9);
       long nanoTime() {
         value += (long)(10 * 1e9);


### PR DESCRIPTION
This is regards to https://github.com/prometheus/client_java/issues/165

As team mates have begun using `Summary` objects, they find that they can't use the built in timer as they have a label like `success="true|false"` they want to include when recording the observation.

I've noticed 2 results: they use something like Guava's `StopWatch` (https://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/Stopwatch.html) class that returns longs (ie using `Duration.Seconds` truncates) or do the math in elapsed milliseconds as longs. I'm convinced of the Prometheus doc recommendations to use seconds (and @brian-brazil article at https://www.robustperception.io/who-wants-seconds/) so I wanted to create a very simple option that supports seconds as doubles.