### PR TITLE
Upgrade Mockito to build on JDK10

### DIFF
--- a/simpleclient_hibernate/pom.xml
+++ b/simpleclient_hibernate/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.6.8</version>
+            <version>2.18.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
@brian-brazil this is a trivial fix to fix building the simpleclient_hibernate in JDK 10.

Current version of Mockito relies on an older version of bytebuddy that does not work correctly with the latest Java release.