### PR TITLE
Add BufferPool metrics

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
@@ -3,6 +3,7 @@ package io.prometheus.client.hotspot;
 import io.prometheus.client.Collector;
 import io.prometheus.client.GaugeMetricFamily;
 
+import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
@@ -30,18 +31,22 @@ import java.util.List;
  */
 public class MemoryPoolsExports extends Collector {
   private final MemoryMXBean memoryBean;
-  private final List<MemoryPoolMXBean> poolBeans;
+  private final List<MemoryPoolMXBean> memoryPoolBeans;
+  private final List<BufferPoolMXBean> bufferPoolBeans;
 
   public MemoryPoolsExports() {
     this(
         ManagementFactory.getMemoryMXBean(),
-        ManagementFactory.getMemoryPoolMXBeans());
+        ManagementFactory.getMemoryPoolMXBeans(),
+        ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class));
   }
 
   public MemoryPoolsExports(MemoryMXBean memoryBean,
-                             List<MemoryPoolMXBean> poolBeans) {
+                             List<MemoryPoolMXBean> memoryPoolBeans,
+                             List<BufferPoolMXBean> bufferPoolBeans) {
     this.memoryBean = memoryBean;
-    this.poolBeans = poolBeans;
+    this.memoryPoolBeans = memoryPoolBeans;
+    this.bufferPoolBeans = bufferPoolBeans;
   }
 
   void addMemoryAreaMetrics(List<MetricFamilySamples> sampleFamilies) {
@@ -89,7 +94,7 @@ public class MemoryPoolsExports extends Collector {
         "Max bytes of a given JVM memory pool.",
         Collections.singletonList("pool"));
     sampleFamilies.add(max);
-    for (final MemoryPoolMXBean pool : poolBeans) {
+    for (final MemoryPoolMXBean pool : memoryPoolBeans) {
       MemoryUsage poolUsage = pool.getUsage();
       used.addMetric(
           Collections.singletonList(pool.getName()),
@@ -103,10 +108,40 @@ public class MemoryPoolsExports extends Collector {
     }
   }
 
+  void addBufferPoolMetrics(List<MetricFamilySamples> sampleFamilies) {
+    GaugeMetricFamily used = new GaugeMetricFamily(
+            "jvm_buffer_pool_bytes_used",
+            "Used bytes of a given JVM buffer pool.",
+            Collections.singletonList("pool"));
+    sampleFamilies.add(used);
+    GaugeMetricFamily capacity = new GaugeMetricFamily(
+            "jvm_buffer_pool_bytes_capacity",
+            "Bytes capacity of a given JVM buffer pool.",
+            Collections.singletonList("pool"));
+    sampleFamilies.add(capacity);
+    GaugeMetricFamily buffers = new GaugeMetricFamily(
+            "jvm_buffer_pool_buffers_used",
+            "Used buffers of a given JVM buffer pool.",
+            Collections.singletonList("pool"));
+    sampleFamilies.add(buffers);
+    for (final BufferPoolMXBean pool : bufferPoolBeans) {
+      used.addMetric(
+              Collections.singletonList(pool.getName()),
+              pool.getMemoryUsed());
+      capacity.addMetric(
+              Collections.singletonList(pool.getName()),
+              pool.getTotalCapacity());
+      buffers.addMetric(
+              Collections.singletonList(pool.getName()),
+              pool.getCount());
+    }
+  }
+
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
     addMemoryAreaMetrics(mfs);
     addMemoryPoolMetrics(mfs);
+    addBufferPoolMetrics(mfs);
     return mfs;
   }
 }

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/MemoryPoolsExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/MemoryPoolsExportsTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.lang.management.BufferPoolMXBean;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
@@ -16,21 +17,32 @@ import static org.mockito.Mockito.when;
 
 public class MemoryPoolsExportsTest {
 
-  private MemoryPoolMXBean mockPoolsBean1 = Mockito.mock(MemoryPoolMXBean.class);
-  private MemoryPoolMXBean mockPoolsBean2 = Mockito.mock(MemoryPoolMXBean.class);
+  private BufferPoolMXBean mockBufferPoolsBean1 = Mockito.mock(BufferPoolMXBean.class);
+  private BufferPoolMXBean mockBufferPoolsBean2 = Mockito.mock(BufferPoolMXBean.class);
+  private MemoryPoolMXBean mockMemoryPoolsBean1 = Mockito.mock(MemoryPoolMXBean.class);
+  private MemoryPoolMXBean mockMemoryPoolsBean2 = Mockito.mock(MemoryPoolMXBean.class);
   private MemoryMXBean mockMemoryBean = Mockito.mock(MemoryMXBean.class);
   private MemoryUsage mockUsage1 = Mockito.mock(MemoryUsage.class);
   private MemoryUsage mockUsage2 = Mockito.mock(MemoryUsage.class);
-  private List<MemoryPoolMXBean> mockList = Arrays.asList(mockPoolsBean1, mockPoolsBean2);
+  private List<BufferPoolMXBean> mockBufferList = Arrays.asList(mockBufferPoolsBean1, mockBufferPoolsBean2);
+  private List<MemoryPoolMXBean> mockMemoryList = Arrays.asList(mockMemoryPoolsBean1, mockMemoryPoolsBean2);
   private CollectorRegistry registry = new CollectorRegistry();
   private MemoryPoolsExports collectorUnderTest;
 
   @Before
   public void setUp() {
-    when(mockPoolsBean1.getName()).thenReturn("PS Eden Space");
-    when(mockPoolsBean1.getUsage()).thenReturn(mockUsage1);
-    when(mockPoolsBean2.getName()).thenReturn("PS Old Gen");
-    when(mockPoolsBean2.getUsage()).thenReturn(mockUsage2);
+    when(mockBufferPoolsBean1.getName()).thenReturn("direct");
+    when(mockBufferPoolsBean1.getMemoryUsed()).thenReturn(500000L);
+    when(mockBufferPoolsBean1.getTotalCapacity()).thenReturn(700000L);
+    when(mockBufferPoolsBean1.getCount()).thenReturn(5000L);
+    when(mockBufferPoolsBean2.getName()).thenReturn("mapped");
+    when(mockBufferPoolsBean2.getMemoryUsed()).thenReturn(10000L);
+    when(mockBufferPoolsBean2.getTotalCapacity()).thenReturn(12000L);
+    when(mockBufferPoolsBean2.getCount()).thenReturn(100L);
+    when(mockMemoryPoolsBean1.getName()).thenReturn("PS Eden Space");
+    when(mockMemoryPoolsBean1.getUsage()).thenReturn(mockUsage1);
+    when(mockMemoryPoolsBean2.getName()).thenReturn("PS Old Gen");
+    when(mockMemoryPoolsBean2.getUsage()).thenReturn(mockUsage2);
     when(mockMemoryBean.getHeapMemoryUsage()).thenReturn(mockUsage1);
     when(mockMemoryBean.getNonHeapMemoryUsage()).thenReturn(mockUsage2);
     when(mockUsage1.getUsed()).thenReturn(500000L);
@@ -39,7 +51,7 @@ public class MemoryPoolsExportsTest {
     when(mockUsage2.getUsed()).thenReturn(10000L);
     when(mockUsage2.getCommitted()).thenReturn(20000L);
     when(mockUsage2.getMax()).thenReturn(3000000L);
-    collectorUnderTest = new MemoryPoolsExports(mockMemoryBean, mockList).register(registry);
+    collectorUnderTest = new MemoryPoolsExports(mockMemoryBean, mockMemoryList, mockBufferList).register(registry);
   }
 
   @Test
@@ -85,6 +97,52 @@ public class MemoryPoolsExportsTest {
             "jvm_memory_pool_bytes_max",
             new String[]{"pool"},
             new String[]{"PS Old Gen"}),
+        .0000001);
+  }
+
+  @Test
+  public void testBufferPools() {
+    assertEquals(
+        500000L,
+        registry.getSampleValue(
+            "jvm_buffer_pool_bytes_used",
+            new String[]{"pool"},
+            new String[]{"direct"}),
+        .0000001);
+    assertEquals(
+        700000L,
+        registry.getSampleValue(
+            "jvm_buffer_pool_bytes_capacity",
+            new String[]{"pool"},
+            new String[]{"direct"}),
+        .0000001);
+    assertEquals(
+        5000L,
+        registry.getSampleValue(
+            "jvm_buffer_pool_buffers_used",
+            new String[]{"pool"},
+            new String[]{"direct"}),
+        .0000001);
+    assertEquals(
+        10000L,
+        registry.getSampleValue(
+            "jvm_buffer_pool_bytes_used",
+            new String[]{"pool"},
+            new String[]{"mapped"}),
+        .0000001);
+    assertEquals(
+        12000L,
+        registry.getSampleValue(
+            "jvm_buffer_pool_bytes_capacity",
+            new String[]{"pool"},
+            new String[]{"mapped"}),
+        .0000001);
+    assertEquals(
+        100L,
+        registry.getSampleValue(
+            "jvm_buffer_pool_buffers_used",
+            new String[]{"pool"},
+            new String[]{"mapped"}),
         .0000001);
   }
 


### PR DESCRIPTION
Add metrics for BufferPool (https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html)

`jvm_buffer_pool_bytes_used`: Used bytes of a given JVM buffer pool.
`jvm_buffer_pool_bytes_capacity`: Bytes capacity of a given JVM buffer pool.
`jvm_buffer_pool_buffers_used`: Used buffers of a given JVM buffer pool.