### PR TITLE
Remove unnecessary allocation in TextFormat

### DIFF
--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -9,6 +9,11 @@ import io.prometheus.client.Collector;
 
 public class TextFormat {
   /**
+   * Content-type for text version 0.0.4.
+   */
+  public final static String CONTENT_TYPE_004 = "text/plain; version=0.0.4; charset=utf-8";
+
+  /**
    * Write out the text version 0.0.4 of the given MetricFamilySamples.
    */
   public static void write004(Writer writer, Enumeration<Collector.MetricFamilySamples> mfs) throws IOException {
@@ -18,7 +23,7 @@ public class TextFormat {
       writer.write("# HELP ");
       writer.write(metricFamilySamples.name);
       writer.write(' ');
-      writer.write(escapeHelp(metricFamilySamples.help));
+      writeEscapedHelp(writer, metricFamilySamples.help);
       writer.write('\n');
 
       writer.write("# TYPE ");
@@ -34,7 +39,7 @@ public class TextFormat {
           for (int i = 0; i < sample.labelNames.size(); ++i) {
             writer.write(sample.labelNames.get(i));
             writer.write("=\"");
-            writer.write(escapeLabelValue(sample.labelValues.get(i)));
+            writeEscapedLabelValue(writer, sample.labelValues.get(i));
             writer.write("\",");
           }
           writer.write('}');
@@ -46,51 +51,42 @@ public class TextFormat {
     }
   }
 
-  /**
-   * Content-type for text version 0.0.4.
-   */
-  public final static String CONTENT_TYPE_004 = "text/plain; version=0.0.4; charset=utf-8";
-
-  static String escapeHelp(String s) {
-    StringBuilder sb = new StringBuilder(s.length() * 2);
+  private static void writeEscapedHelp(Writer writer, String s) throws IOException {
     for (int i = 0; i < s.length(); i++) {
       char c = s.charAt(i);
-      switch (s.charAt(i)) {
+      switch (c) {
         case '\\':
-          sb.append("\\\\");
+          writer.append("\\\\");
           break;
         case '\n':
-          sb.append("\\n");
+          writer.append("\\n");
           break;
         default:
-          sb.append(c);
+          writer.append(c);
       }
     }
-    return sb.toString();
   }
 
-  static String escapeLabelValue(String s) {
-    StringBuilder sb = new StringBuilder(s.length() * 2);
+  private static void writeEscapedLabelValue(Writer writer, String s) throws IOException {
     for (int i = 0; i < s.length(); i++) {
       char c = s.charAt(i);
-      switch (s.charAt(i)) {
+      switch (c) {
         case '\\':
-          sb.append("\\\\");
+          writer.append("\\\\");
           break;
         case '\"':
-          sb.append("\\\"");
+          writer.append("\\\"");
           break;
         case '\n':
-          sb.append("\\n");
+          writer.append("\\n");
           break;
         default:
-          sb.append(c);
+          writer.append(c);
       }
     }
-    return sb.toString();
   }
 
-  static String typeString(Collector.Type t) {
+  private static String typeString(Collector.Type t) {
     switch (t) {
       case GAUGE:
         return "gauge";

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
@@ -95,19 +95,19 @@ public class TextFormatTest {
   @Test
   public void testLabelValuesEscaped() throws IOException {
     Gauge labels = Gauge.build().name("labels").help("help").labelNames("l").register(registry);
-    labels.labels("a\nb\\c\"d").inc();
+    labels.labels("ąćčęntěd a\nb\\c\"d").inc();
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP labels help\n"
                  + "# TYPE labels gauge\n"
-                 + "labels{l=\"a\\nb\\\\c\\\"d\",} 1.0\n", writer.toString());
+                 + "labels{l=\"ąćčęntěd a\\nb\\\\c\\\"d\",} 1.0\n", writer.toString());
   }
 
   @Test
   public void testHelpEscaped() throws IOException {
-    Gauge noLabels = Gauge.build().name("nolabels").help("h\"e\\l\np").register(registry);
+    Gauge noLabels = Gauge.build().name("nolabels").help("ąćčęntěd h\"e\\l\np").register(registry);
     noLabels.inc();
     TextFormat.write004(writer, registry.metricFamilySamples());
-    assertEquals("# HELP nolabels h\"e\\\\l\\np\n"
+    assertEquals("# HELP nolabels ąćčęntěd h\"e\\\\l\\np\n"
                  + "# TYPE nolabels gauge\n"
                  + "nolabels 1.0\n", writer.toString());
   }


### PR DESCRIPTION
Further improve work from 5760fe1 - avoid allocating
StringBuilder with double size and allocating a string
from it.
Avoid reading the same character twice.
Add accented characters the the test.