### PR TITLE
More helpful error msg calling labelled collector with no labels

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -144,14 +144,14 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
    * @throws IllegalArgumentException If amt is negative.
    */
   public void inc(double amt) {
-    noLabelsChild.inc(amt);
+    getNoLabelsChild().inc(amt);
   }
   
   /**
    * Get the value of the counter.
    */
   public double get() {
-    return noLabelsChild.get();
+    return getNoLabelsChild().get();
   }
 
   @Override

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -231,7 +231,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
    * Increment the gauge with no labels by the given amount.
    */
   public void inc(double amt) {
-    noLabelsChild.inc(amt);
+    getNoLabelsChild().inc(amt);
   }
   /**
    * Increment the gauge with no labels by 1.
@@ -243,19 +243,19 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
    * Decrement the gauge with no labels by the given amount.
    */
   public void dec(double amt) {
-    noLabelsChild.dec(amt);
+    getNoLabelsChild().dec(amt);
   }
   /**
    * Set the gauge with no labels to the given value.
    */
   public void set(double val) {
-    noLabelsChild.set(val);
+    getNoLabelsChild().set(val);
   }
   /**
    * Set the gauge with no labels to the current unixtime.
    */
   public void setToCurrentTime() {
-    noLabelsChild.setToCurrentTime();
+    getNoLabelsChild().setToCurrentTime();
   }
   /**
    * Start a timer to track a duration, for the gauge with no labels.
@@ -267,7 +267,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
    * Call {@link Timer#setDuration} at the end of what you want to measure the duration of.
    */
   public Timer startTimer() {
-    return noLabelsChild.startTimer();
+    return getNoLabelsChild().startTimer();
   }
 
   /**
@@ -277,14 +277,14 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
    * @return Measured duration in seconds for timeable to complete.
    */
   public double setToTime(Runnable timeable){
-    return noLabelsChild.setToTime(timeable);
+    return getNoLabelsChild().setToTime(timeable);
   }
   
   /**
    * Get the value of the gauge.
    */
   public double get() {
-    return noLabelsChild.get();
+    return getNoLabelsChild().get();
   }
 
 

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -271,7 +271,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
    * Observe the given amount on the histogram with no labels.
    */
   public void observe(double amt) {
-    noLabelsChild.observe(amt);
+    getNoLabelsChild().observe(amt);
   }
   /**
    * Start a timer to track a duration on the histogram with no labels.
@@ -279,7 +279,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
    * Call {@link Timer#observeDuration} at the end of what you want to measure the duration of.
    */
   public Timer startTimer() {
-    return noLabelsChild.startTimer();
+    return getNoLabelsChild().startTimer();
   }
 
   /**
@@ -289,7 +289,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
    * @return Measured duration in seconds for timeable to complete.
    */
   public double time(Runnable timeable){
-    return noLabelsChild.time(timeable);
+    return getNoLabelsChild().time(timeable);
   }
 
   @Override

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -52,7 +52,7 @@ public abstract class SimpleCollector<Child> extends Collector {
   protected final List<String> labelNames;
 
   protected final ConcurrentMap<List<String>, Child> children = new ConcurrentHashMap<List<String>, Child>();
-  protected Child noLabelsChild;
+  private Child noLabelsChild;
 
   /**
    * Return the Child with the given labels, creating it if needed.
@@ -106,6 +106,17 @@ public abstract class SimpleCollector<Child> extends Collector {
     if (labelNames.size() == 0) {
       noLabelsChild = labels();
     }
+  }
+
+  /**
+   * Return the child with no labels, which should have been already initialised. It is an error to call this method
+   * if the collector is labelled.
+   */
+  protected Child getNoLabelsChild() throws IllegalArgumentException {
+    if (noLabelsChild == null) {
+      throw new IllegalArgumentException("For a labelled metric you must specify the labels");
+    }
+    return noLabelsChild;
   }
 
   /**

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -112,7 +112,7 @@ public abstract class SimpleCollector<Child> extends Collector {
    * Return the child with no labels, which should have been already initialised. It is an error to call this method
    * if the collector is labelled.
    */
-  protected Child getNoLabelsChild() throws IllegalArgumentException {
+  protected Child getNoLabelsChild() {
     if (noLabelsChild == null) {
       throw new IllegalArgumentException("For a labelled metric you must specify the labels");
     }

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -285,7 +285,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
    * Observe the given amount on the summary with no labels.
    */
   public void observe(double amt) {
-    noLabelsChild.observe(amt);
+    getNoLabelsChild().observe(amt);
   }
   /**
    * Start a timer to track a duration on the summary with no labels.
@@ -293,7 +293,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
    * Call {@link Timer#observeDuration} at the end of what you want to measure the duration of.
    */
   public Timer startTimer() {
-    return noLabelsChild.startTimer();
+    return getNoLabelsChild().startTimer();
   }
 
   /**
@@ -303,7 +303,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
    * @return Measured duration in seconds for timeable to complete.
    */
   public double time(Runnable timeable){
-    return noLabelsChild.time(timeable);
+    return getNoLabelsChild().time(timeable);
   }
   
   /**
@@ -312,7 +312,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
    * <em>Warning:</em> The definition of {@link Child.Value} is subject to change.
    */
   public Child.Value get() {
-    return noLabelsChild.get();
+    return getNoLabelsChild().get();
   }
 
   @Override


### PR DESCRIPTION
Calling a labelled collector without labels threw a NullPointerException without any explanation of the reason for the error. Change this to throw IllegalArgumentException with an explanatory message. This is consistent with the error thrown when calling a labelled collector with a mismatching number of labels.

Fixes https://github.com/prometheus/client_java/issues/332