### PR TITLE
Accept URL to Pushgateway constructor. Closes #258

### DIFF
--- a/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
+++ b/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
@@ -59,7 +59,6 @@ public class PushGateway {
   // Visible for testing
   final String gatewayBaseURL;
   private static final int MILLISECONDS_PER_SECOND = 1000;
-
   /**
    * Construct a Pushgateway, with the given address.
    * <p>
@@ -272,7 +271,6 @@ public class PushGateway {
         url += "/" + entry.getKey() + "/" + URLEncoder.encode(entry.getValue(), "UTF-8");
       }
     }
-
     HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
     connection.setRequestProperty("Content-Type", TextFormat.CONTENT_TYPE_004);
     if (!method.equals("DELETE")) {

--- a/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
+++ b/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
@@ -83,6 +83,8 @@ public class PushGateway {
    * Creates a URL instance from a String representation of a URL without throwing a checked exception.
    * Required because you can't wrap a call to another constructor in a try statement.
    *
+   * TODO: Remove this along with other deprecated methods before version 1.0 is released.
+   *
    * @param urlString the String representation of the URL.
    * @return The URL instance.
    */

--- a/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
+++ b/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
@@ -1,23 +1,22 @@
 package io.prometheus.client.exporter;
 
-import io.prometheus.client.Collector;
-import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.exporter.common.TextFormat;
-
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
 
 /**
  * Export metrics via the Prometheus Pushgateway.
@@ -58,6 +57,7 @@ public class PushGateway {
 
   // Visible for testing
   protected final String gatewayBaseURL;
+
   private static final int MILLISECONDS_PER_SECOND = 1000;
   /**
    * Construct a Pushgateway, with the given address.

--- a/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
+++ b/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
@@ -55,7 +55,7 @@ import io.prometheus.client.exporter.common.TextFormat;
  */
 public class PushGateway {
 
-  // Visible for testing
+  // Visible for testing.
   protected final String gatewayBaseURL;
 
   private static final int MILLISECONDS_PER_SECOND = 1000;

--- a/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
+++ b/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
@@ -57,7 +57,7 @@ import java.io.OutputStreamWriter;
 public class PushGateway {
 
   // Visible for testing
-  final String gatewayBaseURL;
+  protected final String gatewayBaseURL;
   private static final int MILLISECONDS_PER_SECOND = 1000;
   /**
    * Construct a Pushgateway, with the given address.

--- a/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
+++ b/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java
@@ -70,7 +70,7 @@ public class PushGateway {
   }
 
   /**
-   * Construct a Pushgateway, with the given URI.
+   * Construct a Pushgateway, with the given URL.
    * <p>
    * @param serverBaseURL the base URL and optional context path of the Pushgateway server.
    */

--- a/simpleclient_pushgateway/src/test/java/io/prometheus/client/exporter/PushGatewayTest.java
+++ b/simpleclient_pushgateway/src/test/java/io/prometheus/client/exporter/PushGatewayTest.java
@@ -36,6 +36,20 @@ public class PushGatewayTest {
     groupingKey.put("l", "v");
   }
 
+  @Test(expected = RuntimeException.class)
+  public void testInvalidURLThrowsRuntimeException() {
+    new PushGateway("::"); // ":" is interpreted as port number, so parsing fails
+  }
+
+  @Test
+  public void testMultipleSlashesAreStrippedFromURL() {
+    final PushGateway pushGateway = new PushGateway("example.com:1234/context///path//");
+    Assert.assertEquals(
+        "http://example.com:1234/context/path/metrics/job/",
+        pushGateway.gatewayBaseURL
+    );
+  }
+
   @Test
   public void testPush() throws IOException {
     mockServerClient.when(


### PR DESCRIPTION
The `address` parameter to the Pushgateway constructor confused me a bit as I tried to simply pass in an actual URL (protocol and slash after path).

I think accepting a `java.net.URI` is better for hiding internals. The behaviour changes slightly as an exception is thrown when the `Pushgateway` is constructed (typically on startup), rather than upon trying to publish metrics.

The URI is `normalize()`d in case the caller includes trailing slashes in the URI.

As a side note, this allows `https` support rather than just `http`, which might be helpful.

I believe all the code paths I've introduced are visited by the existing test suite—please correct me if I'm wrong.

cc @brian-brazil will you please have a look?