### PR TITLE
MetricFamily#addMetric() should return this to allow builder like usage

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CounterMetricFamily.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CounterMetricFamily.java
@@ -48,10 +48,11 @@ public class CounterMetricFamily extends Collector.MetricFamilySamples {
     this.labelNames = labelNames;
   }
 
-  public void addMetric(List<String> labelValues, double value) {
+  public CounterMetricFamily addMetric(List<String> labelValues, double value) {
     if (labelValues.size() != labelNames.size()) {
       throw new IllegalArgumentException("Incorrect number of labels.");
     }
     samples.add(new Sample(name, labelNames, labelValues, value));
+    return this;
   }
 }

--- a/simpleclient/src/main/java/io/prometheus/client/GaugeMetricFamily.java
+++ b/simpleclient/src/main/java/io/prometheus/client/GaugeMetricFamily.java
@@ -48,10 +48,11 @@ public class GaugeMetricFamily extends Collector.MetricFamilySamples {
     this.labelNames = labelNames;
   }
 
-  public void addMetric(List<String> labelValues, double value) {
+  public GaugeMetricFamily addMetric(List<String> labelValues, double value) {
     if (labelValues.size() != labelNames.size()) {
       throw new IllegalArgumentException("Incorrect number of labels.");
     }
     samples.add(new Sample(name, labelNames, labelValues, value));
+    return this;
   }
 }

--- a/simpleclient/src/main/java/io/prometheus/client/SummaryMetricFamily.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SummaryMetricFamily.java
@@ -49,10 +49,10 @@ public class SummaryMetricFamily extends Collector.MetricFamilySamples {
     this.quantiles = quantiles;
   }
 
-  public void addMetric(List<String> labelValues, double count, double sum) {
-    addMetric(labelValues, count, sum, Collections.<Double>emptyList());
+  public SummaryMetricFamily addMetric(List<String> labelValues, double count, double sum) {
+    return addMetric(labelValues, count, sum, Collections.<Double>emptyList());
   }
-  public void addMetric(List<String> labelValues, double count, double sum, List<Double> quantiles) {
+  public SummaryMetricFamily addMetric(List<String> labelValues, double count, double sum, List<Double> quantiles) {
     if (labelValues.size() != labelNames.size()) {
       throw new IllegalArgumentException("Incorrect number of labels.");
     }
@@ -68,5 +68,6 @@ public class SummaryMetricFamily extends Collector.MetricFamilySamples {
       labelValuesWithQuantile.add(Collector.doubleToGoString(this.quantiles.get(i)));
       samples.add(new Sample(name, labelNamesWithQuantile, labelValuesWithQuantile, quantiles.get(i)));
     }
+    return this;
   }
 }

--- a/simpleclient/src/test/java/io/prometheus/client/CounterMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterMetricFamilyTest.java
@@ -44,16 +44,12 @@ public class CounterMetricFamilyTest {
 
   @Test
   public void testBuilderStyleUsage() {
-
     class YourCustomCollector extends Collector {
-
       public List<MetricFamilySamples> collect() {
         return Arrays.<MetricFamilySamples>asList(
-
             new CounterMetricFamily("my_metric", "help", Arrays.asList("name"))
                 .addMetric(Arrays.asList("value1"), 1.0)
                 .addMetric(Arrays.asList("value2"), 2.0)
-
         );
       }
     }
@@ -65,7 +61,6 @@ public class CounterMetricFamilyTest {
     assertEquals(2.0,
         registry.getSampleValue("my_metric", new String[]{"name"}, new String[]{"value2"})
             .doubleValue(), .001);
-
   }
 
 }

--- a/simpleclient/src/test/java/io/prometheus/client/CounterMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterMetricFamilyTest.java
@@ -42,4 +42,30 @@ public class CounterMetricFamilyTest {
     assertEquals(5.0, registry.getSampleValue("my_other_counter", new String[]{"labelname"}, new String[]{"bar"}).doubleValue(), .001);
   }
 
+  @Test
+  public void testBuilderStyleUsage() {
+
+    class YourCustomCollector extends Collector {
+
+      public List<MetricFamilySamples> collect() {
+        return Arrays.<MetricFamilySamples>asList(
+
+            new CounterMetricFamily("my_metric", "help", Arrays.asList("name"))
+                .addMetric(Arrays.asList("value1"), 1.0)
+                .addMetric(Arrays.asList("value2"), 2.0)
+
+        );
+      }
+    }
+    new YourCustomCollector().register(registry);
+
+    assertEquals(1.0,
+        registry.getSampleValue("my_metric", new String[]{"name"}, new String[]{"value1"})
+            .doubleValue(), .001);
+    assertEquals(2.0,
+        registry.getSampleValue("my_metric", new String[]{"name"}, new String[]{"value2"})
+            .doubleValue(), .001);
+
+  }
+
 }

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeMetricFamilyTest.java
@@ -42,4 +42,30 @@ public class GaugeMetricFamilyTest {
     assertEquals(5.0, registry.getSampleValue("my_other_gauge", new String[]{"labelname"}, new String[]{"bar"}).doubleValue(), .001);
   }
 
+  @Test
+  public void testBuilderStyleUsage() {
+
+    class YourCustomCollector extends Collector {
+
+      public List<MetricFamilySamples> collect() {
+        return Arrays.<MetricFamilySamples>asList(
+
+            new GaugeMetricFamily("my_metric", "help", Arrays.asList("name"))
+                .addMetric(Arrays.asList("value1"), 1.0)
+                .addMetric(Arrays.asList("value2"), 2.0)
+
+        );
+      }
+    }
+    new YourCustomCollector().register(registry);
+
+    assertEquals(1.0,
+        registry.getSampleValue("my_metric", new String[]{"name"}, new String[]{"value1"})
+            .doubleValue(), .001);
+    assertEquals(2.0,
+        registry.getSampleValue("my_metric", new String[]{"name"}, new String[]{"value2"})
+            .doubleValue(), .001);
+
+  }
+
 }

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeMetricFamilyTest.java
@@ -44,16 +44,12 @@ public class GaugeMetricFamilyTest {
 
   @Test
   public void testBuilderStyleUsage() {
-
     class YourCustomCollector extends Collector {
-
       public List<MetricFamilySamples> collect() {
         return Arrays.<MetricFamilySamples>asList(
-
             new GaugeMetricFamily("my_metric", "help", Arrays.asList("name"))
                 .addMetric(Arrays.asList("value1"), 1.0)
                 .addMetric(Arrays.asList("value2"), 2.0)
-
         );
       }
     }
@@ -65,7 +61,6 @@ public class GaugeMetricFamilyTest {
     assertEquals(2.0,
         registry.getSampleValue("my_metric", new String[]{"name"}, new String[]{"value2"})
             .doubleValue(), .001);
-
   }
 
 }

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryMetricFamilyTest.java
@@ -45,4 +45,30 @@ public class SummaryMetricFamilyTest {
 		assertEquals(5.0, registry.getSampleValue("my_other_summary", new String[]{"labelname", "quantile"}, new String[]{"foo", "0.99"}).doubleValue(), .001);
 	}
 
+	@Test
+	public void testBuilderStyleUsage() {
+
+		class YourCustomCollector extends Collector {
+
+			public List<MetricFamilySamples> collect() {
+				return Arrays.<MetricFamilySamples>asList(
+
+						new SummaryMetricFamily("my_metric", "help", Arrays.asList("name"))
+								.addMetric(Arrays.asList("value1"), 1, 1.0)
+								.addMetric(Arrays.asList("value2"), 2, 2.0)
+
+				);
+			}
+		}
+		new YourCustomCollector().register(registry);
+
+		assertEquals(1.0,
+				registry.getSampleValue("my_metric_count", new String[]{"name"}, new String[]{"value1"})
+						.doubleValue(), .001);
+		assertEquals(2.0,
+				registry.getSampleValue("my_metric_count", new String[]{"name"}, new String[]{"value2"})
+						.doubleValue(), .001);
+
+	}
+
 }

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryMetricFamilyTest.java
@@ -47,16 +47,12 @@ public class SummaryMetricFamilyTest {
 
 	@Test
 	public void testBuilderStyleUsage() {
-
 		class YourCustomCollector extends Collector {
-
 			public List<MetricFamilySamples> collect() {
 				return Arrays.<MetricFamilySamples>asList(
-
 						new SummaryMetricFamily("my_metric", "help", Arrays.asList("name"))
 								.addMetric(Arrays.asList("value1"), 1, 1.0)
 								.addMetric(Arrays.asList("value2"), 2, 2.0)
-
 				);
 			}
 		}
@@ -68,7 +64,6 @@ public class SummaryMetricFamilyTest {
 		assertEquals(2.0,
 				registry.getSampleValue("my_metric_count", new String[]{"name"}, new String[]{"value2"})
 						.doubleValue(), .001);
-
 	}
 
 }


### PR DESCRIPTION
Currently all `addMetric()` methods on `MetricFamily` implementations have a `void` return type. A typical usage would look like this:

```java
CounterMetricFamily counter =
    new CounterMetricFamily("foobar", "Foobar", Arrays.asList("label"));
counter.addMetric(Arrays.asList("value1"), 4);
counter.addMetric(Arrays.asList("value2"), 5);
```

This PR changes the return type of the `addMetric()` methods to `this` which now allows builder like usage to create metric families:

```java
CounterMetricFamily counter =
    new CounterMetricFamily("foobar", "Foobar", Arrays.asList("label"))
        .addMetric(Arrays.asList("value1"), 4)
        .addMetric(Arrays.asList("value2"), 5);
```

This is especially useful when implementing `Collector.collect()` and creating many metric families.