### PR TITLE
Improve array allocation

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -144,7 +144,7 @@ public abstract class Collector {
      *  describe, or if that's not practical have describe return an empty
      *  list.
      */
-    public List<MetricFamilySamples> describe();
+    List<MetricFamilySamples> describe();
   }
 
 

--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -87,7 +87,7 @@ public class CollectorRegistry {
    */
   private Set<Collector> collectors() {
     synchronized (collectorsToNames) {
-      return new HashSet(collectorsToNames.keySet());
+      return new HashSet<Collector>(collectorsToNames.keySet());
     }
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -1,6 +1,7 @@
 package io.prometheus.client;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -155,21 +156,15 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
 
   @Override
   public List<MetricFamilySamples> collect() {
-    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
       samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
     }
-    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.COUNTER, help, samples);
-
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(mfs);
-    return mfsList;
+    return familySamplesList(Type.COUNTER, samples);
   }
 
   @Override
   public List<MetricFamilySamples> describe() {
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(new CounterMetricFamily(fullname, help, labelNames));
-    return mfsList;
+    return Collections.<MetricFamilySamples>singletonList(new CounterMetricFamily(fullname, help, labelNames));
   }
 }

--- a/simpleclient/src/main/java/io/prometheus/client/CounterMetricFamily.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CounterMetricFamily.java
@@ -1,8 +1,8 @@
 package io.prometheus.client;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Counter metric family, for custom collectors and exporters.
@@ -30,7 +30,7 @@ import java.util.Collections;
  */
 public class CounterMetricFamily extends Collector.MetricFamilySamples {
 
-  private List<String> labelNames;
+  private final List<String> labelNames;
 
   public CounterMetricFamily(String name, String help, double value) {
     super(name, Collector.Type.COUNTER, help, new ArrayList<Sample>());

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -3,6 +3,7 @@ package io.prometheus.client;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -291,22 +292,16 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
 
   @Override
   public List<MetricFamilySamples> collect() {
-    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
       samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
     }
-    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.GAUGE, help, samples);
-
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(mfs);
-    return mfsList;
+    return familySamplesList(Type.GAUGE, samples);
   }
 
   @Override
   public List<MetricFamilySamples> describe() {
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(new GaugeMetricFamily(fullname, help, labelNames));
-    return mfsList;
+    return Collections.<MetricFamilySamples>singletonList(new GaugeMetricFamily(fullname, help, labelNames));
   }
 
   static class TimeProvider {

--- a/simpleclient/src/main/java/io/prometheus/client/GaugeMetricFamily.java
+++ b/simpleclient/src/main/java/io/prometheus/client/GaugeMetricFamily.java
@@ -1,8 +1,8 @@
 package io.prometheus.client;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Gauge metric family, for custom collectors and exporters.
@@ -30,7 +30,7 @@ import java.util.Collections;
  */
 public class GaugeMetricFamily extends Collector.MetricFamilySamples {
 
-  private List<String> labelNames;
+  private final List<String> labelNames;
 
   public GaugeMetricFamily(String name, String help, double value) {
     super(name, Collector.Type.GAUGE, help, new ArrayList<Sample>());

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -3,6 +3,7 @@ package io.prometheus.client;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -309,17 +310,13 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
       samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum));
     }
 
-    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.HISTOGRAM, help, samples);
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(mfs);
-    return mfsList;
+    return familySamplesList(Type.HISTOGRAM, samples);
   }
 
   @Override
   public List<MetricFamilySamples> describe() {
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(new MetricFamilySamples(fullname, Type.HISTOGRAM, help, new ArrayList<MetricFamilySamples.Sample>()));
-    return mfsList;
+    return Collections.singletonList(
+            new MetricFamilySamples(fullname, Type.HISTOGRAM, help, Collections.<MetricFamilySamples.Sample>emptyList()));
   }
 
   double[] getBuckets() {

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -1,5 +1,6 @@
 package io.prometheus.client;
 
+import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.Arrays;
@@ -141,6 +142,13 @@ public abstract class SimpleCollector<Child> extends Collector {
    * Return a new child, workaround for Java generics limitations.
    */
   protected abstract Child newChild();
+
+  protected List<MetricFamilySamples> familySamplesList(Collector.Type type, List<MetricFamilySamples.Sample> samples) {
+    MetricFamilySamples mfs = new MetricFamilySamples(fullname, type, help, samples);
+    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>(1);
+    mfsList.add(mfs);
+    return mfsList;
+  }
 
   protected SimpleCollector(Builder b) {
     if (b.name.isEmpty()) throw new IllegalStateException("Name hasn't been set.");

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -94,7 +94,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
 
   public static class Builder extends SimpleCollector.Builder<Builder, Summary> {
 
-    private List<Quantile> quantiles = new ArrayList<Quantile>();
+    private final List<Quantile> quantiles = new ArrayList<Quantile>();
     private long maxAgeSeconds = TimeUnit.MINUTES.toSeconds(10);
     private int ageBuckets = 5;
 
@@ -333,17 +333,12 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
       samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum));
     }
 
-    MetricFamilySamples mfs = new MetricFamilySamples(fullname, Type.SUMMARY, help, samples);
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(mfs);
-    return mfsList;
+    return familySamplesList(Type.SUMMARY, samples);
   }
 
   @Override
   public List<MetricFamilySamples> describe() {
-    List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
-    mfsList.add(new SummaryMetricFamily(fullname, help, labelNames));
-    return mfsList;
+    return Collections.<MetricFamilySamples>singletonList(new SummaryMetricFamily(fullname, help, labelNames));
   }
 
 }

--- a/simpleclient/src/main/java/io/prometheus/client/SummaryMetricFamily.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SummaryMetricFamily.java
@@ -30,8 +30,8 @@ import java.util.Collections;
  */
 public class SummaryMetricFamily extends Collector.MetricFamilySamples {
 
-  private List<String> labelNames;
-  private List<Double> quantiles;
+  private final List<String> labelNames;
+  private final List<Double> quantiles;
 
   public SummaryMetricFamily(String name, String help, double count, double sum) {
     super(name, Collector.Type.SUMMARY, help, new ArrayList<Sample>());

--- a/simpleclient/src/test/java/io/prometheus/client/CounterMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterMetricFamilyTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeMetricFamilyTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryMetricFamilyTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/SpringBootMetricsCollector.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/SpringBootMetricsCollector.java
@@ -40,7 +40,7 @@ public class SpringBootMetricsCollector extends Collector implements Collector.D
         double value = metric.getValue().doubleValue();
         MetricFamilySamples metricFamilySamples = new MetricFamilySamples(
                 name, Type.GAUGE, name, Collections.singletonList(
-                new MetricFamilySamples.Sample(name, new ArrayList<String>(), new ArrayList<String>(), value)));
+                new MetricFamilySamples.Sample(name, Collections.<String>emptyList(), Collections.<String>emptyList(), value)));
         samples.add(metricFamilySamples);
       }
     }


### PR DESCRIPTION
- precompute array size when it's obvious - avoids re-allocating
- use singletonList() when the array can be immutable
- replace some empty arrays with emptyList()