### PR TITLE
SimpleCollecor.labels() initialization performance

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -73,8 +73,9 @@ public abstract class SimpleCollector<Child> extends Collector {
     if (c != null) {
       return c;
     }
-    children.putIfAbsent(key, newChild());
-    return children.get(key);
+    Child c2 = newChild();
+    Child tmp = children.putIfAbsent(key, c2);
+    return tmp == null ? c2 : tmp;
   }
 
   /**


### PR DESCRIPTION
- Now, we do 3 lookups in the children Map when we create a new tupple of
labels. From my understanding, it's to manage concurrent initializations.

It can be improved. I suggest to check the result of 'putIfAbsent' to avoid the third
lookup.

Because we do not want to create a new Child for each call to #labels, I
don't find a solution with only 1 lookup. BUT with Java 8, we can consider
the use of 'computeIfAbsent' with a lambda.