### PR TITLE
Improve CollectorRegistry#unregister()

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -66,10 +66,10 @@ public class CollectorRegistry {
    */
   public void unregister(Collector m) {
     synchronized (collectorsToNames) {
-      for (String name : collectorsToNames.get(m)) {
+      List<String> names = collectorsToNames.remove(m);
+      for (String name : names) {
         namesToCollectors.remove(name);
       }
-      collectorsToNames.remove(m);
     }
   }
 


### PR DESCRIPTION
- In 'unregister', remove the collector before its names, so we do operations
in the reverse order compare to 'register'. It is consistent with 'clear'.
- So we do 1 lookup in collectors hash map instead of 2.

Signed-off-by: Cyril Martin <c.martin@criteo.com>