### PR TITLE
Add support for RedHat OpenShift HOSA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     </developers>
 
     <modules>
-        <module>simpleclient</module>
+        <!--module>simpleclient</module>
         <module>simpleclient_common</module>
         <module>simpleclient_caffeine</module>
         <module>simpleclient_dropwizard</module>
@@ -55,11 +55,11 @@
         <module>simpleclient_log4j2</module>
         <module>simpleclient_logback</module>
         <module>simpleclient_pushgateway</module>
-        <module>simpleclient_servlet</module>
+        <module>simpleclient_servlet</module-->
         <module>simpleclient_spring_boot</module>
-        <module>simpleclient_jetty</module>
+        <!--module>simpleclient_jetty</module>
         <module>simpleclient_vertx</module>
-        <module>benchmark</module>
+        <module>benchmark</module-->
     </modules>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     </developers>
 
     <modules>
-        <!--module>simpleclient</module>
+        <module>simpleclient</module>
         <module>simpleclient_common</module>
         <module>simpleclient_caffeine</module>
         <module>simpleclient_dropwizard</module>
@@ -55,11 +55,11 @@
         <module>simpleclient_log4j2</module>
         <module>simpleclient_logback</module>
         <module>simpleclient_pushgateway</module>
-        <module>simpleclient_servlet</module-->
+        <module>simpleclient_servlet</module>
         <module>simpleclient_spring_boot</module>
-        <!--module>simpleclient_jetty</module>
+        <module>simpleclient_jetty</module>
         <module>simpleclient_vertx</module>
-        <module>benchmark</module-->
+        <module>benchmark</module>
     </modules>
     
     <properties>

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusEndpointConfiguration.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusEndpointConfiguration.java
@@ -1,8 +1,11 @@
 package io.prometheus.client.spring.boot;
 
-import io.prometheus.client.CollectorRegistry;
+import org.springframework.boot.actuate.condition.ConditionalOnEnabledEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import io.prometheus.client.CollectorRegistry;
 
 @Configuration
 class PrometheusEndpointConfiguration {
@@ -10,5 +13,12 @@ class PrometheusEndpointConfiguration {
   @Bean
   public PrometheusEndpoint prometheusEndpoint() {
     return new PrometheusEndpoint(CollectorRegistry.defaultRegistry);
+  }
+  
+  @Bean
+  @ConditionalOnBean(PrometheusEndpoint.class)
+  @ConditionalOnEnabledEndpoint("prometheus")
+  public PrometheusMVCEndpoint prometheusMVCEndpoint(PrometheusEndpoint delegate) {
+	return new PrometheusMVCEndpoint(delegate);
   }
 }

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMVCEndpoint.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMVCEndpoint.java
@@ -1,0 +1,33 @@
+package io.prometheus.client.spring.boot;
+
+import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@ConfigurationProperties("endpoints.prometheus")
+public class PrometheusMVCEndpoint extends EndpointMvcAdapter {
+
+	private final PrometheusEndpoint delegate;
+	
+	public PrometheusMVCEndpoint(PrometheusEndpoint delegate) {
+		super(delegate);
+		this.delegate = delegate;
+	}
+	
+	@ResponseBody
+	@RequestMapping(value="/metrics", produces={"text/plain;version=0.0.4"})
+	public String metrics() {
+		if (!this.delegate.isEnabled()) {
+			// Shouldn't happen - MVC endpoint shouldn't be registered when delegate's
+			// disabled
+			return getDisabledResponse().toString();
+		}
+		
+		ResponseEntity<String> result = this.delegate.invoke();
+		
+		return result.getBody();
+	}
+
+}

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMVCEndpoint.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMVCEndpoint.java
@@ -6,6 +6,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import io.prometheus.client.exporter.common.TextFormat;
+
 @ConfigurationProperties("endpoints.prometheus")
 public class PrometheusMVCEndpoint extends EndpointMvcAdapter {
 
@@ -16,18 +18,19 @@ public class PrometheusMVCEndpoint extends EndpointMvcAdapter {
 		this.delegate = delegate;
 	}
 	
+	@SuppressWarnings("unchecked")
 	@ResponseBody
-	@RequestMapping(value="/metrics", produces={"text/plain;version=0.0.4"})
-	public String metrics() {
+	@RequestMapping(value="/metrics", produces={TextFormat.CONTENT_TYPE_004})
+	public ResponseEntity<String> metrics() {
 		if (!this.delegate.isEnabled()) {
 			// Shouldn't happen - MVC endpoint shouldn't be registered when delegate's
 			// disabled
-			return getDisabledResponse().toString();
+			return (ResponseEntity<String>) getDisabledResponse();
 		}
 		
 		ResponseEntity<String> result = this.delegate.invoke();
 		
-		return result.getBody();
+		return result;
 	}
 
 }

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMVCEndpoint.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMVCEndpoint.java
@@ -20,7 +20,7 @@ public class PrometheusMVCEndpoint extends EndpointMvcAdapter {
 	
 	@SuppressWarnings("unchecked")
 	@ResponseBody
-	@RequestMapping(value="/metrics", produces={TextFormat.CONTENT_TYPE_004})
+	@RequestMapping( produces={TextFormat.CONTENT_TYPE_004})
 	public ResponseEntity<String> metrics() {
 		if (!this.delegate.isEnabled()) {
 			// Shouldn't happen - MVC endpoint shouldn't be registered when delegate's

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusEndpointTest.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusEndpointTest.java
@@ -77,7 +77,7 @@ public class PrometheusEndpointTest {
     headers.setAccept(Arrays.asList( MediaType.valueOf("text/plain;version=0.0.4")));
     HttpEntity<String> entity = new HttpEntity<String>("parameters", headers);
         
-    ResponseEntity<String> metricsResponse = template.exchange(getBaseUrl() + "/prometheus/metrics", HttpMethod.GET, entity, String.class);
+    ResponseEntity<String> metricsResponse = template.exchange(getBaseUrl() + "/prometheus", HttpMethod.GET, entity, String.class);
 
     // then:
     assertEquals(HttpStatus.OK, metricsResponse.getStatusCode());

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusEndpointTest.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusEndpointTest.java
@@ -5,9 +5,13 @@ import io.prometheus.client.matchers.CustomMatchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.endpoint.mvc.EndpointHandlerMapping;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.TestRestTemplate;
 import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -53,6 +57,35 @@ public class PrometheusEndpointTest {
     List<String> responseLines = Arrays.asList(metricsResponse.getBody().split("\n"));
     assertThat(responseLines, CustomMatchers.<String>exactlyNItems(1,
         matchesPattern("foo_bar\\{label1=\"val1\",label2=\"val2\",?\\} 3.0")));
+  }
+  
+  @Test
+  public void testMetricsExportedThroughPrometheusMVCEndpoint() {
+    // given:
+    final Counter promCounter = Counter.build()
+        .name("foo_bar2")
+        .help("a simple prometheus counter")
+        .labelNames("label1", "label2")
+        .register();
+
+    // when:
+    promCounter.labels("val1", "val2").inc(3);
+   
+    final String xx = "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3";
+    
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(Arrays.asList( MediaType.valueOf("text/plain;version=0.0.4")));
+    HttpEntity<String> entity = new HttpEntity<String>("parameters", headers);
+        
+    ResponseEntity<String> metricsResponse = template.exchange(getBaseUrl() + "/prometheus/metrics", HttpMethod.GET, entity, String.class);
+
+    // then:
+    assertEquals(HttpStatus.OK, metricsResponse.getStatusCode());
+    assertTrue(MediaType.TEXT_PLAIN.isCompatibleWith(metricsResponse.getHeaders().getContentType()));
+
+    List<String> responseLines = Arrays.asList(metricsResponse.getBody().split("\n"));
+    assertThat(responseLines, CustomMatchers.<String>exactlyNItems(1,
+        matchesPattern("foo_bar2\\{label1=\"val1\",label2=\"val2\",?\\} 3.0")));
   }
 
   private String getBaseUrl() {


### PR DESCRIPTION
My extention aim to address the integration between prometheus metrics and RedHat Openshift platform. See this article for reference:

https://www.hawkular.org/blog/2017/01/17/obst-hosa.html

The short story is that HOSA, in the request where it collects application metrics, adds an HTTP header like this:
```
accept: application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3
```
This prevents your endpoint to answer correctly and HOSA receive instead a error: HTTP 404.

My modification adds a second endpoint at /prometheus/metrics witch produce content compatible with the HOSA request.

Bye
Nicola Santi 

