### PR TITLE
add `simpleclient_spring_hibernate` module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>simpleclient_logback</module>
         <module>simpleclient_pushgateway</module>
         <module>simpleclient_servlet</module>
+        <module>simpleclient_spring_hibernate</module>
         <module>simpleclient_spring_web</module>
         <module>simpleclient_spring_boot</module>
         <module>simpleclient_jetty</module>

--- a/simpleclient_spring_hibernate/pom.xml
+++ b/simpleclient_spring_hibernate/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.22-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>simpleclient_spring_hibernate</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Prometheus Java SimpleClient Spring Hibernate Integration</name>
+    <description>
+        Spring-specific metrics helpers
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>abacaphiliac</id>
+            <name>Timothy Younger</name>
+            <email>abacaphiliac@gmail.com</email>
+        </developer>
+    </developers>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_spring_boot</artifactId>
+            <version>0.0.22-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hibernate</artifactId>
+            <version>0.0.22-SNAPSHOT</version>
+        </dependency>
+
+        <!-- We support Hibernate versions >= 4.2 -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>4.2.0.Final</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test Dependencies Follow -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>1.3.3.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+            <version>1.3.3.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/simpleclient_spring_hibernate/src/main/java/io/prometheus/client/spring/hibernate/SimpleClientHibernateApplicationListener.java
+++ b/simpleclient_spring_hibernate/src/main/java/io/prometheus/client/spring/hibernate/SimpleClientHibernateApplicationListener.java
@@ -1,0 +1,48 @@
+package io.prometheus.client.spring.hibernate;
+
+import io.prometheus.client.hibernate.HibernateStatisticsCollector;
+import org.hibernate.Session;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+
+@Component
+public class SimpleClientHibernateApplicationListener implements ApplicationListener<ApplicationReadyEvent> {
+  @Autowired
+  private EntityManager entityManager;
+
+  @Value("${spring.application.name:bootstrap}")
+  private String appName = "bootstrap";
+
+  private HibernateStatisticsCollector collector = new HibernateStatisticsCollector();
+
+  public SimpleClientHibernateApplicationListener() {
+
+  }
+
+  public SimpleClientHibernateApplicationListener(
+      HibernateStatisticsCollector collector,
+      EntityManager entityManager,
+      String appName
+  ) {
+    this.collector = collector;
+    this.entityManager = entityManager;
+    this.appName = appName;
+  }
+
+  @Override
+  public void onApplicationEvent(ApplicationReadyEvent event) {
+    if (entityManager == null) {
+      return;
+    }
+
+    Session session = (Session) entityManager.getDelegate();
+
+    collector.add(session.getSessionFactory(), appName);
+    collector.register();
+  }
+}

--- a/simpleclient_spring_hibernate/src/test/java/io/prometheus/client/spring/hibernate/SimpleClientHibernateApplicationListenerTest.java
+++ b/simpleclient_spring_hibernate/src/test/java/io/prometheus/client/spring/hibernate/SimpleClientHibernateApplicationListenerTest.java
@@ -1,0 +1,58 @@
+package io.prometheus.client.spring.hibernate;
+
+import io.prometheus.client.hibernate.HibernateStatisticsCollector;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.persistence.EntityManager;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleClientHibernateApplicationListenerTest {
+  @Mock
+  private HibernateStatisticsCollector collector;
+
+  @Mock
+  private EntityManager entityManager;
+
+  @Mock
+  private Session session;
+
+  @Mock
+  private SessionFactory sessionFactory;
+
+  @Mock
+  private ApplicationReadyEvent event;
+
+  @Before
+  public void setUp() throws Exception {
+    initMocks(this);
+
+    when(entityManager.getDelegate()).thenReturn(session);
+
+    when(session.getSessionFactory()).thenReturn(sessionFactory);
+  }
+
+  @Test
+  public void onApplicationEventWithEventManagerAndAppName() throws Exception {
+    (new SimpleClientHibernateApplicationListener(collector, entityManager, "MySpringApp"))
+        .onApplicationEvent(event);
+
+    verify(collector).add(sessionFactory, "MySpringApp");
+    verify(collector).register();
+  }
+
+  @Test
+  public void onApplicationEventWithoutEventManager() throws Exception {
+    (new SimpleClientHibernateApplicationListener()).onApplicationEvent(event);
+  }
+}


### PR DESCRIPTION
add `simpleclient_spring_hibernate` module, which integrates `simpleclient_hibernate` and `simpleclient_spring_boot`.

this module provides an annotated ApplicationListener to listen for the SpringBoot ApplicationReadyEvent and registers HibernateStatisticsCollector with an autowired SessionFactory and annotated `spring.application.name`.

this was how i was able to activate Hibernate stats in a SpringBoot app and thought it might save others some time. what do you think?