### PR TITLE
Adding Histogram as an optional type of Collector for Spring Web PrometheusTimeMethod annotated methods

### DIFF
--- a/simpleclient_spring_web/src/main/java/io/prometheus/client/spring/web/PrometheusTimeMethod.java
+++ b/simpleclient_spring_web/src/main/java/io/prometheus/client/spring/web/PrometheusTimeMethod.java
@@ -1,5 +1,8 @@
 package io.prometheus.client.spring.web;
 
+import io.prometheus.client.SimpleCollector;
+import io.prometheus.client.Summary;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,8 +10,9 @@ import java.lang.annotation.Target;
 
 /**
  * Enable Spring-AOP-based automated method timing for the annotated method. The timings will be recorded in a
- * {@link io.prometheus.client.Summary} with a name specified by the required {@code name} parameter, and help
- * specified by the {@code help} parameter.
+ * {@link io.prometheus.client.Summary} or a {@link io.prometheus.client.Histogram } with a name specified by the
+ * required {@code name} parameter, and help specified by the {@code help} parameter. The default collector is a
+ * Summary. Histograms use default bucketing.
  *
  * To properly work, {@link EnablePrometheusTiming} must be specified somewhere in your application configuration.
  *
@@ -17,7 +21,7 @@ import java.lang.annotation.Target;
  *  public class MyController {
  *    {@literal @}RequestMapping("/")
  *    {@literal @}ResponseBody
- *    {@literal @}PrometheusTimeMethod(name = "my_method_seconds", help = "The number of seconds taken by the main handler")
+ *    {@literal @}PrometheusTimeMethod(name = "my_method_seconds", help = "The number of seconds taken by the main handler", collectorClass = Summary.class)
  *    public Object handleRequest() {
  *      // Each invocation will be timed and recorded.
  *      return database.withCache().get("some_data");
@@ -42,4 +46,10 @@ public @interface PrometheusTimeMethod {
      * @return A help string
      */
     String help();
+
+    /**
+     * Defines the collector class to be used to capture metrics. Supports Summary (default) and Histogram.
+     * @return Collector class
+     */
+    Class<? extends SimpleCollector> collectorClass() default Summary.class;
 }


### PR DESCRIPTION
The `PrometheusTimeMethod` annotation is a very convenient way to collect timing metrics for a method -- I think it makes sense to let a user choose between `Summary` and `Histogram` collectors since they might want to calculate percentiles and aggregate data across hosts. 

```
@PrometheusTimeMethod(name = "foobar", help = "help info", collectorClass = Histogram.class)
```

For backwards compatibility, collectorClass defaults to `Summary`.

This code would be a little cleaner if Summary and Histogram inherited startTimer from a common interface (and used the same Timer object) but I didn't want to make any changes to the core classes. Open to suggestions if this implementation doesn't sit well. 