### PR TITLE
Fix null pointer in unregister

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -67,6 +67,9 @@ public class CollectorRegistry {
   public void unregister(Collector m) {
     synchronized (collectorsToNames) {
       List<String> names = collectorsToNames.remove(m);
+      if (names == null) {
+        return;
+      }
       for (String name : names) {
         namesToCollectors.remove(name);
       }


### PR DESCRIPTION
If there is no such collector it nullpointers. As the intention of remove is to
remove the given collector from the registry and if there is no such collector
this intention is fulfilled, this should not nullpointer.