### PR TITLE
Make StandardExports work with modules and/or IBM JVMs

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
@@ -105,7 +105,7 @@ public class StandardExports extends Collector {
   }
 
   /**
-   * Attempts to call a method either as is or via one of the interfaces it is defined in.
+   * Attempts to call a method either directly or via one of the implemented interfaces.
    */
   static ReturnValue callMethod(Method method, Object obj) {
     try {
@@ -134,9 +134,10 @@ public class StandardExports extends Collector {
     return ReturnValue.NO_VALUE;
   }
 
+  /**
+   * Wraps a return value, similar to a Future but simplified.
+   */
   static class ReturnValue {
-    // Wraps a return value, similar to a Future but simplified.
-
     static final ReturnValue NO_VALUE = new ReturnValue();
 
     final boolean hasValue;

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java
@@ -103,6 +103,12 @@ public class StandardExports extends Collector {
 
   /**
    * Attempts to call a method either directly or via one of the implemented interfaces.
+   * <p>
+   * There is a built-in assumption that the method will never return null (or, equivalently, that
+   * it returns the primitive data type, i.e. {@code long} rather than {@code Long}). Similarly,
+   * there is an assumption that the method doesn't throw an exception. If one of these assumptions
+   * doesn't hold, the method might be called repeatedly and the returned value will be null (any
+   * exception will be silently swallowed).
    */
   static Long callLongGetter(Method method, Object obj) {
     try {


### PR DESCRIPTION
com.sun.management.UnixOperatingSystemMXBean is not available in IBM JVMs and not easily accessible in some environments, such as WildFly. Use reflection instead to collect file descriptor metrics.