### PR TITLE
Shutdown HTTPServer executor service to avoid non-daemon threads potentially blocking exiting JVM

### DIFF
--- a/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
+++ b/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
@@ -12,6 +12,7 @@ import java.net.URLDecoder;
 import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.zip.GZIPOutputStream;
 
@@ -108,6 +109,7 @@ public class HTTPServer {
     }
 
     protected HttpServer server;
+    protected final ExecutorService executorService;
 
 
     /**
@@ -119,7 +121,8 @@ public class HTTPServer {
         HttpHandler mHandler = new HTTPMetricHandler(registry);
         server.createContext("/", mHandler);
         server.createContext("/metrics", mHandler);
-        server.setExecutor(Executors.newFixedThreadPool(5));
+        executorService = Executors.newFixedThreadPool(5);
+        server.setExecutor(executorService);
         server.start();
     }
 
@@ -142,6 +145,7 @@ public class HTTPServer {
      */
     public void stop() {
         server.stop(0);
+        executorService.shutdown(); // Free any (parked/idle) threads in pool
     }
 }
 


### PR DESCRIPTION
The HTTPServer creates a Java ExecutorService but does not shut it down when stopping the HTTPServer. 

As the default executor service creates non-daemon threads, this will cause the JVM to hang if the JVM does not exist using a forced System.exit(...).

@brian-brazil  : This happens currently when using the latest jmx_exporter (disable the System.exit(...) in TestApplication to reproduce/verify).