### PR TITLE
Fix jvm_gc_collection metrics naming

### DIFF
--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/GarbageCollectorExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/GarbageCollectorExportsTest.java
@@ -38,7 +38,7 @@ public class GarbageCollectorExportsTest {
     assertEquals(
         100L,
         registry.getSampleValue(
-            "jvm_gc_collection_seconds_count",
+            "jvm_gc_collection_count_sum",
             new String[]{"gc"},
             new String[]{"MyGC1"}),
         .0000001);
@@ -52,7 +52,7 @@ public class GarbageCollectorExportsTest {
     assertEquals(
         200L,
         registry.getSampleValue(
-            "jvm_gc_collection_seconds_count",
+            "jvm_gc_collection_count_sum",
             new String[]{"gc"},
             new String[]{"MyGC2"}),
         .0000001);


### PR DESCRIPTION
- GC collections count has nothing to do with "seconds".
- As GC MBean metrics are already aggregated I don't think we can use a `SummaryMetric`.