### PR TITLE
allow Histograms and Summaries to time Callables

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * Histogram metric, to track distributions of events.
@@ -207,6 +208,24 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
       return elapsed;
     }
 
+    /**
+     * Executes callable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+     *
+     * @param timeable Code that is being timed
+     * @return Result returned by callable.
+     */
+    public <E> E time(Callable<E> timeable) {
+      Timer timer = startTimer();
+
+      try {
+        return timeable.call();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      } finally {
+        timer.observeDuration();
+      }
+    }
+
     public static class Value {
       public final double sum;
       public final double[] buckets;
@@ -289,6 +308,16 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
    * @return Measured duration in seconds for timeable to complete.
    */
   public double time(Runnable timeable){
+    return noLabelsChild.time(timeable);
+  }
+
+  /**
+   * Executes callable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+   *
+   * @param timeable Code that is being timed
+   * @return Result returned by callable.
+   */
+  public <E> E time(Callable<E> timeable){
     return noLabelsChild.time(timeable);
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -214,6 +215,24 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
       return elapsed;
     }
 
+    /**
+     * Executes callable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+     *
+     * @param timeable Code that is being timed
+     * @return Result returned by callable.
+     */
+    public <E> E time(Callable<E> timeable) {
+      Timer timer = startTimer();
+
+      try {
+        return timeable.call();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      } finally {
+        timer.observeDuration();
+      }
+    }
+
     public static class Value {
       public final double count;
       public final double sum;
@@ -305,7 +324,17 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
   public double time(Runnable timeable){
     return noLabelsChild.time(timeable);
   }
-  
+
+  /**
+   * Executes callable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+   *
+   * @param timeable Code that is being timed
+   * @return Result returned by callable.
+   */
+  public <E> E time(Callable<E> timeable){
+    return noLabelsChild.time(timeable);
+  }
+
   /**
    * Get the value of the Summary.
    * <p>

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -124,19 +125,27 @@ public class SummaryTest {
     });
     assertEquals(10, elapsed, .001);
 
+    int result = noLabels.time(new Callable<Integer>() {
+      @Override
+      public Integer call() {
+        return 123;
+      }
+    });
+    assertEquals(123, result);
+
     Summary.Timer timer = noLabels.startTimer();
     elapsed = timer.observeDuration();
-    assertEquals(2, getCount(), .001);
-    assertEquals(20, getSum(), .001);
+    assertEquals(3, getCount(), .001);
+    assertEquals(30, getSum(), .001);
     assertEquals(10, elapsed, .001);
   }
-  
+
   @Test
   public void noLabelsDefaultZeroValue() {
     assertEquals(0.0, getCount(), .001);
     assertEquals(0.0, getSum(), .001);
   }
-  
+
   private Double getLabelsCount(String labelValue) {
     return registry.getSampleValue("labels_count", new String[]{"l"}, new String[]{labelValue});
   }


### PR DESCRIPTION
Another usability enhancement allowing instead of:

```java
    String v;
    try (Summary.Timer timer = summary.startTimer()) {
      v = someMethod();
    }
```

to write:

```java
    String v = summary.time(this::someMethod);
```

This is especially useful when programming (reactive) streams.

Trying to make metric code as unobtrusive as possible.

BTW Micrometer already does that.