### PR TITLE
Add convenience 'get'-methods to nolabel-Counter, Gauge and Summary

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -145,6 +145,13 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
   public void inc(double amt) {
     noLabelsChild.inc(amt);
   }
+  
+  /**
+   * Get the value of the counter.
+   */
+  public double get() {
+    return noLabelsChild.get();
+  }
 
   @Override
   public List<MetricFamilySamples> collect() {

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -280,6 +280,14 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
   public double setToTime(Runnable timeable){
     return noLabelsChild.setToTime(timeable);
   }
+  
+  /**
+   * Get the value of the gauge.
+   */
+  public double get() {
+    return noLabelsChild.get();
+  }
+
 
   @Override
   public List<MetricFamilySamples> collect() {

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -1,7 +1,6 @@
 package io.prometheus.client;
 
 import io.prometheus.client.CKMSQuantiles.Quantile;
-import io.prometheus.client.Summary.Child.Value;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -314,7 +313,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
    * <p>
    * <em>Warning:</em> The definition of {@link Value} is subject to change.
    */
-  public Value get() {
+  public Child.Value get() {
     return noLabelsChild.get();
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -311,7 +311,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
   /**
    * Get the value of the Summary.
    * <p>
-   * <em>Warning:</em> The definition of {@link Child#Value} is subject to change.
+   * <em>Warning:</em> The definition of {@link Child.Value} is subject to change.
    */
   public Child.Value get() {
     return noLabelsChild.get();

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -1,6 +1,7 @@
 package io.prometheus.client;
 
 import io.prometheus.client.CKMSQuantiles.Quantile;
+import io.prometheus.client.Summary.Child.Value;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -306,6 +307,15 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
    */
   public double time(Runnable timeable){
     return noLabelsChild.time(timeable);
+  }
+  
+  /**
+   * Get the value of the Summary.
+   * <p>
+   * <em>Warning:</em> The definition of {@link Value} is subject to change.
+   */
+  public Value get() {
+    return noLabelsChild.get();
   }
 
   @Override

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -311,7 +311,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
   /**
    * Get the value of the Summary.
    * <p>
-   * <em>Warning:</em> The definition of {@link Value} is subject to change.
+   * <em>Warning:</em> The definition of {@link Child#Value} is subject to change.
    */
   public Child.Value get() {
     return noLabelsChild.get();

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -27,12 +27,16 @@ public class CounterTest {
   public void testIncrement() {
     noLabels.inc();
     assertEquals(1.0, getValue(), .001);
+    assertEquals(1.0, noLabels.get(), .001);
     noLabels.inc(2);
     assertEquals(3.0, getValue(), .001);
+    assertEquals(3.0, noLabels.get(), .001);
     noLabels.labels().inc(4);
     assertEquals(7.0, getValue(), .001);
+    assertEquals(7.0, noLabels.get(), .001);
     noLabels.labels().inc();
     assertEquals(8.0, getValue(), .001);
+    assertEquals(8.0, noLabels.get(), .001);
   }
     
   @Test(expected=IllegalArgumentException.class)

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
@@ -34,12 +34,16 @@ public class GaugeTest {
   public void testIncrement() {
     noLabels.inc();
     assertEquals(1.0, getValue(), .001);
+    assertEquals(1.0, noLabels.get(), .001);
     noLabels.inc(2);
     assertEquals(3.0, getValue(), .001);
+    assertEquals(3.0, noLabels.get(), .001);
     noLabels.labels().inc(4);
     assertEquals(7.0, getValue(), .001);
+    assertEquals(7.0, noLabels.get(), .001);
     noLabels.labels().inc();
     assertEquals(8.0, getValue(), .001);
+    assertEquals(8.0, noLabels.get(), .001);
   }
     
   @Test

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -60,9 +60,13 @@ public class SummaryTest {
     noLabels.observe(2);
     assertEquals(1.0, getCount(), .001);
     assertEquals(2.0, getSum(), .001);
+    assertEquals(1.0, noLabels.get().count, .001);
+    assertEquals(2.0, noLabels.get().sum, .001);
     noLabels.labels().observe(4);
     assertEquals(2.0, getCount(), .001);
     assertEquals(6.0, getSum(), .001);
+    assertEquals(2.0, noLabels.get().count, .001);
+    assertEquals(6.0, noLabels.get().sum, .001);
   }
 
   @Test


### PR DESCRIPTION
Child classes of `Counter`, `Gauge `and `Summary` have `get()` methods for the current value.
This adds this capability to the base classes to make nolabel-objects able to get the current value.