### PR TITLE
New Hibernate integration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,22 +247,22 @@ To register the Logback collector can be added to the root level like so:
 #### Hibernate
 
 There is a collector for Hibernate which allows to collect metrics from one or more 
-`SessionFactory` instances. To use this collector add the following dependency:
+`SessionFactory` instances. 
 
-```xml
-<dependency>
-  <groupId>io.prometheus</groupId>
-  <artifactId>simpleclient_hibernate</artifactId>
-  <version>0.0.20</version>
-</dependency>
+If you want to collect metrics from a single `SessionFactory`, you can register
+the collector like this:
+
+```java
+new HibernateStatisticsCollector(sessionFactory, "myapp").register();
 ```
 
-Now you can create the collector, add your `SessionFactory` instances and register 
-the collector.
+In some situations you may want to collect metrics from multiple factories. In this
+case just call `add()` on the collector for each of them.
 
 ```java
 new HibernateStatisticsCollector()
-    .add(sessionFactory, "myapp")
+    .add(sessionFactory1, "myapp1")
+    .add(sessionFactory2, "myapp2")
     .register();
 ```
 

--- a/README.md
+++ b/README.md
@@ -266,12 +266,11 @@ new HibernateStatisticsCollector()
     .register();
 ```
 
-If you are using Hibernate in a JPA environment and only have access to the `EntityManager`,
-you can use this code to access the underlying `SessionFactory`:
+If you are using Hibernate in a JPA environment and only have access to the `EntityManager`
+or `EntityManagerFactory`, you can use this code to access the underlying `SessionFactory`:
 
 ```java
-SessionFactory sessionFactory =
-    entityManager.getEntityManagerFactory().unwrap(SessionFactory.class);
+SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
 ```
 
 ## Exporting

--- a/README.md
+++ b/README.md
@@ -244,6 +244,36 @@ To register the Logback collector can be added to the root level like so:
 </configuration>
 ```
 
+#### Hibernate
+
+There is a collector for Hibernate which allows to collect metrics from one or more 
+`SessionFactory` instances. To use this collector add the following dependency:
+
+```xml
+<dependency>
+  <groupId>io.prometheus</groupId>
+  <artifactId>simpleclient_hibernate</artifactId>
+  <version>0.0.20</version>
+</dependency>
+```
+
+Now you can create the collector, add your `SessionFactory` instances and register 
+the collector.
+
+```java
+new HibernateStatisticsCollector()
+    .add(sessionFactory, "myapp")
+    .register();
+```
+
+If you are using Hibernate in a JPA environment and only have access to the `EntityManager`,
+you can use this code to access the underlying `SessionFactory`:
+
+```java
+SessionFactory sessionFactory =
+    entityManager.getEntityManagerFactory().unwrap(SessionFactory.class);
+```
+
 ## Exporting
 
 There are several options for exporting metrics.

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>simpleclient_common</module>
         <module>simpleclient_dropwizard</module>
         <module>simpleclient_graphite_bridge</module>
+        <module>simpleclient_hibernate</module>
         <module>simpleclient_hotspot</module>
         <module>simpleclient_log4j</module>
         <module>simpleclient_logback</module>

--- a/simpleclient_hibernate/pom.xml
+++ b/simpleclient_hibernate/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>0.0.20-SNAPSHOT</version>
+            <version>0.0.21-SNAPSHOT</version>
         </dependency>
 
         <!-- We support Hibernate versions >= 4.2 -->

--- a/simpleclient_hibernate/pom.xml
+++ b/simpleclient_hibernate/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>4.2.21.Final</version>
+            <version>4.2.0.Final</version>
             <scope>provided</scope>
         </dependency>
 

--- a/simpleclient_hibernate/pom.xml
+++ b/simpleclient_hibernate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.prometheus</groupId>
         <artifactId>parent</artifactId>
-        <version>0.0.20-SNAPSHOT</version>
+        <version>0.0.21-SNAPSHOT</version>
     </parent>
 
     <groupId>io.prometheus</groupId>

--- a/simpleclient_hibernate/pom.xml
+++ b/simpleclient_hibernate/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.20-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.prometheus</groupId>
+    <artifactId>simpleclient_hibernate</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Prometheus Java Simpleclient Hibernate</name>
+    <description>
+        Collectors of data from Hibernate.
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>chkal</id>
+            <name>Christian Kaltepoth</name>
+            <email>christian@kaltepoth.de</email>
+        </developer>
+    </developers>
+
+    <dependencies>
+        
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.0.20-SNAPSHOT</version>
+        </dependency>
+
+        <!-- We support Hibernate versions >= 4.2 -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>4.2.21.Final</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.6.8</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -16,10 +16,15 @@ import org.hibernate.stat.Statistics;
 /**
  * Collect metrics from one or more Hibernate SessionFactory instances.
  * <p>
- * Usage example:
+ * Usage example for a single session factory:
+ * <pre>
+ * new HibernateStatisticsCollector(sessionFactory, "myapp").register();
+ * </pre>
+ * Usage example for multiple session factories:
  * <pre>
  * new HibernateStatisticsCollector()
- *     .add(sessionFactory, "myapp")
+ *     .add(sessionFactory1, "myapp1")
+ *     .add(sessionFactory2, "myapp2")
  *     .register();
  * </pre>
  * If you are in a JPA environment, you can obtain the SessionFactory like this:
@@ -35,6 +40,27 @@ public class HibernateStatisticsCollector extends Collector {
   private static final List<String> LABEL_NAMES = Collections.singletonList("unit");
 
   private final Map<String, SessionFactory> sessionFactories = new LinkedHashMap<String, SessionFactory>();
+
+  /**
+   * Creates an empty collector. If you use this constructor, you have to add one or more
+   * session factories to the collector by calling the {@link #add(SessionFactory, String)}
+   * method.
+   */
+  public HibernateStatisticsCollector() {
+    // nothing
+  }
+
+  /**
+   * Creates a new collector for the given session factory. Calling this constructor
+   * has the same effect as creating an empty collector and adding the session factory
+   * using {@link #add(SessionFactory, String)}.
+   *
+   * @param sessionFactory The Hibernate SessionFactory to collect metrics for
+   * @param name A unique name for this SessionFactory
+   */
+  public HibernateStatisticsCollector(SessionFactory sessionFactory, String name) {
+    add(sessionFactory, name);
+  }
 
   /**
    * Registers a Hibernate SessionFactory with this collector.

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -30,7 +30,7 @@ import org.hibernate.stat.Statistics;
  * If you are in a JPA environment, you can obtain the SessionFactory like this:
  * <pre>
  * SessionFactory sessionFactory =
- *     entityManager.getEntityManagerFactory().unwrap(SessionFactory.class);
+ *     entityManagerFactory.unwrap(SessionFactory.class);
  * </pre>
  *
  * @author Christian Kaltepoth

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -55,27 +55,27 @@ public class HibernateStatisticsCollector extends Collector {
     return Arrays.<MetricFamilySamples>asList(
         createCounter(
             "hibernate_session_opened_total",
-            "Global number of sessions opened",
+            "Global number of sessions opened (getSessionOpenCount)",
             statistics.getSessionOpenCount()
         ),
         createCounter(
             "hibernate_session_closed_total",
-            "Global number of sessions closed",
+            "Global number of sessions closed (getSessionCloseCount)",
             statistics.getSessionCloseCount()
         ),
         createCounter(
             "hibernate_flushes_total",
-            "The global number of flush executed by sessions",
+            "The global number of flush executed by sessions (getFlushCount)",
             statistics.getFlushCount()
         ),
         createCounter(
             "hibernate_connection_requested_total",
-            "The global number of connections asked by the sessions",
+            "The global number of connections asked by the sessions (getConnectCount)",
             statistics.getConnectCount()
         ),
         createCounter(
             "hibernate_optimistic_failure_total",
-            "The number of StaleObjectStateExceptions that occurred",
+            "The number of StaleObjectStateExceptions that occurred (getOptimisticFailureCount)",
             statistics.getOptimisticFailureCount()
         )
     );
@@ -85,22 +85,22 @@ public class HibernateStatisticsCollector extends Collector {
     return Arrays.<MetricFamilySamples>asList(
         createCounter(
             "hibernate_statement_prepared_total",
-            "The number of prepared statements that were acquired",
+            "The number of prepared statements that were acquired (getPrepareStatementCount)",
             statistics.getPrepareStatementCount()
         ),
         createCounter(
             "hibernate_statement_closed_total",
-            "The number of prepared statements that were released",
+            "The number of prepared statements that were released (getCloseStatementCount)",
             statistics.getCloseStatementCount()
         ),
         createCounter(
             "hibernate_transaction_total",
-            "The number of transactions we know to have completed",
+            "The number of transactions we know to have completed (getTransactionCount)",
             statistics.getTransactionCount()
         ),
         createCounter(
             "hibernate_transaction_success_total",
-            "The number of transactions we know to have been successful",
+            "The number of transactions we know to have been successful (getSuccessfulTransactionCount)",
             statistics.getSuccessfulTransactionCount()
         )
     );
@@ -110,62 +110,62 @@ public class HibernateStatisticsCollector extends Collector {
     return Arrays.<MetricFamilySamples>asList(
         createCounter(
             "hibernate_second_level_cache_hit_total",
-            "Global number of cacheable entities/collections successfully retrieved from the cache",
+            "Global number of cacheable entities/collections successfully retrieved from the cache (getSecondLevelCacheHitCount)",
             statistics.getSecondLevelCacheHitCount()
         ),
         createCounter(
             "hibernate_second_level_cache_miss_total",
-            "Global number of cacheable entities/collections not found in the cache and loaded from the database.",
+            "Global number of cacheable entities/collections not found in the cache and loaded from the database (getSecondLevelCacheMissCount)",
             statistics.getSecondLevelCacheMissCount()
         ),
         createCounter(
             "hibernate_second_level_cache_put_total",
-            "Global number of cacheable entities/collections put in the cache",
+            "Global number of cacheable entities/collections put in the cache (getSecondLevelCachePutCount)",
             statistics.getSecondLevelCachePutCount()
         ),
         createCounter(
             "hibernate_query_cache_hit_total",
-            "The global number of cached queries successfully retrieved from cache",
+            "The global number of cached queries successfully retrieved from cache (getQueryCacheHitCount)",
             statistics.getQueryCacheHitCount()
         ),
         createCounter(
             "hibernate_query_cache_miss_total",
-            "The global number of cached queries not found in cache",
+            "The global number of cached queries not found in cache (getQueryCacheMissCount)",
             statistics.getQueryCacheMissCount()
         ),
         createCounter(
             "hibernate_query_cache_put_total",
-            "The global number of cacheable queries put in cache",
+            "The global number of cacheable queries put in cache (getQueryCachePutCount)",
             statistics.getQueryCachePutCount()
         ),
         createCounter(
             "hibernate_natural_id_cache_hit_total",
-            "The global number of cached naturalId lookups successfully retrieved from cache",
+            "The global number of cached naturalId lookups successfully retrieved from cache (getNaturalIdCacheHitCount)",
             statistics.getNaturalIdCacheHitCount()
         ),
         createCounter(
             "hibernate_natural_id_cache_miss_total",
-            "The global number of cached naturalId lookups not found in cache",
+            "The global number of cached naturalId lookups not found in cache (getNaturalIdCacheMissCount)",
             statistics.getNaturalIdCacheMissCount()
         ),
         createCounter(
             "hibernate_natural_id_cache_put_total",
-            "The global number of cacheable naturalId lookups put in cache",
+            "The global number of cacheable naturalId lookups put in cache (getNaturalIdCachePutCount)",
             statistics.getNaturalIdCachePutCount()
         ),
         createCounter(
             "hibernate_update_timestamps_cache_hit_total",
-            "The global number of timestamps successfully retrieved from cache",
+            "The global number of timestamps successfully retrieved from cache (getUpdateTimestampsCacheHitCount)",
             statistics.getUpdateTimestampsCacheHitCount()
         ),
         createCounter(
             "hibernate_update_timestamps_cache_miss_total",
-            "The global number of tables for which no update timestamps was not found in cache",
+            "The global number of tables for which no update timestamps was not found in cache (getUpdateTimestampsCacheMissCount)",
             statistics.getUpdateTimestampsCacheMissCount()
         ),
         createCounter(
             "hibernate_update_timestamps_cache_put_total",
-            "The global number of timestamps put in cache",
+            "The global number of timestamps put in cache (getUpdateTimestampsCachePutCount)",
             statistics.getUpdateTimestampsCachePutCount()
         )
     );
@@ -175,52 +175,52 @@ public class HibernateStatisticsCollector extends Collector {
     return Arrays.<MetricFamilySamples>asList(
         createCounter(
             "hibernate_entity_delete_total",
-            "Global number of entity deletes",
+            "Global number of entity deletes (getEntityDeleteCount)",
             statistics.getEntityDeleteCount()
         ),
         createCounter(
             "hibernate_entity_insert_total",
-            "Global number of entity inserts",
+            "Global number of entity inserts (getEntityInsertCount)",
             statistics.getEntityInsertCount()
         ),
         createCounter(
             "hibernate_entity_load_total",
-            "Global number of entity loads",
+            "Global number of entity loads (getEntityLoadCount)",
             statistics.getEntityLoadCount()
         ),
         createCounter(
             "hibernate_entity_fetch_total",
-            "Global number of entity fetches",
+            "Global number of entity fetches (getEntityFetchCount)",
             statistics.getEntityFetchCount()
         ),
         createCounter(
             "hibernate_entity_update_total",
-            "Global number of entity updates",
+            "Global number of entity updates (getEntityUpdateCount)",
             statistics.getEntityUpdateCount()
         ),
         createCounter(
             "hibernate_collection_load_total",
-            "Global number of collections loaded",
+            "Global number of collections loaded (getCollectionLoadCount)",
             statistics.getCollectionLoadCount()
         ),
         createCounter(
             "hibernate_collection_fetch_total",
-            "Global number of collections fetched",
+            "Global number of collections fetched (getCollectionFetchCount)",
             statistics.getCollectionFetchCount()
         ),
         createCounter(
             "hibernate_collection_update_total",
-            "Global number of collections updated",
+            "Global number of collections updated (getCollectionUpdateCount)",
             statistics.getCollectionUpdateCount()
         ),
         createCounter(
             "hibernate_collection_remove_total",
-            "Global number of collections removed",
+            "Global number of collections removed (getCollectionRemoveCount)",
             statistics.getCollectionRemoveCount()
         ),
         createCounter(
             "hibernate_collection_recreate_total",
-            "Global number of collections recreated",
+            "Global number of collections recreated (getCollectionRecreateCount)",
             statistics.getCollectionRecreateCount()
         )
     );
@@ -230,12 +230,12 @@ public class HibernateStatisticsCollector extends Collector {
     return Arrays.<MetricFamilySamples>asList(
         createCounter(
             "hibernate_query_execution_total",
-            "Global number of executed queries",
+            "Global number of executed queries (getQueryExecutionCount)",
             statistics.getQueryExecutionCount()
         ),
         createCounter(
             "hibernate_natural_id_query_execution_total",
-            "The global number of naturalId queries executed against the database",
+            "The global number of naturalId queries executed against the database (getNaturalIdQueryExecutionCount)",
             statistics.getNaturalIdQueryExecutionCount()
         )
     );

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -67,13 +67,13 @@ public class HibernateStatisticsCollector extends Collector {
         ),
 
         createCounter(
-            "hibernate_flushed_total",
+            "hibernate_flushes_total",
             "The global number of flush executed by sessions",
             statistics.getFlushCount()
         ),
 
         createCounter(
-            "hibernate_connect_total",
+            "hibernate_connection_requested_total",
             "The global number of connections asked by the sessions",
             statistics.getConnectCount()
         ),

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -53,73 +53,61 @@ public class HibernateStatisticsCollector extends Collector {
 
   private List<MetricFamilySamples> getSessionMetrics() {
     return Arrays.<MetricFamilySamples>asList(
-
         createCounter(
             "hibernate_session_opened_total",
             "Global number of sessions opened",
             statistics.getSessionOpenCount()
         ),
-
         createCounter(
             "hibernate_session_closed_total",
             "Global number of sessions closed",
             statistics.getSessionCloseCount()
         ),
-
         createCounter(
             "hibernate_flushes_total",
             "The global number of flush executed by sessions",
             statistics.getFlushCount()
         ),
-
         createCounter(
             "hibernate_connection_requested_total",
             "The global number of connections asked by the sessions",
             statistics.getConnectCount()
         ),
-
         createCounter(
             "hibernate_optimistic_failure_total",
             "The number of StaleObjectStateExceptions that occurred",
             statistics.getOptimisticFailureCount()
         )
-
     );
   }
 
   private List<MetricFamilySamples> getConnectionMetrics() {
     return Arrays.<MetricFamilySamples>asList(
-
         createCounter(
             "hibernate_statement_prepared_total",
             "The number of prepared statements that were acquired",
             statistics.getPrepareStatementCount()
         ),
-
         createCounter(
             "hibernate_statement_closed_total",
             "The number of prepared statements that were released",
             statistics.getCloseStatementCount()
         ),
-
         createCounter(
             "hibernate_transaction_total",
             "The number of transactions we know to have completed",
             statistics.getTransactionCount()
         ),
-
         createCounter(
             "hibernate_transaction_success_total",
             "The number of transactions we know to have been successful",
             statistics.getSuccessfulTransactionCount()
         )
-
     );
   }
 
   private List<MetricFamilySamples> getCacheMetrics() {
     return Arrays.<MetricFamilySamples>asList(
-
         createCounter(
             "hibernate_second_level_cache_hit_total",
             "Global number of cacheable entities/collections successfully retrieved from the cache",
@@ -135,7 +123,6 @@ public class HibernateStatisticsCollector extends Collector {
             "Global number of cacheable entities/collections put in the cache",
             statistics.getSecondLevelCachePutCount()
         ),
-
         createCounter(
             "hibernate_query_cache_hit_total",
             "The global number of cached queries successfully retrieved from cache",
@@ -151,7 +138,6 @@ public class HibernateStatisticsCollector extends Collector {
             "The global number of cacheable queries put in cache",
             statistics.getQueryCachePutCount()
         ),
-
         createCounter(
             "hibernate_natural_id_cache_hit_total",
             "The global number of cached naturalId lookups successfully retrieved from cache",
@@ -167,7 +153,6 @@ public class HibernateStatisticsCollector extends Collector {
             "The global number of cacheable naturalId lookups put in cache",
             statistics.getNaturalIdCachePutCount()
         ),
-
         createCounter(
             "hibernate_update_timestamps_cache_hit_total",
             "The global number of timestamps successfully retrieved from cache",
@@ -183,13 +168,11 @@ public class HibernateStatisticsCollector extends Collector {
             "The global number of timestamps put in cache",
             statistics.getUpdateTimestampsCachePutCount()
         )
-
     );
   }
 
   private List<MetricFamilySamples> getEntityMetrics() {
     return Arrays.<MetricFamilySamples>asList(
-
         createCounter(
             "hibernate_entity_delete_total",
             "Global number of entity deletes",
@@ -215,7 +198,6 @@ public class HibernateStatisticsCollector extends Collector {
             "Global number of entity updates",
             statistics.getEntityUpdateCount()
         ),
-
         createCounter(
             "hibernate_collection_load_total",
             "Global number of collections loaded",
@@ -241,25 +223,21 @@ public class HibernateStatisticsCollector extends Collector {
             "Global number of collections recreated",
             statistics.getCollectionRecreateCount()
         )
-
     );
   }
 
   private List<MetricFamilySamples> getQueryExecutionMetrics() {
     return Arrays.<MetricFamilySamples>asList(
-
         createCounter(
             "hibernate_query_execution_total",
             "Global number of executed queries",
             statistics.getQueryExecutionCount()
         ),
-
         createCounter(
             "hibernate_natural_id_query_execution_total",
             "The global number of naturalId queries executed against the database",
             statistics.getNaturalIdQueryExecutionCount()
         )
-
     );
   }
 

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -1,0 +1,282 @@
+package io.prometheus.client.hibernate;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.GaugeMetricFamily;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+
+/**
+ * Collect metrics from Hibernate statistics.
+ * <p>
+ * Usage example:
+ * <pre>
+ * new HibernateStatisticsCollector(sessionFactory).register();
+ * </pre>
+ * If you are in a JPA environment, you can obtain the SessionFactory like this:
+ * <pre>
+ * SessionFactory sessionFactory =
+ *     entityManager.getEntityManagerFactory().unwrap(SessionFactory.class);
+ * </pre>
+ *
+ * @author Christian Kaltepoth
+ */
+public class HibernateStatisticsCollector extends Collector {
+
+  private final Statistics statistics;
+
+  public HibernateStatisticsCollector(SessionFactory sessionFactory) {
+    this(sessionFactory.getStatistics());
+  }
+
+  public HibernateStatisticsCollector(Statistics statistics) {
+    this.statistics = statistics;
+  }
+
+  @Override
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples> metrics = new ArrayList<MetricFamilySamples>();
+    metrics.addAll(getSessionMetrics());
+    metrics.addAll(getConnectionMetrics());
+    metrics.addAll(getCacheMetrics());
+    metrics.addAll(getEntityMetrics());
+    metrics.addAll(getQueryExecutionMetrics());
+    return metrics;
+  }
+
+  private List<MetricFamilySamples> getSessionMetrics() {
+    return Arrays.<MetricFamilySamples>asList(
+
+        createCounter(
+            "hibernate_session_open_total",
+            "Global number of sessions opened",
+            statistics.getSessionOpenCount()
+        ),
+
+        createCounter(
+            "hibernate_session_close_total",
+            "Global number of sessions closed",
+            statistics.getSessionCloseCount()
+        ),
+
+        createCounter(
+            "hibernate_flush_total",
+            "Get the global number of flush executed by sessions",
+            statistics.getFlushCount()
+        ),
+
+        createCounter(
+            "hibernate_connect_total",
+            "Get the global number of connections asked by the sessions",
+            statistics.getConnectCount()
+        ),
+
+        createCounter(
+            "hibernate_optimistic_failure_total",
+            "The number of StaleObjectStateExceptions that occurred",
+            statistics.getOptimisticFailureCount()
+        )
+
+    );
+  }
+
+  private List<MetricFamilySamples> getConnectionMetrics() {
+    return Arrays.<MetricFamilySamples>asList(
+
+        createCounter(
+            "hibernate_statement_prepare_total",
+            "The number of prepared statements that were acquired",
+            statistics.getPrepareStatementCount()
+        ),
+
+        createCounter(
+            "hibernate_statement_close_total",
+            "The number of prepared statements that were released",
+            statistics.getCloseStatementCount()
+        ),
+
+        createCounter(
+            "hibernate_transaction_total",
+            "The number of transactions we know to have completed",
+            statistics.getTransactionCount()
+        ),
+
+        createCounter(
+            "hibernate_transaction_success_total",
+            "The number of transactions we know to have been successful",
+            statistics.getSuccessfulTransactionCount()
+        )
+
+    );
+  }
+
+  private List<MetricFamilySamples> getCacheMetrics() {
+    return Arrays.<MetricFamilySamples>asList(
+
+        createCounter(
+            "hibernate_second_level_cache_hit_total",
+            "Global number of cacheable entities/collections successfully retrieved from the cache",
+            statistics.getSecondLevelCacheHitCount()
+        ),
+        createCounter(
+            "hibernate_second_level_cache_miss_total",
+            "Global number of cacheable entities/collections not found in the cache and loaded from the database.",
+            statistics.getSecondLevelCacheMissCount()
+        ),
+        createCounter(
+            "hibernate_second_level_cache_put_total",
+            "Global number of cacheable entities/collections put in the cache",
+            statistics.getSecondLevelCachePutCount()
+        ),
+
+        createCounter(
+            "hibernate_query_cache_hit_total",
+            "Get the global number of cached queries successfully retrieved from cache",
+            statistics.getQueryCacheHitCount()
+        ),
+        createCounter(
+            "hibernate_query_cache_miss_total",
+            "Get the global number of cached queries not found in cache",
+            statistics.getQueryCacheMissCount()
+        ),
+        createCounter(
+            "hibernate_query_cache_put_total",
+            "Get the global number of cacheable queries put in cache",
+            statistics.getQueryCachePutCount()
+        ),
+
+        createCounter(
+            "hibernate_natural_id_cache_hit_total",
+            "Get the global number of cached naturalId lookups successfully retrieved from cache",
+            statistics.getNaturalIdCacheHitCount()
+        ),
+        createCounter(
+            "hibernate_natural_id_cache_miss_total",
+            "Get the global number of cached naturalId lookups not found in cache",
+            statistics.getNaturalIdCacheMissCount()
+        ),
+        createCounter(
+            "hibernate_natural_id_cache_put_total",
+            "Get the global number of cacheable naturalId lookups put in cache",
+            statistics.getNaturalIdCachePutCount()
+        ),
+
+        createCounter(
+            "hibernate_update_timestamps_cache_hit_total",
+            "Get the global number of timestamps successfully retrieved from cache",
+            statistics.getUpdateTimestampsCacheHitCount()
+        ),
+        createCounter(
+            "hibernate_update_timestamps_cache_miss_total",
+            "Get the global number of tables for which no update timestamps was not found in cache",
+            statistics.getUpdateTimestampsCacheMissCount()
+        ),
+        createCounter(
+            "hibernate_update_timestamps_cache_put_total",
+            "Get the global number of timestamps put in cache",
+            statistics.getUpdateTimestampsCachePutCount()
+        )
+
+    );
+  }
+
+  private List<MetricFamilySamples> getEntityMetrics() {
+    return Arrays.<MetricFamilySamples>asList(
+
+        createCounter(
+            "hibernate_entity_delete_total",
+            "Get global number of entity deletes",
+            statistics.getEntityDeleteCount()
+        ),
+        createCounter(
+            "hibernate_entity_insert_total",
+            "Get global number of entity inserts",
+            statistics.getEntityInsertCount()
+        ),
+        createCounter(
+            "hibernate_entity_load_total",
+            "Get global number of entity loads",
+            statistics.getEntityLoadCount()
+        ),
+        createCounter(
+            "hibernate_entity_fetch_total",
+            "Get global number of entity fetches",
+            statistics.getEntityFetchCount()
+        ),
+        createCounter(
+            "hibernate_entity_update_total",
+            "Get global number of entity updates",
+            statistics.getEntityUpdateCount()
+        ),
+
+        createCounter(
+            "hibernate_collection_load_total",
+            "Global number of collections loaded",
+            statistics.getCollectionLoadCount()
+        ),
+        createCounter(
+            "hibernate_collection_fetch_total",
+            "Global number of collections fetched",
+            statistics.getCollectionFetchCount()
+        ),
+        createCounter(
+            "hibernate_collection_update_total",
+            "Global number of collections updated",
+            statistics.getCollectionUpdateCount()
+        ),
+        createCounter(
+            "hibernate_collection_remove_total",
+            "Global number of collections removed",
+            statistics.getCollectionRemoveCount()
+        ),
+        createCounter(
+            "hibernate_collection_recreate_total",
+            "Global number of collections recreated",
+            statistics.getCollectionRecreateCount()
+        )
+
+    );
+  }
+
+  private List<MetricFamilySamples> getQueryExecutionMetrics() {
+    return Arrays.asList(
+
+        createCounter(
+            "hibernate_query_execution_total",
+            "Get global number of executed queries",
+            statistics.getQueryExecutionCount()
+        ),
+
+        createGauge(
+            "hibernate_query_execution_seconds_max",
+            "Get the time in milliseconds of the slowest query.",
+            statistics.getQueryExecutionMaxTime() / 1000.0
+        ),
+
+        createCounter(
+            "hibernate_natural_id_query_execution_total",
+            "Get the global number of naturalId queries executed against the database",
+            statistics.getNaturalIdQueryExecutionCount()
+        ),
+
+        createGauge(
+            "hibernate_natural_id_query_execution_seconds_max",
+            "Get the global maximum query time for naturalId queries executed against the database",
+            statistics.getNaturalIdQueryExecutionMaxTime() / 1000.0
+        )
+
+    );
+  }
+
+  private CounterMetricFamily createCounter(String name, String help, double value) {
+    return new CounterMetricFamily(name, help, value);
+  }
+
+  private GaugeMetricFamily createGauge(String name, String help, double value) {
+    return new GaugeMetricFamily(name, help, value);
+  }
+
+}

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -26,18 +26,18 @@ import org.hibernate.stat.Statistics;
  */
 public class HibernateStatisticsCollector extends Collector {
 
-  private static final List<String> LABEL_NAMES = Collections.singletonList("name");
+  private static final List<String> LABEL_NAMES = Collections.singletonList("unit");
 
   private final Statistics statistics;
-  private final String name;
+  private final String unit;
 
-  public HibernateStatisticsCollector(SessionFactory sessionFactory, String name) {
-    this(sessionFactory.getStatistics(), name);
+  public HibernateStatisticsCollector(SessionFactory sessionFactory, String unit) {
+    this(sessionFactory.getStatistics(), unit);
   }
 
-  public HibernateStatisticsCollector(Statistics statistics, String name) {
+  public HibernateStatisticsCollector(Statistics statistics, String unit) {
     this.statistics = statistics;
-    this.name = name;
+    this.unit = unit;
   }
 
   @Override
@@ -243,7 +243,7 @@ public class HibernateStatisticsCollector extends Collector {
 
   private CounterMetricFamily createCounter(String metric, String help, long value) {
     return new CounterMetricFamily(metric, help, LABEL_NAMES)
-        .addMetric(Collections.singletonList(name), value);
+        .addMetric(Collections.singletonList(unit), value);
   }
 
 }

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -64,13 +64,13 @@ public class HibernateStatisticsCollector extends Collector {
             statistics.getSessionCloseCount()
         ),
         createCounter(
-            "hibernate_flushes_total",
-            "The global number of flush executed by sessions (getFlushCount)",
+            "hibernate_flushed_total",
+            "The global number of flushes executed by sessions (getFlushCount)",
             statistics.getFlushCount()
         ),
         createCounter(
-            "hibernate_connection_requested_total",
-            "The global number of connections asked by the sessions (getConnectCount)",
+            "hibernate_connect_total",
+            "The global number of connections requested by the sessions (getConnectCount)",
             statistics.getConnectCount()
         ),
         createCounter(

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -14,7 +14,7 @@ import org.hibernate.stat.Statistics;
  * <p>
  * Usage example:
  * <pre>
- * new HibernateStatisticsCollector(sessionFactory, "default).register();
+ * new HibernateStatisticsCollector(sessionFactory, "default").register();
  * </pre>
  * If you are in a JPA environment, you can obtain the SessionFactory like this:
  * <pre>

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -51,19 +51,19 @@ public class HibernateStatisticsCollector extends Collector {
     return Arrays.<MetricFamilySamples>asList(
 
         createCounter(
-            "hibernate_session_open_total",
+            "hibernate_session_opened_total",
             "Global number of sessions opened",
             statistics.getSessionOpenCount()
         ),
 
         createCounter(
-            "hibernate_session_close_total",
+            "hibernate_session_closed_total",
             "Global number of sessions closed",
             statistics.getSessionCloseCount()
         ),
 
         createCounter(
-            "hibernate_flush_total",
+            "hibernate_flushed_total",
             "Get the global number of flush executed by sessions",
             statistics.getFlushCount()
         ),
@@ -87,13 +87,13 @@ public class HibernateStatisticsCollector extends Collector {
     return Arrays.<MetricFamilySamples>asList(
 
         createCounter(
-            "hibernate_statement_prepare_total",
+            "hibernate_statement_prepared_total",
             "The number of prepared statements that were acquired",
             statistics.getPrepareStatementCount()
         ),
 
         createCounter(
-            "hibernate_statement_close_total",
+            "hibernate_statement_closed_total",
             "The number of prepared statements that were released",
             statistics.getCloseStatementCount()
         ),

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -6,10 +6,10 @@ import io.prometheus.client.CounterMetricFamily;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.Statistics;
 
@@ -39,7 +39,7 @@ public class HibernateStatisticsCollector extends Collector {
 
   private static final List<String> LABEL_NAMES = Collections.singletonList("unit");
 
-  private final Map<String, SessionFactory> sessionFactories = new LinkedHashMap<String, SessionFactory>();
+  private final Map<String, SessionFactory> sessionFactories = new ConcurrentHashMap<String, SessionFactory>();
 
   /**
    * Creates an empty collector. If you use this constructor, you have to add one or more

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -242,7 +242,7 @@ public class HibernateStatisticsCollector extends Collector {
   }
 
   private List<MetricFamilySamples> getQueryExecutionMetrics() {
-    return Arrays.asList(
+    return Arrays.<MetricFamilySamples>asList(
 
         createCounter(
             "hibernate_query_execution_total",
@@ -250,22 +250,10 @@ public class HibernateStatisticsCollector extends Collector {
             statistics.getQueryExecutionCount()
         ),
 
-        createGauge(
-            "hibernate_query_execution_seconds_max",
-            "The time in milliseconds of the slowest query.",
-            statistics.getQueryExecutionMaxTime() / 1000.0
-        ),
-
         createCounter(
             "hibernate_natural_id_query_execution_total",
             "The global number of naturalId queries executed against the database",
             statistics.getNaturalIdQueryExecutionCount()
-        ),
-
-        createGauge(
-            "hibernate_natural_id_query_execution_seconds_max",
-            "The global maximum query time for naturalId queries executed against the database",
-            statistics.getNaturalIdQueryExecutionMaxTime() / 1000.0
         )
 
     );
@@ -273,10 +261,6 @@ public class HibernateStatisticsCollector extends Collector {
 
   private CounterMetricFamily createCounter(String name, String help, double value) {
     return new CounterMetricFamily(name, help, value);
-  }
-
-  private GaugeMetricFamily createGauge(String name, String help, double value) {
-    return new GaugeMetricFamily(name, help, value);
   }
 
 }

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -2,7 +2,6 @@ package io.prometheus.client.hibernate;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CounterMetricFamily;
-import io.prometheus.client.GaugeMetricFamily;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,31 +49,31 @@ public class HibernateStatisticsCollector extends Collector {
   private List<MetricFamilySamples> getSessionMetrics() {
     return Arrays.<MetricFamilySamples>asList(
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_session_opened_total",
             "Global number of sessions opened",
             statistics.getSessionOpenCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_session_closed_total",
             "Global number of sessions closed",
             statistics.getSessionCloseCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_flushed_total",
             "The global number of flush executed by sessions",
             statistics.getFlushCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_connect_total",
             "The global number of connections asked by the sessions",
             statistics.getConnectCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_optimistic_failure_total",
             "The number of StaleObjectStateExceptions that occurred",
             statistics.getOptimisticFailureCount()
@@ -86,25 +85,25 @@ public class HibernateStatisticsCollector extends Collector {
   private List<MetricFamilySamples> getConnectionMetrics() {
     return Arrays.<MetricFamilySamples>asList(
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_statement_prepared_total",
             "The number of prepared statements that were acquired",
             statistics.getPrepareStatementCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_statement_closed_total",
             "The number of prepared statements that were released",
             statistics.getCloseStatementCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_transaction_total",
             "The number of transactions we know to have completed",
             statistics.getTransactionCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_transaction_success_total",
             "The number of transactions we know to have been successful",
             statistics.getSuccessfulTransactionCount()
@@ -116,65 +115,65 @@ public class HibernateStatisticsCollector extends Collector {
   private List<MetricFamilySamples> getCacheMetrics() {
     return Arrays.<MetricFamilySamples>asList(
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_second_level_cache_hit_total",
             "Global number of cacheable entities/collections successfully retrieved from the cache",
             statistics.getSecondLevelCacheHitCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_second_level_cache_miss_total",
             "Global number of cacheable entities/collections not found in the cache and loaded from the database.",
             statistics.getSecondLevelCacheMissCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_second_level_cache_put_total",
             "Global number of cacheable entities/collections put in the cache",
             statistics.getSecondLevelCachePutCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_query_cache_hit_total",
             "The global number of cached queries successfully retrieved from cache",
             statistics.getQueryCacheHitCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_query_cache_miss_total",
             "The global number of cached queries not found in cache",
             statistics.getQueryCacheMissCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_query_cache_put_total",
             "The global number of cacheable queries put in cache",
             statistics.getQueryCachePutCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_natural_id_cache_hit_total",
             "The global number of cached naturalId lookups successfully retrieved from cache",
             statistics.getNaturalIdCacheHitCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_natural_id_cache_miss_total",
             "The global number of cached naturalId lookups not found in cache",
             statistics.getNaturalIdCacheMissCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_natural_id_cache_put_total",
             "The global number of cacheable naturalId lookups put in cache",
             statistics.getNaturalIdCachePutCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_update_timestamps_cache_hit_total",
             "The global number of timestamps successfully retrieved from cache",
             statistics.getUpdateTimestampsCacheHitCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_update_timestamps_cache_miss_total",
             "The global number of tables for which no update timestamps was not found in cache",
             statistics.getUpdateTimestampsCacheMissCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_update_timestamps_cache_put_total",
             "The global number of timestamps put in cache",
             statistics.getUpdateTimestampsCachePutCount()
@@ -186,53 +185,53 @@ public class HibernateStatisticsCollector extends Collector {
   private List<MetricFamilySamples> getEntityMetrics() {
     return Arrays.<MetricFamilySamples>asList(
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_entity_delete_total",
             "Global number of entity deletes",
             statistics.getEntityDeleteCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_entity_insert_total",
             "Global number of entity inserts",
             statistics.getEntityInsertCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_entity_load_total",
             "Global number of entity loads",
             statistics.getEntityLoadCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_entity_fetch_total",
             "Global number of entity fetches",
             statistics.getEntityFetchCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_entity_update_total",
             "Global number of entity updates",
             statistics.getEntityUpdateCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_collection_load_total",
             "Global number of collections loaded",
             statistics.getCollectionLoadCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_collection_fetch_total",
             "Global number of collections fetched",
             statistics.getCollectionFetchCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_collection_update_total",
             "Global number of collections updated",
             statistics.getCollectionUpdateCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_collection_remove_total",
             "Global number of collections removed",
             statistics.getCollectionRemoveCount()
         ),
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_collection_recreate_total",
             "Global number of collections recreated",
             statistics.getCollectionRecreateCount()
@@ -244,23 +243,19 @@ public class HibernateStatisticsCollector extends Collector {
   private List<MetricFamilySamples> getQueryExecutionMetrics() {
     return Arrays.<MetricFamilySamples>asList(
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_query_execution_total",
             "Global number of executed queries",
             statistics.getQueryExecutionCount()
         ),
 
-        createCounter(
+        new CounterMetricFamily(
             "hibernate_natural_id_query_execution_total",
             "The global number of naturalId queries executed against the database",
             statistics.getNaturalIdQueryExecutionCount()
         )
 
     );
-  }
-
-  private CounterMetricFamily createCounter(String name, String help, double value) {
-    return new CounterMetricFamily(name, help, value);
   }
 
 }

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -4,6 +4,7 @@ import io.prometheus.client.Collector;
 import io.prometheus.client.CounterMetricFamily;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.Statistics;
@@ -13,7 +14,7 @@ import org.hibernate.stat.Statistics;
  * <p>
  * Usage example:
  * <pre>
- * new HibernateStatisticsCollector(sessionFactory).register();
+ * new HibernateStatisticsCollector(sessionFactory, "default).register();
  * </pre>
  * If you are in a JPA environment, you can obtain the SessionFactory like this:
  * <pre>
@@ -25,14 +26,18 @@ import org.hibernate.stat.Statistics;
  */
 public class HibernateStatisticsCollector extends Collector {
 
-  private final Statistics statistics;
+  private static final List<String> LABEL_NAMES = Collections.singletonList("name");
 
-  public HibernateStatisticsCollector(SessionFactory sessionFactory) {
-    this(sessionFactory.getStatistics());
+  private final Statistics statistics;
+  private final String name;
+
+  public HibernateStatisticsCollector(SessionFactory sessionFactory, String name) {
+    this(sessionFactory.getStatistics(), name);
   }
 
-  public HibernateStatisticsCollector(Statistics statistics) {
+  public HibernateStatisticsCollector(Statistics statistics, String name) {
     this.statistics = statistics;
+    this.name = name;
   }
 
   @Override
@@ -49,31 +54,31 @@ public class HibernateStatisticsCollector extends Collector {
   private List<MetricFamilySamples> getSessionMetrics() {
     return Arrays.<MetricFamilySamples>asList(
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_session_opened_total",
             "Global number of sessions opened",
             statistics.getSessionOpenCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_session_closed_total",
             "Global number of sessions closed",
             statistics.getSessionCloseCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_flushed_total",
             "The global number of flush executed by sessions",
             statistics.getFlushCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_connect_total",
             "The global number of connections asked by the sessions",
             statistics.getConnectCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_optimistic_failure_total",
             "The number of StaleObjectStateExceptions that occurred",
             statistics.getOptimisticFailureCount()
@@ -85,25 +90,25 @@ public class HibernateStatisticsCollector extends Collector {
   private List<MetricFamilySamples> getConnectionMetrics() {
     return Arrays.<MetricFamilySamples>asList(
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_statement_prepared_total",
             "The number of prepared statements that were acquired",
             statistics.getPrepareStatementCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_statement_closed_total",
             "The number of prepared statements that were released",
             statistics.getCloseStatementCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_transaction_total",
             "The number of transactions we know to have completed",
             statistics.getTransactionCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_transaction_success_total",
             "The number of transactions we know to have been successful",
             statistics.getSuccessfulTransactionCount()
@@ -115,65 +120,65 @@ public class HibernateStatisticsCollector extends Collector {
   private List<MetricFamilySamples> getCacheMetrics() {
     return Arrays.<MetricFamilySamples>asList(
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_second_level_cache_hit_total",
             "Global number of cacheable entities/collections successfully retrieved from the cache",
             statistics.getSecondLevelCacheHitCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_second_level_cache_miss_total",
             "Global number of cacheable entities/collections not found in the cache and loaded from the database.",
             statistics.getSecondLevelCacheMissCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_second_level_cache_put_total",
             "Global number of cacheable entities/collections put in the cache",
             statistics.getSecondLevelCachePutCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_query_cache_hit_total",
             "The global number of cached queries successfully retrieved from cache",
             statistics.getQueryCacheHitCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_query_cache_miss_total",
             "The global number of cached queries not found in cache",
             statistics.getQueryCacheMissCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_query_cache_put_total",
             "The global number of cacheable queries put in cache",
             statistics.getQueryCachePutCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_natural_id_cache_hit_total",
             "The global number of cached naturalId lookups successfully retrieved from cache",
             statistics.getNaturalIdCacheHitCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_natural_id_cache_miss_total",
             "The global number of cached naturalId lookups not found in cache",
             statistics.getNaturalIdCacheMissCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_natural_id_cache_put_total",
             "The global number of cacheable naturalId lookups put in cache",
             statistics.getNaturalIdCachePutCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_update_timestamps_cache_hit_total",
             "The global number of timestamps successfully retrieved from cache",
             statistics.getUpdateTimestampsCacheHitCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_update_timestamps_cache_miss_total",
             "The global number of tables for which no update timestamps was not found in cache",
             statistics.getUpdateTimestampsCacheMissCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_update_timestamps_cache_put_total",
             "The global number of timestamps put in cache",
             statistics.getUpdateTimestampsCachePutCount()
@@ -185,53 +190,53 @@ public class HibernateStatisticsCollector extends Collector {
   private List<MetricFamilySamples> getEntityMetrics() {
     return Arrays.<MetricFamilySamples>asList(
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_entity_delete_total",
             "Global number of entity deletes",
             statistics.getEntityDeleteCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_entity_insert_total",
             "Global number of entity inserts",
             statistics.getEntityInsertCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_entity_load_total",
             "Global number of entity loads",
             statistics.getEntityLoadCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_entity_fetch_total",
             "Global number of entity fetches",
             statistics.getEntityFetchCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_entity_update_total",
             "Global number of entity updates",
             statistics.getEntityUpdateCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_collection_load_total",
             "Global number of collections loaded",
             statistics.getCollectionLoadCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_collection_fetch_total",
             "Global number of collections fetched",
             statistics.getCollectionFetchCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_collection_update_total",
             "Global number of collections updated",
             statistics.getCollectionUpdateCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_collection_remove_total",
             "Global number of collections removed",
             statistics.getCollectionRemoveCount()
         ),
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_collection_recreate_total",
             "Global number of collections recreated",
             statistics.getCollectionRecreateCount()
@@ -243,19 +248,24 @@ public class HibernateStatisticsCollector extends Collector {
   private List<MetricFamilySamples> getQueryExecutionMetrics() {
     return Arrays.<MetricFamilySamples>asList(
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_query_execution_total",
             "Global number of executed queries",
             statistics.getQueryExecutionCount()
         ),
 
-        new CounterMetricFamily(
+        createCounter(
             "hibernate_natural_id_query_execution_total",
             "The global number of naturalId queries executed against the database",
             statistics.getNaturalIdQueryExecutionCount()
         )
 
     );
+  }
+
+  private CounterMetricFamily createCounter(String metric, String help, long value) {
+    return new CounterMetricFamily(metric, help, LABEL_NAMES)
+        .addMetric(Collections.singletonList(name), value);
   }
 
 }

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -64,13 +64,13 @@ public class HibernateStatisticsCollector extends Collector {
 
         createCounter(
             "hibernate_flushed_total",
-            "Get the global number of flush executed by sessions",
+            "The global number of flush executed by sessions",
             statistics.getFlushCount()
         ),
 
         createCounter(
             "hibernate_connect_total",
-            "Get the global number of connections asked by the sessions",
+            "The global number of connections asked by the sessions",
             statistics.getConnectCount()
         ),
 
@@ -134,49 +134,49 @@ public class HibernateStatisticsCollector extends Collector {
 
         createCounter(
             "hibernate_query_cache_hit_total",
-            "Get the global number of cached queries successfully retrieved from cache",
+            "The global number of cached queries successfully retrieved from cache",
             statistics.getQueryCacheHitCount()
         ),
         createCounter(
             "hibernate_query_cache_miss_total",
-            "Get the global number of cached queries not found in cache",
+            "The global number of cached queries not found in cache",
             statistics.getQueryCacheMissCount()
         ),
         createCounter(
             "hibernate_query_cache_put_total",
-            "Get the global number of cacheable queries put in cache",
+            "The global number of cacheable queries put in cache",
             statistics.getQueryCachePutCount()
         ),
 
         createCounter(
             "hibernate_natural_id_cache_hit_total",
-            "Get the global number of cached naturalId lookups successfully retrieved from cache",
+            "The global number of cached naturalId lookups successfully retrieved from cache",
             statistics.getNaturalIdCacheHitCount()
         ),
         createCounter(
             "hibernate_natural_id_cache_miss_total",
-            "Get the global number of cached naturalId lookups not found in cache",
+            "The global number of cached naturalId lookups not found in cache",
             statistics.getNaturalIdCacheMissCount()
         ),
         createCounter(
             "hibernate_natural_id_cache_put_total",
-            "Get the global number of cacheable naturalId lookups put in cache",
+            "The global number of cacheable naturalId lookups put in cache",
             statistics.getNaturalIdCachePutCount()
         ),
 
         createCounter(
             "hibernate_update_timestamps_cache_hit_total",
-            "Get the global number of timestamps successfully retrieved from cache",
+            "The global number of timestamps successfully retrieved from cache",
             statistics.getUpdateTimestampsCacheHitCount()
         ),
         createCounter(
             "hibernate_update_timestamps_cache_miss_total",
-            "Get the global number of tables for which no update timestamps was not found in cache",
+            "The global number of tables for which no update timestamps was not found in cache",
             statistics.getUpdateTimestampsCacheMissCount()
         ),
         createCounter(
             "hibernate_update_timestamps_cache_put_total",
-            "Get the global number of timestamps put in cache",
+            "The global number of timestamps put in cache",
             statistics.getUpdateTimestampsCachePutCount()
         )
 
@@ -188,27 +188,27 @@ public class HibernateStatisticsCollector extends Collector {
 
         createCounter(
             "hibernate_entity_delete_total",
-            "Get global number of entity deletes",
+            "Global number of entity deletes",
             statistics.getEntityDeleteCount()
         ),
         createCounter(
             "hibernate_entity_insert_total",
-            "Get global number of entity inserts",
+            "Global number of entity inserts",
             statistics.getEntityInsertCount()
         ),
         createCounter(
             "hibernate_entity_load_total",
-            "Get global number of entity loads",
+            "Global number of entity loads",
             statistics.getEntityLoadCount()
         ),
         createCounter(
             "hibernate_entity_fetch_total",
-            "Get global number of entity fetches",
+            "Global number of entity fetches",
             statistics.getEntityFetchCount()
         ),
         createCounter(
             "hibernate_entity_update_total",
-            "Get global number of entity updates",
+            "Global number of entity updates",
             statistics.getEntityUpdateCount()
         ),
 
@@ -246,25 +246,25 @@ public class HibernateStatisticsCollector extends Collector {
 
         createCounter(
             "hibernate_query_execution_total",
-            "Get global number of executed queries",
+            "Global number of executed queries",
             statistics.getQueryExecutionCount()
         ),
 
         createGauge(
             "hibernate_query_execution_seconds_max",
-            "Get the time in milliseconds of the slowest query.",
+            "The time in milliseconds of the slowest query.",
             statistics.getQueryExecutionMaxTime() / 1000.0
         ),
 
         createCounter(
             "hibernate_natural_id_query_execution_total",
-            "Get the global number of naturalId queries executed against the database",
+            "The global number of naturalId queries executed against the database",
             statistics.getNaturalIdQueryExecutionCount()
         ),
 
         createGauge(
             "hibernate_natural_id_query_execution_seconds_max",
-            "Get the global maximum query time for naturalId queries executed against the database",
+            "The global maximum query time for naturalId queries executed against the database",
             statistics.getNaturalIdQueryExecutionMaxTime() / 1000.0
         )
 

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -34,8 +34,8 @@ public class HibernateStatisticsCollectorTest {
 
     assertThat(getSample("hibernate_session_opened_total", "factory1"), is(1.0));
     assertThat(getSample("hibernate_session_closed_total", "factory1"), is(2.0));
-    assertThat(getSample("hibernate_flushed_total", "factory1"), is(3.0));
-    assertThat(getSample("hibernate_connect_total", "factory1"), is(4.0));
+    assertThat(getSample("hibernate_flushes_total", "factory1"), is(3.0));
+    assertThat(getSample("hibernate_connection_requested_total", "factory1"), is(4.0));
     assertThat(getSample("hibernate_optimistic_failure_total", "factory1"), is(5.0));
 
   }

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -131,16 +131,12 @@ public class HibernateStatisticsCollectorTest {
   public void shouldPublishQueryExecutionMetrics() {
 
     when(statistics.getQueryExecutionCount()).thenReturn(1L);
-    when(statistics.getQueryExecutionMaxTime()).thenReturn(2000L);
     when(statistics.getNaturalIdQueryExecutionCount()).thenReturn(3L);
-    when(statistics.getNaturalIdQueryExecutionMaxTime()).thenReturn(4000L);
 
     new HibernateStatisticsCollector(statistics).register(registry);
 
     assertThat(registry.getSampleValue("hibernate_query_execution_total"), is(1.0));
-    assertThat(registry.getSampleValue("hibernate_query_execution_seconds_max"), is(2.0));
     assertThat(registry.getSampleValue("hibernate_natural_id_query_execution_total"), is(3.0));
-    assertThat(registry.getSampleValue("hibernate_natural_id_query_execution_seconds_max"), is(4.0));
 
   }
 

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -30,13 +30,13 @@ public class HibernateStatisticsCollectorTest {
     when(statistics.getConnectCount()).thenReturn(4L);
     when(statistics.getOptimisticFailureCount()).thenReturn(5L);
 
-    new HibernateStatisticsCollector(statistics).register(registry);
+    new HibernateStatisticsCollector(statistics, "factory1").register(registry);
 
-    assertThat(registry.getSampleValue("hibernate_session_opened_total"), is(1.0));
-    assertThat(registry.getSampleValue("hibernate_session_closed_total"), is(2.0));
-    assertThat(registry.getSampleValue("hibernate_flushed_total"), is(3.0));
-    assertThat(registry.getSampleValue("hibernate_connect_total"), is(4.0));
-    assertThat(registry.getSampleValue("hibernate_optimistic_failure_total"), is(5.0));
+    assertThat(getSample("hibernate_session_opened_total", "factory1"), is(1.0));
+    assertThat(getSample("hibernate_session_closed_total", "factory1"), is(2.0));
+    assertThat(getSample("hibernate_flushed_total", "factory1"), is(3.0));
+    assertThat(getSample("hibernate_connect_total", "factory1"), is(4.0));
+    assertThat(getSample("hibernate_optimistic_failure_total", "factory1"), is(5.0));
 
   }
 
@@ -48,12 +48,12 @@ public class HibernateStatisticsCollectorTest {
     when(statistics.getTransactionCount()).thenReturn(3L);
     when(statistics.getSuccessfulTransactionCount()).thenReturn(4L);
 
-    new HibernateStatisticsCollector(statistics).register(registry);
+    new HibernateStatisticsCollector(statistics, "factory2").register(registry);
 
-    assertThat(registry.getSampleValue("hibernate_statement_prepared_total"), is(1.0));
-    assertThat(registry.getSampleValue("hibernate_statement_closed_total"), is(2.0));
-    assertThat(registry.getSampleValue("hibernate_transaction_total"), is(3.0));
-    assertThat(registry.getSampleValue("hibernate_transaction_success_total"), is(4.0));
+    assertThat(getSample("hibernate_statement_prepared_total", "factory2"), is(1.0));
+    assertThat(getSample("hibernate_statement_closed_total", "factory2"), is(2.0));
+    assertThat(getSample("hibernate_transaction_total", "factory2"), is(3.0));
+    assertThat(getSample("hibernate_transaction_success_total", "factory2"), is(4.0));
 
   }
 
@@ -76,23 +76,23 @@ public class HibernateStatisticsCollectorTest {
     when(statistics.getUpdateTimestampsCacheMissCount()).thenReturn(11L);
     when(statistics.getUpdateTimestampsCachePutCount()).thenReturn(12L);
 
-    new HibernateStatisticsCollector(statistics).register(registry);
+    new HibernateStatisticsCollector(statistics, "factory3").register(registry);
 
-    assertThat(registry.getSampleValue("hibernate_second_level_cache_hit_total"), is(1.0));
-    assertThat(registry.getSampleValue("hibernate_second_level_cache_miss_total"), is(2.0));
-    assertThat(registry.getSampleValue("hibernate_second_level_cache_put_total"), is(3.0));
+    assertThat(getSample("hibernate_second_level_cache_hit_total", "factory3"), is(1.0));
+    assertThat(getSample("hibernate_second_level_cache_miss_total", "factory3"), is(2.0));
+    assertThat(getSample("hibernate_second_level_cache_put_total", "factory3"), is(3.0));
 
-    assertThat(registry.getSampleValue("hibernate_query_cache_hit_total"), is(4.0));
-    assertThat(registry.getSampleValue("hibernate_query_cache_miss_total"), is(5.0));
-    assertThat(registry.getSampleValue("hibernate_query_cache_put_total"), is(6.0));
+    assertThat(getSample("hibernate_query_cache_hit_total", "factory3"), is(4.0));
+    assertThat(getSample("hibernate_query_cache_miss_total", "factory3"), is(5.0));
+    assertThat(getSample("hibernate_query_cache_put_total", "factory3"), is(6.0));
 
-    assertThat(registry.getSampleValue("hibernate_natural_id_cache_hit_total"), is(7.0));
-    assertThat(registry.getSampleValue("hibernate_natural_id_cache_miss_total"), is(8.0));
-    assertThat(registry.getSampleValue("hibernate_natural_id_cache_put_total"), is(9.0));
+    assertThat(getSample("hibernate_natural_id_cache_hit_total", "factory3"), is(7.0));
+    assertThat(getSample("hibernate_natural_id_cache_miss_total", "factory3"), is(8.0));
+    assertThat(getSample("hibernate_natural_id_cache_put_total", "factory3"), is(9.0));
 
-    assertThat(registry.getSampleValue("hibernate_update_timestamps_cache_hit_total"), is(10.0));
-    assertThat(registry.getSampleValue("hibernate_update_timestamps_cache_miss_total"), is(11.0));
-    assertThat(registry.getSampleValue("hibernate_update_timestamps_cache_put_total"), is(12.0));
+    assertThat(getSample("hibernate_update_timestamps_cache_hit_total", "factory3"), is(10.0));
+    assertThat(getSample("hibernate_update_timestamps_cache_miss_total", "factory3"), is(11.0));
+    assertThat(getSample("hibernate_update_timestamps_cache_put_total", "factory3"), is(12.0));
 
   }
 
@@ -111,19 +111,19 @@ public class HibernateStatisticsCollectorTest {
     when(statistics.getCollectionRemoveCount()).thenReturn(9L);
     when(statistics.getCollectionRecreateCount()).thenReturn(10L);
 
-    new HibernateStatisticsCollector(statistics).register(registry);
+    new HibernateStatisticsCollector(statistics, "factory4").register(registry);
 
-    assertThat(registry.getSampleValue("hibernate_entity_delete_total"), is(1.0));
-    assertThat(registry.getSampleValue("hibernate_entity_insert_total"), is(2.0));
-    assertThat(registry.getSampleValue("hibernate_entity_load_total"), is(3.0));
-    assertThat(registry.getSampleValue("hibernate_entity_fetch_total"), is(4.0));
-    assertThat(registry.getSampleValue("hibernate_entity_update_total"), is(5.0));
+    assertThat(getSample("hibernate_entity_delete_total", "factory4"), is(1.0));
+    assertThat(getSample("hibernate_entity_insert_total", "factory4"), is(2.0));
+    assertThat(getSample("hibernate_entity_load_total", "factory4"), is(3.0));
+    assertThat(getSample("hibernate_entity_fetch_total", "factory4"), is(4.0));
+    assertThat(getSample("hibernate_entity_update_total", "factory4"), is(5.0));
 
-    assertThat(registry.getSampleValue("hibernate_collection_load_total"), is(6.0));
-    assertThat(registry.getSampleValue("hibernate_collection_fetch_total"), is(7.0));
-    assertThat(registry.getSampleValue("hibernate_collection_update_total"), is(8.0));
-    assertThat(registry.getSampleValue("hibernate_collection_remove_total"), is(9.0));
-    assertThat(registry.getSampleValue("hibernate_collection_recreate_total"), is(10.0));
+    assertThat(getSample("hibernate_collection_load_total", "factory4"), is(6.0));
+    assertThat(getSample("hibernate_collection_fetch_total", "factory4"), is(7.0));
+    assertThat(getSample("hibernate_collection_update_total", "factory4"), is(8.0));
+    assertThat(getSample("hibernate_collection_remove_total", "factory4"), is(9.0));
+    assertThat(getSample("hibernate_collection_recreate_total", "factory4"), is(10.0));
 
   }
 
@@ -133,11 +133,17 @@ public class HibernateStatisticsCollectorTest {
     when(statistics.getQueryExecutionCount()).thenReturn(1L);
     when(statistics.getNaturalIdQueryExecutionCount()).thenReturn(3L);
 
-    new HibernateStatisticsCollector(statistics).register(registry);
+    new HibernateStatisticsCollector(statistics, "factory5").register(registry);
 
-    assertThat(registry.getSampleValue("hibernate_query_execution_total"), is(1.0));
-    assertThat(registry.getSampleValue("hibernate_natural_id_query_execution_total"), is(3.0));
+    assertThat(getSample("hibernate_query_execution_total", "factory5"), is(1.0));
+    assertThat(getSample("hibernate_natural_id_query_execution_total", "factory5"), is(3.0));
 
+  }
+
+  private Double getSample(String metric, String factory) {
+    return registry.getSampleValue(
+        metric, new String[]{"name"}, new String[]{factory}
+    );
   }
 
 }

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -1,0 +1,147 @@
+package io.prometheus.client.hibernate;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.prometheus.client.CollectorRegistry;
+import org.hibernate.stat.Statistics;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HibernateStatisticsCollectorTest {
+
+  private Statistics statistics;
+  private CollectorRegistry registry;
+
+  @Before
+  public void before() {
+    registry = new CollectorRegistry();
+    statistics = mock(Statistics.class);
+  }
+
+  @Test
+  public void shouldPublishSessionMetrics() {
+
+    when(statistics.getSessionOpenCount()).thenReturn(1L);
+    when(statistics.getSessionCloseCount()).thenReturn(2L);
+    when(statistics.getFlushCount()).thenReturn(3L);
+    when(statistics.getConnectCount()).thenReturn(4L);
+    when(statistics.getOptimisticFailureCount()).thenReturn(5L);
+
+    new HibernateStatisticsCollector(statistics).register(registry);
+
+    assertThat(registry.getSampleValue("hibernate_session_open_total"), is(1.0));
+    assertThat(registry.getSampleValue("hibernate_session_close_total"), is(2.0));
+    assertThat(registry.getSampleValue("hibernate_flush_total"), is(3.0));
+    assertThat(registry.getSampleValue("hibernate_connect_total"), is(4.0));
+    assertThat(registry.getSampleValue("hibernate_optimistic_failure_total"), is(5.0));
+
+  }
+
+  @Test
+  public void shouldPublishConnectionMetrics() {
+
+    when(statistics.getPrepareStatementCount()).thenReturn(1L);
+    when(statistics.getCloseStatementCount()).thenReturn(2L);
+    when(statistics.getTransactionCount()).thenReturn(3L);
+    when(statistics.getSuccessfulTransactionCount()).thenReturn(4L);
+
+    new HibernateStatisticsCollector(statistics).register(registry);
+
+    assertThat(registry.getSampleValue("hibernate_statement_prepare_total"), is(1.0));
+    assertThat(registry.getSampleValue("hibernate_statement_close_total"), is(2.0));
+    assertThat(registry.getSampleValue("hibernate_transaction_total"), is(3.0));
+    assertThat(registry.getSampleValue("hibernate_transaction_success_total"), is(4.0));
+
+  }
+
+  @Test
+  public void shouldPublishCacheMetrics() {
+
+    when(statistics.getSecondLevelCacheHitCount()).thenReturn(1L);
+    when(statistics.getSecondLevelCacheMissCount()).thenReturn(2L);
+    when(statistics.getSecondLevelCachePutCount()).thenReturn(3L);
+
+    when(statistics.getQueryCacheHitCount()).thenReturn(4L);
+    when(statistics.getQueryCacheMissCount()).thenReturn(5L);
+    when(statistics.getQueryCachePutCount()).thenReturn(6L);
+
+    when(statistics.getNaturalIdCacheHitCount()).thenReturn(7L);
+    when(statistics.getNaturalIdCacheMissCount()).thenReturn(8L);
+    when(statistics.getNaturalIdCachePutCount()).thenReturn(9L);
+
+    when(statistics.getUpdateTimestampsCacheHitCount()).thenReturn(10L);
+    when(statistics.getUpdateTimestampsCacheMissCount()).thenReturn(11L);
+    when(statistics.getUpdateTimestampsCachePutCount()).thenReturn(12L);
+
+    new HibernateStatisticsCollector(statistics).register(registry);
+
+    assertThat(registry.getSampleValue("hibernate_second_level_cache_hit_total"), is(1.0));
+    assertThat(registry.getSampleValue("hibernate_second_level_cache_miss_total"), is(2.0));
+    assertThat(registry.getSampleValue("hibernate_second_level_cache_put_total"), is(3.0));
+
+    assertThat(registry.getSampleValue("hibernate_query_cache_hit_total"), is(4.0));
+    assertThat(registry.getSampleValue("hibernate_query_cache_miss_total"), is(5.0));
+    assertThat(registry.getSampleValue("hibernate_query_cache_put_total"), is(6.0));
+
+    assertThat(registry.getSampleValue("hibernate_natural_id_cache_hit_total"), is(7.0));
+    assertThat(registry.getSampleValue("hibernate_natural_id_cache_miss_total"), is(8.0));
+    assertThat(registry.getSampleValue("hibernate_natural_id_cache_put_total"), is(9.0));
+
+    assertThat(registry.getSampleValue("hibernate_update_timestamps_cache_hit_total"), is(10.0));
+    assertThat(registry.getSampleValue("hibernate_update_timestamps_cache_miss_total"), is(11.0));
+    assertThat(registry.getSampleValue("hibernate_update_timestamps_cache_put_total"), is(12.0));
+
+  }
+
+  @Test
+  public void shouldPublishEntityMetrics() {
+
+    when(statistics.getEntityDeleteCount()).thenReturn(1L);
+    when(statistics.getEntityInsertCount()).thenReturn(2L);
+    when(statistics.getEntityLoadCount()).thenReturn(3L);
+    when(statistics.getEntityFetchCount()).thenReturn(4L);
+    when(statistics.getEntityUpdateCount()).thenReturn(5L);
+
+    when(statistics.getCollectionLoadCount()).thenReturn(6L);
+    when(statistics.getCollectionFetchCount()).thenReturn(7L);
+    when(statistics.getCollectionUpdateCount()).thenReturn(8L);
+    when(statistics.getCollectionRemoveCount()).thenReturn(9L);
+    when(statistics.getCollectionRecreateCount()).thenReturn(10L);
+
+    new HibernateStatisticsCollector(statistics).register(registry);
+
+    assertThat(registry.getSampleValue("hibernate_entity_delete_total"), is(1.0));
+    assertThat(registry.getSampleValue("hibernate_entity_insert_total"), is(2.0));
+    assertThat(registry.getSampleValue("hibernate_entity_load_total"), is(3.0));
+    assertThat(registry.getSampleValue("hibernate_entity_fetch_total"), is(4.0));
+    assertThat(registry.getSampleValue("hibernate_entity_update_total"), is(5.0));
+
+    assertThat(registry.getSampleValue("hibernate_collection_load_total"), is(6.0));
+    assertThat(registry.getSampleValue("hibernate_collection_fetch_total"), is(7.0));
+    assertThat(registry.getSampleValue("hibernate_collection_update_total"), is(8.0));
+    assertThat(registry.getSampleValue("hibernate_collection_remove_total"), is(9.0));
+    assertThat(registry.getSampleValue("hibernate_collection_recreate_total"), is(10.0));
+
+  }
+
+  @Test
+  public void shouldPublishQueryExecutionMetrics() {
+
+    when(statistics.getQueryExecutionCount()).thenReturn(1L);
+    when(statistics.getQueryExecutionMaxTime()).thenReturn(2000L);
+    when(statistics.getNaturalIdQueryExecutionCount()).thenReturn(3L);
+    when(statistics.getNaturalIdQueryExecutionMaxTime()).thenReturn(4000L);
+
+    new HibernateStatisticsCollector(statistics).register(registry);
+
+    assertThat(registry.getSampleValue("hibernate_query_execution_total"), is(1.0));
+    assertThat(registry.getSampleValue("hibernate_query_execution_seconds_max"), is(2.0));
+    assertThat(registry.getSampleValue("hibernate_natural_id_query_execution_total"), is(3.0));
+    assertThat(registry.getSampleValue("hibernate_natural_id_query_execution_seconds_max"), is(4.0));
+
+  }
+
+}

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -32,9 +32,9 @@ public class HibernateStatisticsCollectorTest {
 
     new HibernateStatisticsCollector(statistics).register(registry);
 
-    assertThat(registry.getSampleValue("hibernate_session_open_total"), is(1.0));
-    assertThat(registry.getSampleValue("hibernate_session_close_total"), is(2.0));
-    assertThat(registry.getSampleValue("hibernate_flush_total"), is(3.0));
+    assertThat(registry.getSampleValue("hibernate_session_opened_total"), is(1.0));
+    assertThat(registry.getSampleValue("hibernate_session_closed_total"), is(2.0));
+    assertThat(registry.getSampleValue("hibernate_flushed_total"), is(3.0));
     assertThat(registry.getSampleValue("hibernate_connect_total"), is(4.0));
     assertThat(registry.getSampleValue("hibernate_optimistic_failure_total"), is(5.0));
 
@@ -50,8 +50,8 @@ public class HibernateStatisticsCollectorTest {
 
     new HibernateStatisticsCollector(statistics).register(registry);
 
-    assertThat(registry.getSampleValue("hibernate_statement_prepare_total"), is(1.0));
-    assertThat(registry.getSampleValue("hibernate_statement_close_total"), is(2.0));
+    assertThat(registry.getSampleValue("hibernate_statement_prepared_total"), is(1.0));
+    assertThat(registry.getSampleValue("hibernate_statement_closed_total"), is(2.0));
     assertThat(registry.getSampleValue("hibernate_transaction_total"), is(3.0));
     assertThat(registry.getSampleValue("hibernate_transaction_success_total"), is(4.0));
 

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -34,8 +34,8 @@ public class HibernateStatisticsCollectorTest {
 
     assertThat(getSample("hibernate_session_opened_total", "factory1"), is(1.0));
     assertThat(getSample("hibernate_session_closed_total", "factory1"), is(2.0));
-    assertThat(getSample("hibernate_flushes_total", "factory1"), is(3.0));
-    assertThat(getSample("hibernate_connection_requested_total", "factory1"), is(4.0));
+    assertThat(getSample("hibernate_flushed_total", "factory1"), is(3.0));
+    assertThat(getSample("hibernate_connect_total", "factory1"), is(4.0));
     assertThat(getSample("hibernate_optimistic_failure_total", "factory1"), is(5.0));
 
   }

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -142,7 +142,7 @@ public class HibernateStatisticsCollectorTest {
 
   private Double getSample(String metric, String factory) {
     return registry.getSampleValue(
-        metric, new String[]{"name"}, new String[]{factory}
+        metric, new String[]{"unit"}, new String[]{factory}
     );
   }
 


### PR DESCRIPTION
This pull requests provides a new module for integration with [Hibernate](http://hibernate.org/orm/). Hibernate provides various statistics using the [Statistics](https://docs.jboss.org/hibernate/orm/5.2/javadocs/org/hibernate/stat/Statistics.html) interface which can be accessed though the `SessionFactory`.

A few notes:
 * The module depends on the oldest Hibernate version which is still supported. IMO this is reasonable to support Hibernate versions which are typically used in real world projects.
 * I followed the "Best Practices" guide regarding the metric & label naming. However, every feedback is welcome.
 * The unit test mocks the Hibernate Statistics interface to check that all metrics are resolved and named correctly.
 * The help texts for the metrics are copied from the corresponding Javadocs of the `Statistics` interface.

Any kind of feedback is welcome.