### PR TITLE
Remove checked exception from constructor since it is not needed

### DIFF
--- a/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
@@ -71,8 +71,7 @@ public class MetricsFilter implements Filter {
             String metricName,
             String help,
             Integer pathComponents,
-            double[] buckets
-    ) throws ServletException {
+            double[] buckets) {
         this.metricName = metricName;
         this.buckets = buckets;
         if (help != null) {


### PR DESCRIPTION
Since this exception is not thrown in the constructor it is not needed.

@brian-brazil 