### PR TITLE
Add JVM and OS version info to export

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java
@@ -25,6 +25,7 @@ public class DefaultExports {
       new GarbageCollectorExports().register();
       new ThreadExports().register();
       new ClassLoadingExports().register();
+      new VersionInfoExports().register();
       initialized = true;
     }
   }

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
@@ -26,14 +26,13 @@ public class VersionInfoExports extends Collector {
 
 
     public List<MetricFamilySamples> collect() {
-        String UNKNOWN_LABEL_VALUE = "unknown";
         List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
 
         GaugeMetricFamily jvmInfo = new GaugeMetricFamily(
                 "jvm_info",
-                "jvm version info",
+                "JVM version info",
                 Arrays.asList("version", "vendor"));
-        jvmInfo.addMetric(Arrays.asList(System.getProperty("java.runtime.version", UNKNOWN_LABEL_VALUE), System.getProperty("java.vm.vendor", UNKNOWN_LABEL_VALUE)), 1L);
+        jvmInfo.addMetric(Arrays.asList(System.getProperty("java.runtime.version", "unknown"), System.getProperty("java.vm.vendor", "unknown")), 1L);
         mfs.add(jvmInfo);
 
         return mfs;

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Exports JVM and OS version info.
+ * Exports JVM version info.
  * <p>
  * Example usage:
  * <pre>
@@ -19,7 +19,6 @@ import java.util.List;
  * Metrics being exported:
  * <pre>
  *   jvm_info{version="1.8.0_45-b14",vendor="Oracle Corporation"} 1.0
- *   os_info{name="Linux",version="2.6.32-504.23.4.el6.x86_64",arch="amd64"} 1.0
  * </pre>
  */
 
@@ -36,13 +35,6 @@ public class VersionInfoExports extends Collector {
                 Arrays.asList("version", "vendor"));
         jvmInfo.addMetric(Arrays.asList(System.getProperty("java.runtime.version", UNKNOWN_LABEL_VALUE), System.getProperty("java.vm.vendor", UNKNOWN_LABEL_VALUE)), 1L);
         mfs.add(jvmInfo);
-
-        GaugeMetricFamily osInfo = new GaugeMetricFamily(
-                "os_info",
-                "os version info",
-                Arrays.asList("name", "version", "arch"));
-        osInfo.addMetric(Arrays.asList(System.getProperty("os.name", UNKNOWN_LABEL_VALUE), System.getProperty("os.version"), System.getProperty("os.arch", UNKNOWN_LABEL_VALUE)), 1L);
-        mfs.add(osInfo);
 
         return mfs;
     }

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
@@ -18,8 +18,8 @@ import java.util.List;
  * </pre>
  * Metrics being exported:
  * <pre>
- *   jvm_info{version="",vendor=""} 1
- *   os_info{name="",version="",arch=""} 1
+ *   jvm_info{version="1.8.0_45-b14",vendor="Oracle Corporation"} 1.0
+ *   os_info{name="Linux",version="2.6.32-504.23.4.el6.x86_64",arch="amd64"} 1.0
  * </pre>
  */
 

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
@@ -1,0 +1,49 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Exports JVM and OS version info.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new VersionInfoExports().register();
+ * }
+ * </pre>
+ * Metrics being exported:
+ * <pre>
+ *   jvm_info{version="",vendor=""} 1
+ *   os_info{name="",version="",arch=""} 1
+ * </pre>
+ */
+
+public class VersionInfoExports extends Collector {
+
+
+    public List<MetricFamilySamples> collect() {
+        String UNKNOWN_LABEL_VALUE = "unknown";
+        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+
+        GaugeMetricFamily jvmInfo = new GaugeMetricFamily(
+                "jvm_info",
+                "jvm version info",
+                Arrays.asList("version", "vendor"));
+        jvmInfo.addMetric(Arrays.asList(System.getProperty("java.runtime.version", UNKNOWN_LABEL_VALUE), System.getProperty("java.vm.vendor", UNKNOWN_LABEL_VALUE)), 1L);
+        mfs.add(jvmInfo);
+
+        GaugeMetricFamily osInfo = new GaugeMetricFamily(
+                "os_info",
+                "os version info",
+                Arrays.asList("name", "version", "arch"));
+        osInfo.addMetric(Arrays.asList(System.getProperty("os.name", UNKNOWN_LABEL_VALUE), System.getProperty("os.version"), System.getProperty("os.arch", UNKNOWN_LABEL_VALUE)), 1L);
+        mfs.add(osInfo);
+
+        return mfs;
+    }
+}

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/VersionInfoExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/VersionInfoExportsTest.java
@@ -18,11 +18,10 @@ public class VersionInfoExportsTest {
 
     @Test
     public void testVersionInfo() {
-        String UNKNOWN_LABEL_VALUE = "unknown";
         assertEquals(
                 1L,
                 registry.getSampleValue(
-                        "jvm_info", new String[]{"version", "vendor"}, new String[]{System.getProperty("java.runtime.version", UNKNOWN_LABEL_VALUE), System.getProperty("java.vm.vendor", UNKNOWN_LABEL_VALUE)}),
+                        "jvm_info", new String[]{"version", "vendor"}, new String[]{System.getProperty("java.runtime.version", "unknown"), System.getProperty("java.vm.vendor", "unknown")}),
                 .0000001);
     }
 }

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/VersionInfoExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/VersionInfoExportsTest.java
@@ -1,0 +1,33 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+
+import static org.junit.Assert.assertEquals;
+
+public class VersionInfoExportsTest {
+
+    private CollectorRegistry registry = new CollectorRegistry();
+
+    @Before
+    public void setUp() {
+        new VersionInfoExports().register(registry);
+    }
+
+    @Test
+    public void testVersionInfo() {
+        String UNKNOWN_LABEL_VALUE = "unknown";
+        assertEquals(
+                1L,
+                registry.getSampleValue(
+                        "jvm_info", new String[]{"version", "vendor"}, new String[]{System.getProperty("java.runtime.version", UNKNOWN_LABEL_VALUE), System.getProperty("java.vm.vendor", UNKNOWN_LABEL_VALUE)}),
+                .0000001);
+        assertEquals(
+                1L,
+                registry.getSampleValue(
+                        "os_info", new String[]{"name", "version", "arch"}, new String[]{System.getProperty("os.name", UNKNOWN_LABEL_VALUE), System.getProperty("os.version", UNKNOWN_LABEL_VALUE), System.getProperty("os.arch", UNKNOWN_LABEL_VALUE)}),
+                .0000001);
+    }
+}

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/VersionInfoExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/VersionInfoExportsTest.java
@@ -24,10 +24,5 @@ public class VersionInfoExportsTest {
                 registry.getSampleValue(
                         "jvm_info", new String[]{"version", "vendor"}, new String[]{System.getProperty("java.runtime.version", UNKNOWN_LABEL_VALUE), System.getProperty("java.vm.vendor", UNKNOWN_LABEL_VALUE)}),
                 .0000001);
-        assertEquals(
-                1L,
-                registry.getSampleValue(
-                        "os_info", new String[]{"name", "version", "arch"}, new String[]{System.getProperty("os.name", UNKNOWN_LABEL_VALUE), System.getProperty("os.version", UNKNOWN_LABEL_VALUE), System.getProperty("os.arch", UNKNOWN_LABEL_VALUE)}),
-                .0000001);
     }
 }


### PR DESCRIPTION
This PR would allow us to report on JVM and OS versions, e.g. for vulnerability management.

@brian-brazil / @beorn7 Please review of this is PR can be accepted. Happy to make changes if and where needed.