### PR TITLE
Add `time()` methods that remove needs for `finally` blocks

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -181,6 +181,26 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
     public Timer startTimer() {
       return new Timer(this);
     }
+
+    /**
+     * Executes runnable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+     *
+     * @param timeable Code that is being timed
+     * @return Measured duration in seconds for timeable to complete.
+     */
+    public double setToTime(Runnable timeable){
+      Timer timer = startTimer();
+
+      double elapsed;
+      try {
+        timeable.run();
+      } finally {
+        elapsed = timer.setDuration();
+      }
+
+      return elapsed;
+    }
+
     /**
      * Get the value of the gauge.
      */
@@ -239,6 +259,16 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
    */
   public Timer startTimer() {
     return noLabelsChild.startTimer();
+  }
+
+  /**
+   * Executes runnable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+   *
+   * @param timeable Code that is being timed
+   * @return Measured duration in seconds for timeable to complete.
+   */
+  public double setToTime(Runnable timeable){
+    return noLabelsChild.setToTime(timeable);
   }
 
   @Override

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -36,6 +36,13 @@ import java.util.Map;
  *          requestTimer.observeDuration();
  *        }
  *     }
+ *
+ *     // Or if using Java 8 lambdas.
+ *     void processRequestLambda(Request req) {
+ *        requestLatency.time(() -> {
+ *          // Your code here.
+ *        });
+ *     }
  *   }
  * }
  * </pre>
@@ -172,6 +179,25 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
    * {@link SimpleCollector#remove} or {@link SimpleCollector#clear}.
    */
   public static class Child {
+
+    /**
+     * Executes runnable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+     *
+     * @param timeable Code that is being timed
+     * @return Measured duration in seconds for timeable to complete.
+     */
+    public double time(Runnable timeable) {
+      Timer timer = startTimer();
+
+      double elapsed;
+      try {
+        timeable.run();
+      } finally {
+        elapsed = timer.observeDuration();
+      }
+      return elapsed;
+    }
+
     public static class Value {
       public final double sum;
       public final double[] buckets;
@@ -245,6 +271,16 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
    */
   public Timer startTimer() {
     return noLabelsChild.startTimer();
+  }
+
+  /**
+   * Executes runnable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+   *
+   * @param timeable Code that is being timed
+   * @return Measured duration in seconds for timeable to complete.
+   */
+  public double time(Runnable timeable){
+    return noLabelsChild.time(timeable);
   }
 
   @Override

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -40,7 +40,15 @@ import java.util.concurrent.TimeUnit;
  *          requestTimer.observeDuration();
  *        }
  *     }
- *   }
+ *
+ *     // Or if using Java 8 and lambdas.
+ *     void processRequestLambda(Request req) {
+ *       receivedBytes.observe(req.size());
+ *       requestLatency.time(() -> {
+ *         // Your code here.
+ *       });
+ *     }
+ * }
  * }
  * </pre>
  * This would allow you to track request rate, average latency and average request size.
@@ -178,6 +186,25 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
    * {@link SimpleCollector#remove} or {@link SimpleCollector#clear}.
    */
   public static class Child {
+
+    /**
+     * Executes runnable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+     *
+     * @param timeable Code that is being timed
+     * @return Measured duration in seconds for timeable to complete.
+     */
+    public double time(Runnable timeable) {
+      Timer timer = startTimer();
+
+      double elapsed;
+      try {
+        timeable.run();
+      } finally {
+        elapsed = timer.observeDuration();
+      }
+      return elapsed;
+    }
+
     public static class Value {
       public final double count;
       public final double sum;
@@ -260,6 +287,16 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
    */
   public Timer startTimer() {
     return noLabelsChild.startTimer();
+  }
+
+  /**
+   * Executes runnable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+   *
+   * @param timeable Code that is being timed
+   * @return Measured duration in seconds for timeable to complete.
+   */
+  public double time(Runnable timeable){
+    return noLabelsChild.time(timeable);
   }
 
   @Override

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
@@ -82,8 +82,17 @@ public class GaugeTest {
         return value;
       }
     };
+
+    double elapsed = noLabels.setToTime(new Runnable() {
+      @Override
+      public void run() {
+        //no op
+      }
+    });
+    assertEquals(10, elapsed, .001);
+
     Gauge.Timer timer = noLabels.startTimer();
-    double elapsed = timer.setDuration();
+    elapsed = timer.setDuration();
     assertEquals(10, getValue(), .001);
     assertEquals(10, elapsed, .001);
   }

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -110,10 +110,19 @@ public class HistogramTest {
         return value;
       }
     };
+
+    double elapsed = noLabels.time(new Runnable() {
+      @Override
+      public void run() {
+        //no op
+      }
+    });
+    assertEquals(10, elapsed, .001);
+
     Histogram.Timer timer = noLabels.startTimer();
-    double elapsed = timer.observeDuration();
-    assertEquals(1, getCount(), .001);
-    assertEquals(10, getSum(), .001);
+    elapsed = timer.observeDuration();
+    assertEquals(2, getCount(), .001);
+    assertEquals(20, getSum(), .001);
     assertEquals(10, elapsed, .001);
   }
   

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -111,10 +111,19 @@ public class SummaryTest {
         return value;
       }
     };
+
+    double elapsed = noLabels.time(new Runnable() {
+      @Override
+      public void run() {
+        //no op
+      }
+    });
+    assertEquals(10, elapsed, .001);
+
     Summary.Timer timer = noLabels.startTimer();
-    double elapsed = timer.observeDuration();
-    assertEquals(1, getCount(), .001);
-    assertEquals(10, getSum(), .001);
+    elapsed = timer.observeDuration();
+    assertEquals(2, getCount(), .001);
+    assertEquals(20, getSum(), .001);
     assertEquals(10, elapsed, .001);
   }
   


### PR DESCRIPTION
This allows for lambda syntax friendly timings.