### PR TITLE
Added method Histogram.observeMany

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -233,14 +233,23 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
      * Observe the given amount.
      */
     public void observe(double amt) {
+      observeMany(amt, 1);
+    }
+    /**
+     * Observe the given amount multiple times.
+     */
+    public void observeMany(double amt, int numObservations) {
+      if (numObservations < 0) {
+        throw new IllegalArgumentException("numObservations must be non-negative");
+      }
       for (int i = 0; i < upperBounds.length; ++i) {
         // The last bucket is +Inf, so we always increment.
         if (amt <= upperBounds[i]) {
-          cumulativeCounts[i].add(1);
+          cumulativeCounts[i].add(numObservations);
           break;
         }
       }
-      sum.add(amt);
+      sum.add(amt * numObservations);
     }
     /**
      * Start a timer to track a duration.
@@ -272,6 +281,9 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
    */
   public void observe(double amt) {
     noLabelsChild.observe(amt);
+  }
+  public void observeMany(double amt, int numObservations) {
+    noLabelsChild.observeMany(amt, numObservations);
   }
   /**
    * Start a timer to track a duration on the histogram with no labels.

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -61,6 +61,24 @@ public class HistogramTest {
   }
 
   @Test
+  public void testObserveMany() {
+    noLabels.observeMany(2, 10);
+    assertEquals(10.0, getCount(), .001);
+    assertEquals(20.0, getSum(), .001);
+    assertEquals(0.0, getBucket(1), .001);
+    assertEquals(10.0, getBucket(2.5), .001);
+    noLabels.labels().observeMany(4, 10);
+    assertEquals(20.0, getCount(), .001);
+    assertEquals(60.0, getSum(), .001);
+    assertEquals(0.0, getBucket(1), .001);
+    assertEquals(10.0, getBucket(2.5), .001);
+    assertEquals(20.0, getBucket(5), .001);
+    assertEquals(20.0, getBucket(7.5), .001);
+    assertEquals(20.0, getBucket(10), .001);
+    assertEquals(20.0, getBucket(Double.POSITIVE_INFINITY), .001);
+  }
+
+  @Test
   public void testBoundaryConditions() {
     // Equal to a bucket.
     noLabels.observe(2.5);
@@ -150,11 +168,11 @@ public class HistogramTest {
     assertEquals(2.0, getLabelsSum("a").doubleValue(), .001);
     assertEquals(null, getLabelsCount("b"));
     assertEquals(null, getLabelsSum("b"));
-    labels.labels("b").observe(3);
+    labels.labels("b").observeMany(3, 10);
     assertEquals(1.0, getLabelsCount("a").doubleValue(), .001);
     assertEquals(2.0, getLabelsSum("a").doubleValue(), .001);
-    assertEquals(1.0, getLabelsCount("b").doubleValue(), .001);
-    assertEquals(3.0, getLabelsSum("b").doubleValue(), .001);
+    assertEquals(10.0, getLabelsCount("b").doubleValue(), .001);
+    assertEquals(30.0, getLabelsSum("b").doubleValue(), .001);
   }
 
   @Test(expected=IllegalStateException.class)


### PR DESCRIPTION
This is occasionally useful when events are observed in bulk, and it enables (hackily) exporting existing histogram data to Prometheus.

Ping @brian-brazil per contributing guidelines.