### PR TITLE
Convenience wrappers for initializing Quantiles

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
@@ -278,10 +278,24 @@ class CKMSQuantiles {
         public final double v;
 
         public Quantile(double quantile, double error) {
+            if (quantile < 0.0 || quantile > 1.0) {
+                throw new IllegalArgumentException("Quantile " + quantile + " invalid: Expected number between 0.0 and 1.0.");
+            }
+            if (error < 0.0 || error > 1.0) {
+                throw new IllegalArgumentException("Error " + error + " invalid: Expected number between 0.0 and 1.0.");
+            }
+
             this.quantile = quantile;
             this.error = error;
             u = 2.0 * error / (1.0 - quantile);
             v = 2.0 * error / quantile;
+        }
+
+        public Quantile(Quantile q) {
+            this.quantile = q.quantile;
+            this.error = q.error;
+            this.u = q.u;
+            this.v = q.v;
         }
 
         @Override

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -120,7 +120,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
       // Not sure if it makes sense to copy list
       // or remove 'final' from this.quantiles so that we can modify it.
       for (Quantile q : quantiles) {
-        quantiles.add(q);
+        this.quantiles.add(q);
       }
       return this;
     }

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -3,12 +3,7 @@ package io.prometheus.client;
 import io.prometheus.client.CKMSQuantiles.Quantile;
 
 import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -98,13 +93,35 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
     private int ageBuckets = 5;
 
     public Builder quantile(double quantile, double error) {
-      if (quantile < 0.0 || quantile > 1.0) {
-        throw new IllegalArgumentException("Quantile " + quantile + " invalid: Expected number between 0.0 and 1.0.");
+      this.quantiles.add(new Quantile(quantile, error));
+      return this;
+    }
+
+    public Builder quantiles(double[] quantiles, double error) {
+      for(double q: quantiles) {
+        this.quantiles.add(new Quantile(q, error));
       }
-      if (error < 0.0 || error > 1.0) {
-        throw new IllegalArgumentException("Error " + error + " invalid: Expected number between 0.0 and 1.0.");
+      return this;
+    }
+
+    public Builder quantiles(double[] quantiles, double[] errors) {
+      if (quantiles.length != errors.length) {
+        throw new IllegalArgumentException("Quantiles and errors array need to have equal number of values.");
       }
-      quantiles.add(new Quantile(quantile, error));
+
+      for(int i=0; i < quantiles.length; i++) {
+        quantile(quantiles[i], errors[i]);
+      }
+
+      return this;
+    }
+
+    public Builder quantiles(List<Quantile> quantiles) {
+      // Not sure if it makes sense to copy list
+      // or remove 'final' from this.quantiles so that we can modify it.
+      for (Quantile q : quantiles) {
+        quantiles.add(q);
+      }
       return this;
     }
 

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertTrue;
 public class SummaryTest {
 
   CollectorRegistry registry;
-  Summary noLabels, labels, labelsAndQuantiles, noLabelsAndQuantiles;
+  Summary noLabels, labels, labelsAndQuantiles, noLabelsAndQuantiles, noLabelsAndArrayQuantiles;
   final double[] quantiles = {0.5, 0.9, 0.99};
   final double[] errors = {0.05, 0.01, 0.001};
   List<CKMSQuantiles.Quantile> quantilesArray;
@@ -30,7 +30,7 @@ public class SummaryTest {
     quantilesArray = Arrays.asList(
                     new CKMSQuantiles.Quantile(0.5, 0.05),
                     new CKMSQuantiles.Quantile(0.9, 0.01),
-                    new CKMSQuantiles.Quantile(0.99, 0.01)
+                    new CKMSQuantiles.Quantile(0.99, 0.001)
             );
     noLabels = Summary.build().name("nolabels").help("help").register(registry);
     labels = Summary.build().name("labels").help("help").labelNames("l").register(registry);
@@ -40,11 +40,12 @@ public class SummaryTest {
             .quantile(0.99, 0.001)
             .name("no_labels_and_quantiles").help("help").register(registry);
     labelsAndQuantiles = Summary.build()
-            .quantile(0.5, 0.05)
-            .quantile(0.9, 0.01)
-            .quantile(0.99, 0.001)
+            .quantiles(quantiles, errors)
             .labelNames("l")
             .name("labels_and_quantiles").help("help").register(registry);
+    noLabelsAndArrayQuantiles = Summary.build()
+            .quantiles(quantilesArray)
+            .name("no_labels_and_array_quantiles").help("Testing Quantiles in List").register(registry);
   }
 
   @After
@@ -60,6 +61,9 @@ public class SummaryTest {
   }
   private double getNoLabelQuantile(double q) {
     return registry.getSampleValue("no_labels_and_quantiles", new String[]{"quantile"}, new String[]{Collector.doubleToGoString(q)}).doubleValue();
+  }
+  private double getNoLabelArrayQuantile(double q) {
+    return registry.getSampleValue("no_labels_and_array_quantiles", new String[]{"quantile"}, new String[]{Collector.doubleToGoString(q)}).doubleValue();
   }
   private double getLabeledQuantile(String labelValue, double q) {
     return registry.getSampleValue("labels_and_quantiles", new String[]{"l", "quantile"}, new String[]{labelValue, Collector.doubleToGoString(q)}).doubleValue();
@@ -88,10 +92,15 @@ public class SummaryTest {
       // because that makes it easy to verify if the quantiles are correct.
       labelsAndQuantiles.labels("a").observe(i);
       noLabelsAndQuantiles.observe(i);
+      noLabelsAndArrayQuantiles.observe(i);
     }
     assertEquals(getNoLabelQuantile(0.5), 0.5 * nSamples, 0.05 * nSamples);
     assertEquals(getNoLabelQuantile(0.9), 0.9 * nSamples, 0.01 * nSamples);
     assertEquals(getNoLabelQuantile(0.99), 0.99 * nSamples, 0.001 * nSamples);
+
+    assertEquals(getNoLabelArrayQuantile(0.5), 0.5 * nSamples, 0.05 * nSamples);
+    assertEquals(getNoLabelArrayQuantile(0.9), 0.9 * nSamples, 0.01 * nSamples);
+    assertEquals(getNoLabelArrayQuantile(0.99), 0.99 * nSamples, 0.001 * nSamples);
 
     assertEquals(getLabeledQuantile("a", 0.5), 0.5 * nSamples, 0.05 * nSamples);
     assertEquals(getLabeledQuantile("a", 0.9), 0.9 * nSamples, 0.01 * nSamples);

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -18,10 +20,18 @@ public class SummaryTest {
 
   CollectorRegistry registry;
   Summary noLabels, labels, labelsAndQuantiles, noLabelsAndQuantiles;
+  final double[] quantiles = {0.5, 0.9, 0.99};
+  final double[] errors = {0.05, 0.01, 0.001};
+  List<CKMSQuantiles.Quantile> quantilesArray;
 
   @Before
   public void setUp() {
     registry = new CollectorRegistry();
+    quantilesArray = Arrays.asList(
+                    new CKMSQuantiles.Quantile(0.5, 0.05),
+                    new CKMSQuantiles.Quantile(0.9, 0.01),
+                    new CKMSQuantiles.Quantile(0.99, 0.01)
+            );
     noLabels = Summary.build().name("nolabels").help("help").register(registry);
     labels = Summary.build().name("labels").help("help").labelNames("l").register(registry);
     noLabelsAndQuantiles = Summary.build()


### PR DESCRIPTION
# Why

I wish to put quantiles in a properties file so that anyone can change the configuration without worrying too much about the implementation details. Not having a way to initialize quantiles using some sort of collection means code would need to be modified to accommodate change in number of values.

# Changes

1. Validation of Quantile values has been moved to its constructor (`CKSMQuantiles::Quantile.Quantile(double,double)`) from `Summary::Builder.quantile(double, double)` to provide validation at a lower level.
2. Copy constructor has been added to `CKSMQuantiles::Quantile`.
3. Following new methods have been added to initialize Quantiles:
    * `Summary::Builder.quantiles(double[], double)`
    * `Summary::Builder.quantiles(double[], double[])`
    * `Summary::Builder.quantiles(List<Quantiles>)`
4. One of the initialization in tests (for `SummaryTest.noLabelsAndQuantiles`) have been modified to use `Summary::Builder.quantiles(double[], double[])`.
5. New variable `SummaryTest.noLabelsAndArrayQuantiles` is initialized using `Summary::Builder.quantiles(List<Quantiles>)` to test for this new code path. It is used in `testQuantiles` in `SummaryTest` to do tests too.

All tests are passing locally.

# Seeking comment

When setting up quantiles using `Summary::Builder.quantiles(List<Quantiles>)`, we can do `this.quantiles = quantiles`. However, I've read somewhere on the blog or Prometheus's website that `final` is preferred when using class level objects as an optimization. In this PR, I am using copy constructor instead to stick to that pattern. I believe it is not a big deal because, practically, it is quite unlikely that so many quantiles will be supplied that just copying values will cause a big performance or memory hit. However, if it is preferred to make `Summary::Builder.quantiles` modifiable, I can do that.

# Attention

@brian-brazil 
