### PR TITLE
Allow configuration of collector registry used

### DIFF
--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusEndpointConfiguration.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusEndpointConfiguration.java
@@ -13,7 +13,7 @@ class PrometheusEndpointConfiguration {
   private final CollectorRegistry collectorRegistry;
 
   @Autowired(required = false)
-  public PrometheusKonfig(CollectorRegistry collectorRegistry) {
+  public PrometheusEndpointConfiguration(CollectorRegistry collectorRegistry) {
     this.collectorRegistry = collectorRegistry == null ? CollectorRegistry.defaultRegistry : collectorRegistry;
   }
 

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusEndpointConfiguration.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusEndpointConfiguration.java
@@ -1,6 +1,7 @@
 package io.prometheus.client.spring.boot;
 
 import io.prometheus.client.CollectorRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.condition.ConditionalOnEnabledEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
@@ -9,9 +10,16 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 class PrometheusEndpointConfiguration {
 
+  private final CollectorRegistry collectorRegistry;
+
+  @Autowired(required = false)
+  public PrometheusKonfig(CollectorRegistry collectorRegistry) {
+    this.collectorRegistry = collectorRegistry == null ? CollectorRegistry.defaultRegistry : collectorRegistry;
+  }
+
   @Bean
   public PrometheusEndpoint prometheusEndpoint() {
-    return new PrometheusEndpoint(CollectorRegistry.defaultRegistry);
+    return new PrometheusEndpoint(collectorRegistry);
   }
 
   @Bean


### PR DESCRIPTION
Currently, the registry is hard-coded to the default registry. With this change, this would no longer be the case without changing the default behavior where no custom registry is registered.