### PR TITLE
 Adding ability to control whether the httpserver is a daemon thread

### DIFF
--- a/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
+++ b/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
@@ -13,7 +13,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ThreadFactory;
 import java.util.zip.GZIPOutputStream;
 
 import com.sun.net.httpserver.HttpHandler;
@@ -108,36 +111,106 @@ public class HTTPServer {
         return names;
     }
 
-    protected HttpServer server;
+
+    static class DaemonThreadFactory implements ThreadFactory {
+        private ThreadFactory delegate;
+        private final boolean daemon;
+
+        DaemonThreadFactory(ThreadFactory delegate, boolean daemon) {
+            this.delegate = delegate;
+            this.daemon = daemon;
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = delegate.newThread(r);
+            t.setDaemon(daemon);
+            return t;
+        }
+
+        static ThreadFactory defaultThreadFactory(boolean daemon) {
+            return new DaemonThreadFactory(Executors.defaultThreadFactory(), daemon);
+        }
+    }
+
+    protected final HttpServer server;
     protected final ExecutorService executorService;
 
 
     /**
      * Start a HTTP server serving Prometheus metrics from the given registry.
      */
-    public HTTPServer(InetSocketAddress addr, CollectorRegistry registry) throws IOException {
+    public HTTPServer(InetSocketAddress addr, CollectorRegistry registry, boolean daemon) throws IOException {
         server = HttpServer.create();
         server.bind(addr, 3);
         HttpHandler mHandler = new HTTPMetricHandler(registry);
         server.createContext("/", mHandler);
         server.createContext("/metrics", mHandler);
-        executorService = Executors.newFixedThreadPool(5);
+        executorService = Executors.newFixedThreadPool(5, DaemonThreadFactory.defaultThreadFactory(daemon));
         server.setExecutor(executorService);
-        server.start();
+        start(daemon);
+    }
+
+    /**
+     * Start a HTTP server serving Prometheus metrics from the given registry using non-daemon threads.
+     */
+    public HTTPServer(InetSocketAddress addr, CollectorRegistry registry) throws IOException {
+        this(addr, registry, false);
     }
 
     /**
      * Start a HTTP server serving the default Prometheus registry.
+     */
+    public HTTPServer(int port, boolean daemon) throws IOException {
+        this(new InetSocketAddress(port), CollectorRegistry.defaultRegistry, daemon);
+    }
+
+    /**
+     * Start a HTTP server serving the default Prometheus registry using non-daemon threads.
      */
     public HTTPServer(int port) throws IOException {
-        this(new InetSocketAddress(port), CollectorRegistry.defaultRegistry);
+        this(port, false);
     }
 
     /**
      * Start a HTTP server serving the default Prometheus registry.
      */
+    public HTTPServer(String host, int port, boolean daemon) throws IOException {
+        this(new InetSocketAddress(host, port), CollectorRegistry.defaultRegistry, daemon);
+    }
+
+    /**
+     * Start a HTTP server serving the default Prometheus registry using non-daemon threads.
+     */
     public HTTPServer(String host, int port) throws IOException {
-        this(new InetSocketAddress(host, port), CollectorRegistry.defaultRegistry);
+        this(new InetSocketAddress(host, port), CollectorRegistry.defaultRegistry, false);
+    }
+
+    /**
+     * Start a HTTP server by making sure that its background thread inherit proper daemon flag.
+     */
+    private void start(boolean daemon) {
+        if (daemon == Thread.currentThread().isDaemon()) {
+            server.start();
+        } else {
+            FutureTask<Void> startTask = new FutureTask<Void>(new Runnable() {
+                @Override
+                public void run() {
+                    server.start();
+                }
+            }, null);
+            DaemonThreadFactory.defaultThreadFactory(daemon).newThread(startTask).start();
+            try {
+                startTask.get();
+            } catch (ExecutionException e) {
+                throw new RuntimeException("Unexpected exception on starting HTTPSever", e);
+            } catch (InterruptedException e) {
+                // This is possible only if the current tread has been interrupted,
+                // but in real use cases this should not happen.
+                // In any case, there is nothing to do, except to propagate interrupted flag.
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     /**

--- a/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestDaemonFlags.java
+++ b/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestDaemonFlags.java
@@ -1,0 +1,43 @@
+package io.prometheus.client.exporter;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDaemonFlags {
+
+    @Test
+    public void testDefaultIsNotDaemon() throws IOException, ExecutionException, InterruptedException {
+        assertThat(usesDaemonExecutor(new HTTPServer(0))).isFalse();
+    }
+
+    @Test
+    public void testDaemon() throws IOException, ExecutionException, InterruptedException {
+        assertThat(usesDaemonExecutor(new HTTPServer(0, true))).isTrue();
+    }
+
+    @Test
+    public void testNonDaemon() throws IOException, ExecutionException, InterruptedException {
+        assertThat(usesDaemonExecutor(new HTTPServer(0, false))).isFalse();
+    }
+
+    private boolean usesDaemonExecutor(HTTPServer httpServer) throws IOException, InterruptedException, ExecutionException {
+        try {
+            FutureTask<Boolean> task = new FutureTask<Boolean>(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return Thread.currentThread().isDaemon();
+                }
+            });
+            httpServer.server.getExecutor().execute(task);
+            return task.get();
+        } finally {
+            httpServer.stop();
+        }
+    }
+}


### PR DESCRIPTION
In some cases it is desirable to run HttpServer in daemon threads. E.g. look into the issue when [Java agent preventing cassandra startup #170](https://github.com/prometheus/jmx_exporter/issues/170)

This pull request add ability to control whether the httpserver will use daemon thread or not (default behavior for backward capability). 