### PR TITLE
Last metric label has redundant comma

### DIFF
--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -40,7 +40,10 @@ public class TextFormat {
             writer.write(sample.labelNames.get(i));
             writer.write("=\"");
             writeEscapedLabelValue(writer, sample.labelValues.get(i));
-            writer.write("\",");
+            writer.write("\"");
+            if (i< sample.labelNames.size()-1) {
+              writer.write(",");
+            }
           }
           writer.write('}');
         }


### PR DESCRIPTION
Prometheus was unable to parse format because of redundant comma (",") in the end of the labels list