### PR TITLE
fix spring_web aop no such method found exception

### DIFF
--- a/simpleclient_spring_web/src/main/java/io/prometheus/client/spring/web/MethodTimer.java
+++ b/simpleclient_spring_web/src/main/java/io/prometheus/client/spring/web/MethodTimer.java
@@ -8,8 +8,10 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -46,7 +48,8 @@ public class MethodTimer {
         // When target is an AOP interface proxy but annotation is on class method (rather than Interface method).
         final String name = signature.getName();
         final Class[] parameterTypes = signature.getParameterTypes();
-        return AnnotationUtils.findAnnotation(pjp.getSignature().getDeclaringType().getDeclaredMethod(name, parameterTypes), PrometheusTimeMethod.class);
+        Method method = ReflectionUtils.findMethod(pjp.getTarget().getClass(), name, parameterTypes);
+        return AnnotationUtils.findAnnotation(method, PrometheusTimeMethod.class);
     }
 
     private Summary ensureSummary(ProceedingJoinPoint pjp, String key) throws IllegalStateException {

--- a/simpleclient_spring_web/src/main/java/io/prometheus/client/spring/web/MethodTimer.java
+++ b/simpleclient_spring_web/src/main/java/io/prometheus/client/spring/web/MethodTimer.java
@@ -47,7 +47,7 @@ public class MethodTimer {
         final String name = signature.getName();
         final Class[] parameterTypes = signature.getParameterTypes();
 
-        return AnnotationUtils.findAnnotation(pjp.getTarget().getClass().getDeclaredMethod(name, parameterTypes), PrometheusTimeMethod.class);
+        return AnnotationUtils.findAnnotation(pjp.getSignature().getDeclaringType().getDeclaredMethod(name, parameterTypes), PrometheusTimeMethod.class);
     }
 
     private Summary ensureSummary(ProceedingJoinPoint pjp, String key) throws IllegalStateException {

--- a/simpleclient_spring_web/src/main/java/io/prometheus/client/spring/web/MethodTimer.java
+++ b/simpleclient_spring_web/src/main/java/io/prometheus/client/spring/web/MethodTimer.java
@@ -46,7 +46,6 @@ public class MethodTimer {
         // When target is an AOP interface proxy but annotation is on class method (rather than Interface method).
         final String name = signature.getName();
         final Class[] parameterTypes = signature.getParameterTypes();
-
         return AnnotationUtils.findAnnotation(pjp.getSignature().getDeclaringType().getDeclaredMethod(name, parameterTypes), PrometheusTimeMethod.class);
     }
 

--- a/simpleclient_spring_web/src/test/java/io/prometheus/client/spring/web/MethodTimerTest.java
+++ b/simpleclient_spring_web/src/test/java/io/prometheus/client/spring/web/MethodTimerTest.java
@@ -16,11 +16,16 @@ public class MethodTimerTest {
         void timeMe() throws Exception;
     }
 
-    private final class TestClass implements Timeable {
+    private class TestClass implements Timeable {
         @PrometheusTimeMethod(name = "test_class", help = "help one")
         public void timeMe() throws Exception {
             Thread.sleep(20);
         }
+
+    }
+
+    //mock cglib proxy by subclass and in this class don't contain timMe() method
+    private final class MockCglibProxyTestClass extends TestClass {
 
     }
 
@@ -31,7 +36,7 @@ public class MethodTimerTest {
 
     @Test
     public void timeMethod() throws Exception {
-        Timeable cprime = new TestClass();
+        Timeable cprime = new MockCglibProxyTestClass();
         AspectJProxyFactory factory = new AspectJProxyFactory(cprime);
         factory.addAspect(MethodTimer.class);
         Timeable proxy = factory.getProxy();


### PR DESCRIPTION
when i follow the instruction.i failed to make the metrics data ,cause:
```
java.lang.NoSuchMethodException: io.github.candyleer.prometheusdemo.PrometheusDemoApplication$$EnhancerBySpringCGLIB$$5772d178.springTest(java.lang.String)
        at java.base/java.lang.Class.getDeclaredMethod(Class.java:2432) ~[na:na]
        at io.prometheus.client.spring.web.MethodTimer.getAnnotation(MethodTimer.java:50) ~[classes!/:na]
        at io.prometheus.client.spring.web.MethodTimer.ensureSummary(MethodTimer.java:56) ~[classes!/:na]
        at io.prometheus.client.spring.web.MethodTimer.timeMethod(MethodTimer.java:107) ~[classes!/:na]
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
        at java.base/java.lang.reflect.Method.invoke(Method.java:564) ~[na:na]
        at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:644) ~[spring-aop-5.0.5.RELEASE.jar!/:5.0.5.RELEASE]
        at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:633) ~[spring-aop-5.0.5.RELEASE.jar!/:5.0.5.RELEASE]
        at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:70) ~[spring-aop-5.0.5.RELEASE.jar!/:5.0.5.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:174) ~[spring-aop-5.0.5.RELEASE.jar!/:5.0.5.RELEASE]
        at org.springframework.aop.framework.adapter.MethodBeforeAdviceInterceptor.invoke(MethodBeforeAdviceInterceptor.java:52) ~[spring-aop-5.0.5.RELEASE.jar!/:5.0.5.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:174) ~[spring-aop-5.0.5.RELEASE.jar!/:5.0.5.RELEASE]
        at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:92) ~[spring-aop-5.0.5.RELEASE.jar!/:5.0.5.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:185) ~[spring-aop-5.0.5.RELEASE.jar!/:5.0.5.RELEASE]
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:689) ~[spring-aop-5.0.5.RELEASE.jar!/:5.0.5.RELEASE]
        at io.github.candyleer.prometheusdemo.PrometheusDemoApplication$$EnhancerBySpringCGLIB$$87a9d754.springTest(<generated>) ~[classes!/:0.0.1-SNAPSHOT]
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
```
after enhanced by `cglib`,it seems that cannot find the method in class `io.github.candyleer.prometheusdemo.PrometheusDemoApplication$$EnhancerBySpringCGLIB$$5772d178`
so i fixed by fetch the original class which mean `io.github.candyleer.prometheusdemo.PrometheusDemoApplication`  through `Method method = ReflectionUtils.findMethod(pjp.getTarget().getClass(), name, parameterTypes);`
it works.