### PR TITLE
Convert spring boot actuator metrics to prometheus 

### DIFF
--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/GaugeResponseActuatorMetricConverter.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/GaugeResponseActuatorMetricConverter.java
@@ -1,0 +1,55 @@
+package io.prometheus.client.spring.boot;
+
+import io.prometheus.client.Collector.MetricFamilySamples;
+import org.springframework.boot.actuate.metrics.Metric;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class GaugeResponseActuatorMetricConverter {
+
+	private List<String> labelsMerged;
+	private List<String> labelsPerHttpMethod;
+
+	private final static String GAUGE_RESPONSE_NAME = "gauge_response";
+
+	public GaugeResponseActuatorMetricConverter() {
+		this.labelsMerged = new ArrayList<String>();
+		this.labelsMerged.add("endpoint");
+
+		this.labelsPerHttpMethod = new ArrayList<String>(labelsMerged);
+		this.labelsPerHttpMethod.add("method");
+	}
+
+	public MetricFamilySamples.Sample convert(Metric<?> metric) {
+		MetricFamilySamples.Sample sample;
+		if (containsHttpMethod(metric.getName())) {
+			List<String> labelValues  = retrieveLabelValues("gauge.response.", metric.getName());
+			return new MetricFamilySamples.Sample(GAUGE_RESPONSE_NAME, labelsPerHttpMethod, labelValues, metric.getValue().doubleValue());
+		} else {
+			List<String> labelValues  = retrieveJustEndpoint("gauge.response.", metric.getName());
+			return new MetricFamilySamples.Sample(GAUGE_RESPONSE_NAME, labelsMerged, labelValues, metric.getValue().doubleValue());
+		}
+	}
+
+	private List<String> retrieveJustEndpoint(String keyToRemove, String name) {
+		return Arrays.asList(name.replace(keyToRemove , ".").replaceAll("\\.","/"));
+	}
+
+	private List<String> retrieveLabelValues(String keyToRemove, String name) {
+		String method = name.split("\\.")[2];
+		String endpoint = name.substring(name.lastIndexOf(method) + method.length()).replaceAll("\\.","/");
+		return Arrays.asList(method, endpoint);
+	}
+
+	private boolean containsHttpMethod(String name) {
+		return name.contains(".GET.")
+				|| name.contains(".POST.")
+				|| name.contains(".PUT.")
+				|| name.contains(".DELETE.")
+				|| name.contains(".OPTIONS.")
+				|| name.contains(".HEAD.")
+				|| name.contains(".CONNECT.");
+	}
+}

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/GaugeResponseActuatorMetricConverter.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/GaugeResponseActuatorMetricConverter.java
@@ -40,7 +40,7 @@ public class GaugeResponseActuatorMetricConverter {
 	private List<String> retrieveLabelValues(String keyToRemove, String name) {
 		String method = name.split("\\.")[2];
 		String endpoint = name.substring(name.lastIndexOf(method) + method.length()).replaceAll("\\.","/");
-		return Arrays.asList(method, endpoint);
+		return Arrays.asList(endpoint, method);
 	}
 
 	private boolean containsHttpMethod(String name) {

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/SpringBootMetricsCollectorTest.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/SpringBootMetricsCollectorTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import static org.hamcrest.Matchers.is;
@@ -42,8 +43,21 @@ public class SpringBootMetricsCollectorTest {
     counterService.increment("foo");
     gaugeService.submit("bar", 3.14);
 
+
     CollectorRegistry defaultRegistry = CollectorRegistry.defaultRegistry;
     assertThat(defaultRegistry.getSampleValue("counter_foo"), is(1.0));
     assertThat(defaultRegistry.getSampleValue("gauge_bar"), is(3.14));
   }
+
+  @Test
+  public void collectConvertedMetrics() throws Exception {
+    gaugeService.submit("response.GET.info.details", 3.0);
+    gaugeService.submit("response.info.details", 3.0);
+
+
+    CollectorRegistry defaultRegistry = CollectorRegistry.defaultRegistry;
+    assertThat(defaultRegistry.getSampleValue("gauge_response", new String[]{"endpoint", "method"}, new String[]{"GET", "/info/details"}), is(3.0));
+    assertThat(defaultRegistry.getSampleValue("gauge_response", new String[]{"endpoint"}, new String[]{"/info/details"}), is(3.0));
+  }
+
 }

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/SpringBootMetricsCollectorTest.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/SpringBootMetricsCollectorTest.java
@@ -56,7 +56,7 @@ public class SpringBootMetricsCollectorTest {
 
 
     CollectorRegistry defaultRegistry = CollectorRegistry.defaultRegistry;
-    assertThat(defaultRegistry.getSampleValue("gauge_response", new String[]{"endpoint", "method"}, new String[]{"GET", "/info/details"}), is(3.0));
+    assertThat(defaultRegistry.getSampleValue("gauge_response", new String[]{"endpoint", "method"}, new String[]{"/info/details", "GET"}), is(3.0));
     assertThat(defaultRegistry.getSampleValue("gauge_response", new String[]{"endpoint"}, new String[]{"/info/details"}), is(3.0));
   }
 


### PR DESCRIPTION
Spring boot actuator already measures some HTTP metrics and expose them, but the spring boot integration with prometheus just convert them in a way that is not really useful. See example bellow:

Spring boot actuator format:
``` 
"gauge.response.GET.metrics": 76.0,
"gauge.response.GET.info": 7.0,
"gauge.response.info": 25.0,
"gauge.response.metrics": 76.0
```

How is current been converted, what is quite useless if you try to create some dashboards 
```
# HELP gauge_response_GET_metrics gauge_response_GET_metrics
# TYPE gauge_response_GET_metrics gauge
gauge_response_GET_metrics 6.0
# HELP gauge_response_metrics gauge_response_metrics
# TYPE gauge_response_metrics gauge
gauge_response_metrics 5.0
```

And this is how is supposed to be:
```
# HELP gauge_response gauge_response
# TYPE gauge_response gauge
gauge_response{endpoint="/metrics", method="GET"} 4534.0
gauge_response{endpoint="/metrics"} 22.0
```

In case this PR is accepted I can also create another converter for COUNTERs. 