### PR TITLE
Fix Timer#close signature to not throws IOException

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -1,7 +1,6 @@
 package io.prometheus.client;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -120,10 +119,9 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
 
      /**
       * Equivalent to calling {@link #setDuration()}.
-      * @throws IOException
       */
      @Override
-     public void close() throws IOException {
+     public void close() {
        setDuration();
      }
    }

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -1,7 +1,6 @@
 package io.prometheus.client;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -175,10 +174,9 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
 
     /**
      * Equivalent to calling {@link #observeDuration()}.
-     * @throws IOException
      */
     @Override
-    public void close() throws IOException {
+    public void close() {
       observeDuration();
     }
   }

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -3,7 +3,6 @@ package io.prometheus.client;
 import io.prometheus.client.CKMSQuantiles.Quantile;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -182,10 +181,9 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
 
     /**
      * Equivalent to calling {@link #observeDuration()}.
-     * @throws IOException
      */
     @Override
-    public void close() throws IOException {
+    public void close() {
       observeDuration();
     }
   }


### PR DESCRIPTION
Please consider following method:
```
void run() { // Do not throw anything
    heavy();
}
```
Now I'd like to measure how long does `heavy` take using Timer with try-with-resources:
```
void run() { // Do not throw anything
    try (Timer t = FOO.startTimer()) {
        heavy();
    }
}
```
Unexpectedly, we got compiler error like: 
```
Unhandled exception from auto-closeable resource: IOException
```
Because the signature of `close` throws IOE, but it never gonna throw it.

So we need to write like following:
```
void run() { // Do not throw anything
    try (Timer t = FOO.startTimer()) {
        heavy();
    } catch (IOException e) {/* never gonna be happen */}
}
or
void run() throws IOException { // sometime it impossible by constraint of super method
    try (Timer t = FOO.startTimer()) {
        heavy();
    }
}
```
These will lose benefit of try-with-resources.

Let's fix the signature of `close`.

@brian-brazil 