### PR TITLE
Add Collector integration with Kafka client metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,27 @@ new QueuedThreadPoolStatisticsCollector()
     .register();
 ```
 
+### Kafka
+
+There is a collector for recording metrics from Kafka clients. Use the `metric.reporters` to
+add a `MetricReporter` when constructing a consumer or producer:
+
+```java
+Properties props = new Properties();
+// ...
+props.put("client.id", "cookie-monster");
+props.put("metric.reporters", "io.prometheus.client.kafka.PrometheusMetricsReporter");
+// ...
+KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
+```
+
+Note that the `client.id` is included as a label in all metrics, so if you are using
+multiple consumers and/or producers, you'll likely want to set this to some meaningful
+value in order to be able to distinguish different instances.
+
+By default, Kafka assigns `client.id`s with format `consumer_N` and `producer_N` where 
+`N` is an integer starting from 1 and increasing for each new instance.
+
 #### Servlet Filter
 
 There is a servlet filter available for measuring the duration taken by servlet

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <module>simpleclient_jetty</module>
         <module>simpleclient_jetty_jdk8</module>
         <module>simpleclient_vertx</module>
+        <module>simpleclient_kafka</module>
         <module>benchmark</module>
     </modules>
 

--- a/simpleclient_kafka/pom.xml
+++ b/simpleclient_kafka/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.3.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>simpleclient_kafka</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Prometheus Java Simpleclient Kafka</name>
+    <description>
+        Metrics collector for Kafka client
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>liff</id>
+            <name>Olli Helenius</name>
+            <email>liff@iki.fi</email>
+        </developer>
+    </developers>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.3.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>0.11.0.2</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/simpleclient_kafka/src/main/java/io/prometheus/client/kafka/KafkaGauge.java
+++ b/simpleclient_kafka/src/main/java/io/prometheus/client/kafka/KafkaGauge.java
@@ -1,0 +1,85 @@
+package io.prometheus.client.kafka;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+import org.apache.kafka.common.metrics.KafkaMetric;
+
+import java.util.*;
+
+
+final class KafkaGauge extends Collector implements Collector.Describable {
+    private final List<KafkaMetric> metrics;
+    private final String fullName;
+
+    private KafkaGauge(String group, String name) {
+        this.metrics = new ArrayList<KafkaMetric>();
+        this.fullName = "kafka_" + sanitize(group) + "_" + sanitize(name);
+    }
+
+    KafkaGauge(String group, String name, KafkaMetric firstMetric) {
+        this(group, name);
+        this.add(firstMetric);
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+
+        for (KafkaMetric metric : metrics) {
+            Map<String, String> labels = metric.metricName().tags();
+            List<String> labelNames = new ArrayList<String>();
+            List<String> labelValues = new ArrayList<String>();
+            for (Map.Entry<String, String> label : labels.entrySet()) {
+                labelNames.add(sanitize(label.getKey()));
+                labelValues.add(sanitize(label.getValue()));
+            }
+            samples.add(new MetricFamilySamples.Sample(fullName, labelNames, labelValues, metric.value()));
+        }
+
+        return Collections.singletonList(new MetricFamilySamples(fullName, Type.GAUGE, help(), samples));
+    }
+
+    @Override
+    public List<MetricFamilySamples> describe() {
+        List<String> labelNames = new ArrayList<String>();
+        for (KafkaMetric metric : metrics) {
+            labelNames.addAll(metric.metricName().tags().keySet());
+        }
+        return Collections.singletonList((MetricFamilySamples) new GaugeMetricFamily(fullName, help(), labelNames));
+    }
+
+    boolean isEmpty() {
+        return metrics.isEmpty();
+    }
+
+    void add(KafkaMetric metric) {
+        metrics.add(metric);
+    }
+
+    void remove(KafkaMetric metric) {
+        int at = -1;
+        for (int i = 0; i < metrics.size(); i++) {
+            if (metrics.get(i).metricName().equals(metric.metricName())) {
+                at = i;
+            }
+        }
+        if (at != -1)
+            metrics.remove(at);
+    }
+
+    private String help() {
+        for (KafkaMetric metric : metrics) {
+            if (!metric.metricName().description().isEmpty())
+                return metric.metricName().description();
+        }
+        return "";
+    }
+
+    private static String sanitize(String name) {
+        return name
+                .replace('-', '_')
+                .replace('.', '_')
+                .replace(':', '_')
+                .replace(' ', '_');
+    }
+}

--- a/simpleclient_kafka/src/main/java/io/prometheus/client/kafka/PrometheusMetricsReporter.java
+++ b/simpleclient_kafka/src/main/java/io/prometheus/client/kafka/PrometheusMetricsReporter.java
@@ -1,0 +1,126 @@
+package io.prometheus.client.kafka;
+
+import io.prometheus.client.CollectorRegistry;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class PrometheusMetricsReporter implements MetricsReporter {
+    private final static Logger logger = LoggerFactory.getLogger("PrometheusMetricsReporter");
+
+    private final static IdentityHashMap<CollectorRegistry, Map<FullName, KafkaGauge>> metricsPerRegistry =
+            new IdentityHashMap<CollectorRegistry, Map<FullName, KafkaGauge>>();
+
+    private final CollectorRegistry registry;
+
+    public PrometheusMetricsReporter(CollectorRegistry registry) {
+        this.registry = registry;
+    }
+
+    public PrometheusMetricsReporter() {
+        this(CollectorRegistry.defaultRegistry);
+    }
+
+    @Override
+    public void init(List<KafkaMetric> metrics) {
+        synchronized (metricsPerRegistry) {
+            if (metricsPerRegistry.get(registry) == null) {
+                metricsPerRegistry.put(registry, new HashMap<FullName, KafkaGauge>());
+            }
+        }
+
+        for (KafkaMetric metric : metrics) {
+            metricChange(metric);
+        }
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+    }
+
+    @Override
+    public void metricChange(KafkaMetric metric) {
+        Map<FullName, KafkaGauge> namesToMetrics = getNamesToMetrics();
+        synchronized (namesToMetrics) {
+            FullName fullName = FullName.of(metric);
+            KafkaGauge existing = namesToMetrics.get(fullName);
+            if (existing == null) {
+                KafkaGauge gauge = new KafkaGauge(fullName.group, fullName.name, metric);
+                namesToMetrics.put(fullName, gauge);
+                registry.register(gauge);
+            } else {
+                existing.add(metric);
+            }
+        }
+    }
+
+    @Override
+    public void metricRemoval(KafkaMetric metric) {
+        Map<FullName, KafkaGauge> namesToMetrics = getNamesToMetrics();
+        synchronized (namesToMetrics) {
+            FullName fullName = FullName.of(metric);
+            KafkaGauge existing = namesToMetrics.get(fullName);
+            if (existing != null) {
+                existing.remove(metric);
+                if (existing.isEmpty()) {
+                    namesToMetrics.remove(fullName);
+                    registry.unregister(existing);
+                }
+            } else {
+                logger.error("Attempted to remove non-existing metric {}", metric.metricName());
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        synchronized (metricsPerRegistry) {
+            metricsPerRegistry.remove(registry);
+        }
+    }
+
+    private Map<FullName, KafkaGauge> getNamesToMetrics() {
+        synchronized (metricsPerRegistry) {
+            return metricsPerRegistry.get(registry);
+        }
+    }
+
+    private static class FullName {
+        final String group;
+        final String name;
+
+        FullName(String group, String name) {
+            this.group = group;
+            this.name = name;
+        }
+
+        static FullName of(KafkaMetric metric) {
+            return new FullName(metric.metricName().group(), metric.metricName().name());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            FullName fullName = (FullName) o;
+
+            if (group != null ? !group.equals(fullName.group) : fullName.group != null) return false;
+            return name != null ? name.equals(fullName.name) : fullName.name == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = group != null ? group.hashCode() : 0;
+            result = 31 * result + (name != null ? name.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/simpleclient_kafka/src/test/java/io/prometheus/client/kafka/PrometheusMetricsReporterTest.java
+++ b/simpleclient_kafka/src/test/java/io/prometheus/client/kafka/PrometheusMetricsReporterTest.java
@@ -1,0 +1,83 @@
+package io.prometheus.client.kafka;
+
+import io.prometheus.client.CollectorRegistry;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.common.metrics.stats.Value;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+
+public class PrometheusMetricsReporterTest {
+    private CollectorRegistry registry;
+    private Metrics kafkaMetrics;
+
+    @Before
+    public void before() {
+        registry = new CollectorRegistry();
+        MetricsReporter reporter = new PrometheusMetricsReporter(registry);
+        kafkaMetrics = new Metrics();
+        kafkaMetrics.addReporter(reporter);
+    }
+
+    @Test
+    public void shouldRegisterMetricFromKafka() {
+        kafkaMetrics.addMetric(metricName("hello", "world"), new Value());
+
+        assertThat(registry.getSampleValue("kafka_hello_world"), is(0.0));
+    }
+
+    @Test
+    public void shouldUnregisterMetricFromKafka() {
+        MetricName name = metricName("g", "n");
+        kafkaMetrics.addMetric(name, valueOf(0.0));
+        assertThat(registry.getSampleValue("kafka_g_n"), is(0.0));
+        kafkaMetrics.removeMetric(name);
+        assertNull(registry.getSampleValue("kafka_g_n"));
+    }
+
+    @Test
+    public void shouldRegisterWithLabels() {
+        MetricName name1 = metricName("g", "n", Collections.singletonMap("tag-a", "A"));
+        MetricName name2 = metricName("g", "n", Collections.singletonMap("tag-a", "B"));
+        kafkaMetrics.addMetric(name1, valueOf(11.0));
+        kafkaMetrics.addMetric(name2, valueOf(22.0));
+        assertThat(registry.getSampleValue("kafka_g_n", new String[]{"tag_a"}, new String[]{"A"}), is(11.0));
+        assertThat(registry.getSampleValue("kafka_g_n", new String[]{"tag_a"}, new String[]{"B"}), is(22.0));
+    }
+
+    @Test
+    public void shouldUnregisterWithLabels() {
+        MetricName name1 = metricName("g", "n", Collections.singletonMap("tag-a", "A"));
+        MetricName name2 = metricName("g", "n", Collections.singletonMap("tag-a", "B"));
+        kafkaMetrics.addMetric(name1, valueOf(11.0));
+        kafkaMetrics.addMetric(name2, valueOf(22.0));
+        assertThat(registry.getSampleValue("kafka_g_n", new String[]{"tag_a"}, new String[]{"A"}), is(11.0));
+        assertThat(registry.getSampleValue("kafka_g_n", new String[]{"tag_a"}, new String[]{"B"}), is(22.0));
+        kafkaMetrics.removeMetric(name1);
+        assertNull(registry.getSampleValue("kafka_g_n", new String[]{"tag_a"}, new String[]{"A"}));
+    }
+
+    private MetricName metricName(String group, String name) {
+        return metricName(group, name, Collections.<String, String>emptyMap());
+    }
+
+    private MetricName metricName(String group, String name, Map<String, String> tags) {
+        return new MetricName(name, group, "description", tags);
+    }
+
+    private Value valueOf(double init) {
+        Value value = new Value();
+        value.record(new MetricConfig(), init, 0L);
+        return value;
+    }
+}


### PR DESCRIPTION
A small proposed addition of integration with Kafka clients library.

This integrates the Prometheus collector with Kafka metrics via kafka-clients `MetricsReporter`.

The kafka-clients version in this is somewhat conservatively 0.11 but could be bumped to 1.0 or 1.1 if needed.