### PR TITLE
Adding info for the java runtime name

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
@@ -18,7 +18,7 @@ import java.util.List;
  * </pre>
  * Metrics being exported:
  * <pre>
- *   jvm_info{version="1.8.0_45-b14",vendor="Oracle Corporation"} 1.0
+ *   jvm_info{version="1.8.0_151-b12",vendor="Oracle Corporation",runtime="OpenJDK Runtime Environment",} 1.0
  * </pre>
  */
 
@@ -31,8 +31,13 @@ public class VersionInfoExports extends Collector {
         GaugeMetricFamily jvmInfo = new GaugeMetricFamily(
                 "jvm_info",
                 "JVM version info",
-                Arrays.asList("version", "vendor"));
-        jvmInfo.addMetric(Arrays.asList(System.getProperty("java.runtime.version", "unknown"), System.getProperty("java.vm.vendor", "unknown")), 1L);
+                Arrays.asList("version", "vendor", "runtime"));
+        jvmInfo.addMetric(
+                Arrays.asList(
+                    System.getProperty("java.runtime.version", "unknown"),
+                    System.getProperty("java.vm.vendor", "unknown"),
+                    System.getProperty("java.runtime.name", "unknown")),
+                    1L);
         mfs.add(jvmInfo);
 
         return mfs;

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/VersionInfoExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/VersionInfoExportsTest.java
@@ -21,7 +21,7 @@ public class VersionInfoExportsTest {
         assertEquals(
                 1L,
                 registry.getSampleValue(
-                        "jvm_info", new String[]{"version", "vendor"}, new String[]{System.getProperty("java.runtime.version", "unknown"), System.getProperty("java.vm.vendor", "unknown")}),
+                        "jvm_info", new String[]{"version", "vendor", "runtime"}, new String[]{System.getProperty("java.runtime.version", "unknown"), System.getProperty("java.vm.vendor", "unknown"), System.getProperty("java.runtime.name", "unknown")}),
                 .0000001);
     }
 }


### PR DESCRIPTION
Currently we get the following on the `jvm_info`

* version
* vendor

See:
```
jvm_info{version="1.8.0_151-b12",vendor="Oracle Corporation",} 1.0
```

But we do not get info if running on OpenJDK or not, hence adding the `java.runtime.name` property to the metrics.  Result w/ the PR:

```
jvm_info{version="1.8.0_151-b12",vendor="Oracle Corporation",runtime="OpenJDK Runtime Environment",} 1.0
```