### PR TITLE
Spring Boot counter metrics are now counters in Prometheus

### DIFF
--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/SpringBootMetricsCollector.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/SpringBootMetricsCollector.java
@@ -31,6 +31,13 @@ public class SpringBootMetricsCollector extends Collector implements Collector.D
     this.publicMetrics = publicMetrics;
   }
 
+  protected Type parseType(String name) {
+    if (name.startsWith("counter.")) {
+      return Type.COUNTER;
+    }
+    return Type.GAUGE;
+  }
+
   @Override
   public List<MetricFamilySamples> collect() {
     ArrayList<MetricFamilySamples> samples = new ArrayList<MetricFamilySamples>();
@@ -38,8 +45,9 @@ public class SpringBootMetricsCollector extends Collector implements Collector.D
       for (Metric<?> metric : publicMetrics.metrics()) {
         String name = Collector.sanitizeMetricName(metric.getName());
         double value = metric.getValue().doubleValue();
+        Type type = parseType(metric.getName());
         MetricFamilySamples metricFamilySamples = new MetricFamilySamples(
-                name, Type.GAUGE, name, Collections.singletonList(
+                name, type, name, Collections.singletonList(
                 new MetricFamilySamples.Sample(name, Collections.<String>emptyList(), Collections.<String>emptyList(), value)));
         samples.add(metricFamilySamples);
       }

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/SpringBootMetricsCollectorTest.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/SpringBootMetricsCollectorTest.java
@@ -1,5 +1,6 @@
 package io.prometheus.client.spring.boot;
 
+import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Collection;
+import java.util.Enumeration;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -37,13 +39,26 @@ public class SpringBootMetricsCollectorTest {
     return springBootMetricsCollector;
   }
 
+  private Collector.MetricFamilySamples metricFamilySample(String name) {
+    Enumeration<Collector.MetricFamilySamples> samples = CollectorRegistry.defaultRegistry.metricFamilySamples();
+    while (samples.hasMoreElements()) {
+      Collector.MetricFamilySamples sample = samples.nextElement();
+      if (sample.name.equals(name)) {
+        return sample;
+      }
+    }
+    throw new RuntimeException("Expected metric " + name + " not found");
+  }
+
   @Test
   public void collect() throws Exception {
     counterService.increment("foo");
     gaugeService.submit("bar", 3.14);
 
     CollectorRegistry defaultRegistry = CollectorRegistry.defaultRegistry;
+    assertThat(metricFamilySample("counter_foo").type, is(Collector.Type.COUNTER));
     assertThat(defaultRegistry.getSampleValue("counter_foo"), is(1.0));
+    assertThat(metricFamilySample("gauge_bar").type, is(Collector.Type.GAUGE));
     assertThat(defaultRegistry.getSampleValue("gauge_bar"), is(3.14));
   }
 }


### PR DESCRIPTION
Primary motivation here is correctly exposing response code counts (metrics like `counter.status.200.star-star`).