### PR TITLE
Add `build()` method that has required fields.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -78,6 +78,16 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
   }
 
   /**
+   *  Return a Builder to allow configuration of a new Counter. Ensures required fields are provided.
+   *
+   *  @param name The name of the metric
+   *  @param help The help string of the metric
+   */
+  public static Builder build(String name, String help) {
+    return new Builder().name(name).help(help);
+  }
+
+  /**
    *  Return a Builder to allow configuration of a new Counter.
    */
   public static Builder build() {

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -76,6 +76,16 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
   }
 
   /**
+   *  Return a Builder to allow configuration of a new Gauge. Ensures required fields are provided.
+   *
+   *  @param name The name of the metric
+   *  @param help The help string of the metric
+   */
+  public static Builder build(String name, String help) {
+    return new Builder().name(name).help(help);
+  }
+
+  /**
    *  Return a Builder to allow configuration of a new Gauge.
    */
   public static Builder build() {

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -131,6 +131,16 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
   }
 
   /**
+   *  Return a Builder to allow configuration of a new Histogram. Ensures required fields are provided.
+   *
+   *  @param name The name of the metric
+   *  @param help The help string of the metric
+   */
+  public static Builder build(String name, String help) {
+    return new Builder().name(name).help(help);
+  }
+
+  /**
    *  Return a Builder to allow configuration of a new Histogram.
    */
   public static Builder build() {

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -138,6 +138,16 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
   }
 
   /**
+   *  Return a Builder to allow configuration of a new Summary. Ensures required fields are provided.
+   *
+   *  @param name The name of the metric
+   *  @param help The help string of the metric
+   */
+  public static Builder build(String name, String help) {
+    return new Builder().name(name).help(help);
+  }
+
+  /**
    *  Return a Builder to allow configuration of a new Summary.
    */
   public static Builder build() {


### PR DESCRIPTION
The builder pattern is ideal when you have optional parameters you would like to leave out of a constructor. However, when there are values that are required to be set, it is good to include them as part of the builder's constructor, making it obvious that those values are needed.

On several occasions I've created a metric and forgotten the `help()` part (or even the name part a couple of times). Luckily it blows up when registering the metric, but that means it is a runtime check instead of a compile time check.