### PR TITLE
Spring Boot response counts exported the Prometheus way

### DIFF
--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/SpringBootMetricsCollector.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/SpringBootMetricsCollector.java
@@ -6,10 +6,7 @@ import org.springframework.boot.actuate.endpoint.PublicMetrics;
 import org.springframework.boot.actuate.metrics.Metric;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
  * <p>Spring boot metrics integration for Prometheus exporter.</p>
@@ -25,14 +22,45 @@ import java.util.List;
 @Component
 public class SpringBootMetricsCollector extends Collector implements Collector.Describable {
   private final Collection<PublicMetrics> publicMetrics;
+  protected MetricFamilySamples httpResponseCountSamples;
 
   @Autowired
   public SpringBootMetricsCollector(Collection<PublicMetrics> publicMetrics) {
     this.publicMetrics = publicMetrics;
   }
 
+  protected void reset() {
+    // Spring Boot counters can be decremented, so we play it safe and make this a gauge in Prometheus
+    httpResponseCountSamples = new MetricFamilySamples(
+            "http_response_count", Type.GAUGE, "HTTP response count by path and status",
+            new LinkedList<MetricFamilySamples.Sample>());
+  }
+
+  protected void processHttpResponseCount(Metric<?> metric) {
+    if (!metric.getName().startsWith("counter.status.")) {
+      return;
+    }
+    // Parse the Spring Boot Actuator metric name
+    String[] parts = metric.getName().split("\\.", 4);
+    String responseCode = parts[2];
+    // We could do more processing, like mapping "root" -> "/", but there's not enough information provided by
+    // Spring to determine whether "counter.status.200.foo.bar" means the path "/foo.bar" or the path "/foo/bar",
+    // so it's less confusing to just leave the path as it is
+    String path = parts[3];
+    // Register the sample
+    httpResponseCountSamples.samples.add(
+            new MetricFamilySamples.Sample(
+                    httpResponseCountSamples.name,
+                    Arrays.asList("path", "status"),
+                    Arrays.asList(path, responseCode),
+                    metric.getValue().doubleValue()
+            )
+    );
+  }
+
   @Override
   public List<MetricFamilySamples> collect() {
+    reset();
     ArrayList<MetricFamilySamples> samples = new ArrayList<MetricFamilySamples>();
     for (PublicMetrics publicMetrics : this.publicMetrics) {
       for (Metric<?> metric : publicMetrics.metrics()) {
@@ -42,7 +70,11 @@ public class SpringBootMetricsCollector extends Collector implements Collector.D
                 name, Type.GAUGE, name, Collections.singletonList(
                 new MetricFamilySamples.Sample(name, Collections.<String>emptyList(), Collections.<String>emptyList(), value)));
         samples.add(metricFamilySamples);
+        processHttpResponseCount(metric);
       }
+    }
+    if (httpResponseCountSamples.samples.size() > 0) {
+      samples.add(httpResponseCountSamples);
     }
     return samples;
   }

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/SpringBootMetricsCollectorTest.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/SpringBootMetricsCollectorTest.java
@@ -1,6 +1,8 @@
 package io.prometheus.client.spring.boot;
 
+import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Gauge;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,8 +15,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Collection;
+import java.util.Enumeration;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -45,5 +49,36 @@ public class SpringBootMetricsCollectorTest {
     CollectorRegistry defaultRegistry = CollectorRegistry.defaultRegistry;
     assertThat(defaultRegistry.getSampleValue("counter_foo"), is(1.0));
     assertThat(defaultRegistry.getSampleValue("gauge_bar"), is(3.14));
+  }
+
+  private Double httpResponseCount(String path, String status) {
+    return CollectorRegistry.defaultRegistry.getSampleValue(
+            "http_response_count",
+            new String[]{"path", "status"},
+            new String[]{path, status}
+    );
+  }
+
+  @Test
+  public void httpResponseCount() throws Exception {
+    CollectorRegistry defaultRegistry = CollectorRegistry.defaultRegistry;
+    assertThat(httpResponseCount("root", "200"), nullValue());
+
+    counterService.increment("status.200.root");
+    counterService.increment("status.200.root");
+    counterService.increment("status.301.star-star");
+    counterService.increment("status.200.foo.bar.html");
+
+    // Test that the single http_response_count metric with labels is correctly exported
+    assertThat(httpResponseCount("root", "200"), is(2.0));
+    assertThat(httpResponseCount("root", "400"), nullValue());
+    assertThat(httpResponseCount("star-star", "301"), is(1.0));
+    assertThat(httpResponseCount("foo.bar.html", "200"), is(1.0));
+
+    // Test that the metrics are also exported transparently
+    assertThat(defaultRegistry.getSampleValue("counter_status_200_root"), is(2.0));
+    assertThat(defaultRegistry.getSampleValue("counter_status_400_root"), nullValue());
+    assertThat(defaultRegistry.getSampleValue("counter_status_301_star_star"), is(1.0));
+    assertThat(defaultRegistry.getSampleValue("counter_status_200_foo_bar_html"), is(1.0));
   }
 }


### PR DESCRIPTION
Building Prometheus queries for useful aggregations with the current way response counts are exported is rather painful - since there are no labels, the only thing we can do is do various kinds of matches on the metric name.

This PR creates a single metric `http_response_count`  with labels `status` and `path`, while also retaining the old metric names for backwards compatibility.