### PR TITLE
more performant version of TextFormat (avoids String concats)

### DIFF
--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -1,11 +1,11 @@
 package io.prometheus.client.exporter.common;
 
-import io.prometheus.client.Collector;
-
-import java.util.Collections;
-import java.util.Enumeration;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import io.prometheus.client.Collector;
 
 public class TextFormat {
   /**
@@ -15,19 +15,31 @@ public class TextFormat {
     /* See http://prometheus.io/docs/instrumenting/exposition_formats/
      * for the output format specification. */
     for (Collector.MetricFamilySamples metricFamilySamples: Collections.list(mfs)) {
-      writer.write("# HELP " + metricFamilySamples.name + " " + escapeHelp(metricFamilySamples.help) + "\n");
-      writer.write("# TYPE " + metricFamilySamples.name + " " + typeString(metricFamilySamples.type) + "\n");
+      writer.write("# HELP ");
+      writer.write(metricFamilySamples.name);
+      writer.write(' ');
+      writer.write(escapeHelp(metricFamilySamples.help));
+      writer.write('\n');
+      writer.write("# TYPE ");
+      writer.write(metricFamilySamples.name);
+      writer.write(' ');
+      writer.write(typeString(metricFamilySamples.type));
+      writer.write('\n');
       for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
         writer.write(sample.name);
         if (sample.labelNames.size() > 0) {
-          writer.write("{");
+          writer.write('{');
           for (int i = 0; i < sample.labelNames.size(); ++i) {
-            writer.write(String.format("%s=\"%s\",",
-                sample.labelNames.get(i),  escapeLabelValue(sample.labelValues.get(i))));
+            writer.write(sample.labelNames.get(i));
+            writer.write("=\"");
+            writer.write(escapeLabelValue(sample.labelValues.get(i)));
+            writer.write("\",");
           }
-          writer.write("}");
+          writer.write('}');
         }
-        writer.write(" " + Collector.doubleToGoString(sample.value) + "\n");
+        writer.write(' ');
+        writer.write(Collector.doubleToGoString(sample.value));
+        writer.write('\n');
       }
     }
   }
@@ -38,10 +50,42 @@ public class TextFormat {
   public final static String CONTENT_TYPE_004 = "text/plain; version=0.0.4; charset=utf-8";
 
   static String escapeHelp(String s) {
-    return s.replace("\\", "\\\\").replace("\n", "\\n");
+    StringBuilder sb = new StringBuilder(s.length() * 2);
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      switch (s.charAt(i)) {
+        case '\\':
+          sb.append("\\\\");
+          break;
+        case '\n':
+          sb.append("\\n");
+          break;
+        default:
+          sb.append(c);
+      }
+    }
+    return sb.toString();
   }
+
   static String escapeLabelValue(String s) {
-    return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+    StringBuilder sb = new StringBuilder(s.length() * 2);
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      switch (s.charAt(i)) {
+        case '\\':
+          sb.append("\\\\");
+          break;
+        case '\"':
+          sb.append("\\\"");
+          break;
+        case '\n':
+          sb.append("\\n");
+          break;
+        default:
+          sb.append(c);
+      }
+    }
+    return sb.toString();
   }
 
   static String typeString(Collector.Type t) {

--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -20,11 +20,13 @@ public class TextFormat {
       writer.write(' ');
       writer.write(escapeHelp(metricFamilySamples.help));
       writer.write('\n');
+
       writer.write("# TYPE ");
       writer.write(metricFamilySamples.name);
       writer.write(' ');
       writer.write(typeString(metricFamilySamples.type));
       writer.write('\n');
+
       for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
         writer.write(sample.name);
         if (sample.labelNames.size() > 0) {

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
@@ -2,16 +2,16 @@ package io.prometheus.client.exporter.common;
 
 import static org.junit.Assert.assertEquals;
 
-import io.prometheus.client.Counter;
-import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Summary;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Vector;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
 
 
 public class TextFormatTest {
@@ -26,7 +26,7 @@ public class TextFormatTest {
 
   @Test
   public void testGaugeOutput() throws IOException {
-    Gauge noLabels = (Gauge) Gauge.build().name("nolabels").help("help").register(registry);
+    Gauge noLabels = Gauge.build().name("nolabels").help("help").register(registry);
     noLabels.inc();
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP nolabels help\n"
@@ -36,7 +36,7 @@ public class TextFormatTest {
 
   @Test
   public void testValueInfinity() throws IOException {
-    Gauge noLabels = (Gauge) Gauge.build().name("nolabels").help("help").register(registry);
+    Gauge noLabels = Gauge.build().name("nolabels").help("help").register(registry);
     noLabels.set(Double.POSITIVE_INFINITY);
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP nolabels help\n"
@@ -46,7 +46,7 @@ public class TextFormatTest {
 
   @Test
   public void testCounterOutput() throws IOException {
-    Counter noLabels = (Counter) Counter.build().name("nolabels").help("help").register(registry);
+    Counter noLabels = Counter.build().name("nolabels").help("help").register(registry);
     noLabels.inc();
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP nolabels help\n"
@@ -56,7 +56,7 @@ public class TextFormatTest {
 
   @Test
   public void testSummaryOutput() throws IOException {
-    Summary noLabels = (Summary) Summary.build().name("nolabels").help("help").register(registry);
+    Summary noLabels = Summary.build().name("nolabels").help("help").register(registry);
     noLabels.observe(2);
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP nolabels help\n"
@@ -84,7 +84,7 @@ public class TextFormatTest {
 
   @Test
   public void testLabelsOutput() throws IOException {
-    Gauge labels = (Gauge) Gauge.build().name("labels").help("help").labelNames("l").register(registry);
+    Gauge labels = Gauge.build().name("labels").help("help").labelNames("l").register(registry);
     labels.labels("a").inc();
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP labels help\n"
@@ -94,7 +94,7 @@ public class TextFormatTest {
 
   @Test
   public void testLabelValuesEscaped() throws IOException {
-    Gauge labels = (Gauge) Gauge.build().name("labels").help("help").labelNames("l").register(registry);
+    Gauge labels = Gauge.build().name("labels").help("help").labelNames("l").register(registry);
     labels.labels("a\nb\\c\"d").inc();
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP labels help\n"
@@ -104,7 +104,7 @@ public class TextFormatTest {
 
   @Test
   public void testHelpEscaped() throws IOException {
-    Gauge noLabels = (Gauge) Gauge.build().name("nolabels").help("h\"e\\l\np").register(registry);
+    Gauge noLabels = Gauge.build().name("nolabels").help("h\"e\\l\np").register(registry);
     noLabels.inc();
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP nolabels h\"e\\\\l\\np\n"


### PR DESCRIPTION
I had a discussion with @brian-brazil about potential improvements in TextFormat.java.
This is one proposal. Replaces https://github.com/prometheus/client_java/pull/181
 