### PR TITLE
Fix bug in CollectorRegistry#collectorNames method

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -109,10 +109,13 @@ public class CollectorRegistry {
           names.add(family.name + "_count");
           names.add(family.name + "_sum");
           names.add(family.name);
+          break;
         case HISTOGRAM:
           names.add(family.name + "_count");
           names.add(family.name + "_sum");
           names.add(family.name + "_bucket");
+          names.add(family.name);
+          break;
         default:
           names.add(family.name);
       }


### PR DESCRIPTION
The switch statement was missing breaks for SUMMARY and HISTOGRAM cases.
Due to this bug wrong and duplicate collector names are produced for summaries and histograms.
cc @brian-brazil