### PR TITLE
Add Dropwizard metric reporter to pushgateway

### DIFF
--- a/simpleclient_dropwizard/pom.xml
+++ b/simpleclient_dropwizard/pom.xml
@@ -17,6 +17,10 @@
         Collector of data from Dropwizard metrics library.
     </description>
 
+    <properties>
+        <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>
+    </properties>
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -35,12 +39,18 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_pushgateway</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>3.1.2</version>
+            <version>${dropwizard.metrics.version}</version>
         </dependency>
         <!-- Test Dependencies Follow -->
         <dependency>
@@ -49,5 +59,12 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.18.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardPrometheusReporter.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardPrometheusReporter.java
@@ -1,0 +1,73 @@
+package io.prometheus.client.dropwizard;
+
+import java.io.IOException;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A reporter that publishes metrics to Prometheus Pushgateway.
+ *
+ * @see <a href="https://github.com/prometheus/pushgateway/">Prometheus Pushgateway</a>
+ */
+public class DropwizardPrometheusReporter extends ScheduledReporter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DropwizardPrometheusReporter.class);
+
+    private final PrometheusSender sender;
+
+    private DropwizardPrometheusReporter(MetricRegistry registry, MetricFilter filter, PrometheusSender sender) {
+        super(registry, "prometheus-reporter", filter, TimeUnit.SECONDS, TimeUnit.SECONDS);
+        this.sender = sender;
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges,
+                       SortedMap<String, Counter> counters,
+                       SortedMap<String, Histogram> histograms,
+                       SortedMap<String, Meter> meters,
+                       SortedMap<String, Timer> timers) {
+        try {
+            sender.send(new DropwizardExports(gauges, counters, histograms, meters, timers));
+        } catch (IOException e) {
+            LOGGER.warn("Failed to report: {}", e.getMessage());
+        }
+    }
+
+    public static class Builder {
+
+        private final MetricRegistry registry;
+        private MetricFilter filter = MetricFilter.ALL;
+
+        Builder(MetricRegistry registry) {
+            this.registry = registry;
+        }
+
+        public Builder filter(MetricFilter filter) {
+            if (filter == null) {
+                throw new NullPointerException("filter must not be null");
+            }
+            this.filter = filter;
+            return this;
+        }
+
+        public DropwizardPrometheusReporter build(PrometheusSender sender) {
+            return new DropwizardPrometheusReporter(registry, filter, sender);
+        }
+    }
+
+    public static Builder forRegistry(MetricRegistry registry) {
+        return new Builder(registry);
+    }
+
+}

--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/PrometheusSender.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/PrometheusSender.java
@@ -1,0 +1,64 @@
+package io.prometheus.client.dropwizard;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.exporter.PushGateway;
+
+public class PrometheusSender {
+
+    private final PushGateway pushGateway;
+    private final String jobId;
+    private final Map<String, String> groupingKeys;
+
+    private PrometheusSender(PushGateway pushGateway, String jobId, Map<String, String> groupingKeys) {
+        this.pushGateway = pushGateway;
+        this.jobId = jobId;
+        this.groupingKeys = groupingKeys;
+    }
+
+    public void send(Collector collector) throws IOException {
+        pushGateway.pushAdd(collector, jobId, groupingKeys);
+    }
+
+    public static class Builder {
+
+        private final PushGateway pushGateway;
+        private final Map<String, String> groupingKeys = new LinkedHashMap<String, String>();
+        private String jobId;
+
+        Builder(PushGateway pushGateway) {
+            this.pushGateway = pushGateway;
+        }
+
+        public Builder jobId(String jobId) {
+            this.jobId = jobId;
+            return this;
+        }
+
+        public Builder addGroup(String key, String value) {
+            if (groupingKeys.containsKey(key)) {
+                throw new IllegalArgumentException("Group key must be unique: " + key);
+            }
+            groupingKeys.put(key, value);
+            return this;
+        }
+
+        public PrometheusSender build() {
+            if (jobId == null || jobId.isEmpty()) {
+                throw new IllegalArgumentException("jobId must not be null nor empty");
+            }
+            return new PrometheusSender(pushGateway, jobId, groupingKeys);
+        }
+
+    }
+
+    public static Builder withPushGateway(PushGateway pushGateway) {
+        if (pushGateway == null) {
+            throw new NullPointerException("pushGateway must not be null");
+        }
+        return new Builder(pushGateway);
+    }
+}

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardPrometheusReporterTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardPrometheusReporterTest.java
@@ -1,0 +1,118 @@
+package io.prometheus.client.dropwizard;
+
+import java.net.ConnectException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class DropwizardPrometheusReporterTest {
+
+    private final PrometheusSender prometheus = mock(PrometheusSender.class);
+
+    @Test
+    public void shouldReportsAllMetrics() throws Exception {
+
+        MetricRegistry registry = new MetricRegistry();
+        DropwizardPrometheusReporter reporter = DropwizardPrometheusReporter.forRegistry(registry)
+                .build(prometheus);
+
+        registry.counter("counter-1");
+        registry.meter("meter-1");
+        registry.timer("timer-1");
+        registry.histogram("histogram-1");
+        registry.register("gauge-1", gauge(1));
+
+        reporter.report();
+
+        ArgumentCaptor<Collector> captor = ArgumentCaptor.forClass(Collector.class);
+        verify(prometheus).send(captor.capture());
+        verifyNoMoreInteractions(prometheus);
+
+        List<MetricFamilySamples> metrics = captor.getValue().collect();
+        assertThat(metrics.size(), is(5));
+        assertThat(namesOf(metrics), hasItems("counter_1", "gauge_1",
+                "meter_1_total", "timer_1", "histogram_1"));
+    }
+
+    @Test
+    public void shouldReportsFilteredMetrics() throws Exception {
+
+        MetricRegistry registry = new MetricRegistry();
+        DropwizardPrometheusReporter reporter = DropwizardPrometheusReporter.forRegistry(registry)
+                .filter(new MetricFilter() {
+                    @Override
+                    public boolean matches(String name, Metric metric) {
+                        return name.endsWith("-2");
+                    }
+                })
+                .build(prometheus);
+
+        registry.counter("counter-1");
+        registry.counter("counter-2");
+        registry.meter("meter-1");
+        registry.timer("timer-1");
+        registry.timer("timer-2");
+        registry.histogram("histogram-1");
+        registry.register("gauge-1", gauge(2));
+
+        reporter.report();
+
+        ArgumentCaptor<Collector> captor = ArgumentCaptor.forClass(Collector.class);
+        verify(prometheus).send(captor.capture());
+        verifyNoMoreInteractions(prometheus);
+
+        List<MetricFamilySamples> metrics = captor.getValue().collect();
+        assertThat(metrics.size(), is(2));
+        assertThat(namesOf(metrics), hasItems("timer_2", "counter_2"));
+    }
+
+    @Test
+    public void shouldLogErrorAndContinue() throws Exception {
+        doThrow(new ConnectException("connection refused")).when(prometheus).send(any(Collector.class));
+
+        MetricRegistry registry = new MetricRegistry();
+        DropwizardPrometheusReporter reporter = DropwizardPrometheusReporter.forRegistry(registry)
+                .build(prometheus);
+
+        reporter.report();
+        reporter.report();
+        reporter.report();
+
+        verify(prometheus, times(3)).send(any(Collector.class));
+        verifyNoMoreInteractions(prometheus);
+    }
+
+    private List<String> namesOf(List<MetricFamilySamples> metrics) {
+        List<String> names = new ArrayList<String>(metrics.size());
+        for (MetricFamilySamples metric: metrics) {
+            names.add(metric.name);
+        }
+        return names;
+    }
+
+    private <T> Gauge gauge(T value) {
+        final Gauge gauge = mock(Gauge.class);
+        when(gauge.getValue()).thenReturn(value);
+        return gauge;
+    }
+
+}

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/PrometheusSenderTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/PrometheusSenderTest.java
@@ -1,0 +1,100 @@
+package io.prometheus.client.dropwizard;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.exporter.PushGateway;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class PrometheusSenderTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldThrowExceptionIfJobIsNull() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("jobId must not be null nor empty");
+        PrometheusSender.withPushGateway(mock(PushGateway.class))
+                .build();
+    }
+
+    @Test
+    public void shouldThrowExceptionIfJobIsEmpty() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("jobId must not be null nor empty");
+        PrometheusSender.withPushGateway(mock(PushGateway.class))
+                .jobId("")
+                .build();
+    }
+
+    @Test
+    public void shouldThrowExceptionIfPushGatewayIsNull() {
+        exception.expect(NullPointerException.class);
+        exception.expectMessage("pushGateway must not be null");
+        PrometheusSender.withPushGateway(null)
+                .jobId("job-1")
+                .build();
+    }
+
+    @Test
+    public void shouldThrowExceptionIfGroupKeyIsNotUnique() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Group key must be unique: key-1");
+        PrometheusSender.withPushGateway(mock(PushGateway.class))
+                .jobId("job-1")
+                .addGroup("key-1", "value-1")
+                .addGroup("key-1", "value-2")
+                .build();
+    }
+
+    @Test
+    public void shouldSendWithoutGroupKeys() throws Exception {
+
+        PushGateway gateway = mock(PushGateway.class);
+        Collector collector = mock(Collector.class);
+
+        PrometheusSender sender = PrometheusSender.withPushGateway(gateway)
+                .jobId("job-1")
+                .build();
+
+        sender.send(collector);
+
+        verify(gateway).pushAdd(eq(collector), eq("job-1"), eq(Collections.<String, String>emptyMap()));
+    }
+
+    @Test
+    public void shouldSendWithGroupKeys() throws Exception {
+
+        PushGateway gateway = mock(PushGateway.class);
+        Collector collector = mock(Collector.class);
+
+        PrometheusSender sender = PrometheusSender.withPushGateway(gateway)
+                .jobId("job-1")
+                .addGroup("instance", "127.0.0.1")
+                .addGroup("role", "master")
+                .build();
+
+        sender.send(collector);
+
+        verify(gateway).pushAdd(eq(collector), eq("job-1"), eq(pairsOf("instance", "127.0.0.1",
+                "role", "master")));
+
+    }
+
+    private Map<String, String> pairsOf(String... keyAndValue) {
+        Map<String, String> map = new LinkedHashMap<String, String>(keyAndValue.length/2);
+        for (int i = 0; i < keyAndValue.length; i+=2) {
+            map.put(keyAndValue[i], keyAndValue[i+1]);
+        }
+        return map;
+    }
+}


### PR DESCRIPTION
Hi,

This PR adds scheduled reporter for Dropwizard metrics through push-gateway as an alternative to pull mechanism. It can be useful for projects like Spark to collect data from dynamic set of executors. 

Originally I didn't think about adding reporter to this projects, but since `DropwizardExports` class does not really open for extension, instead of just making its methods public and implementing reporter in another project, I decided to add it here. I think it fits good. It the same time it might be a good idea to make `fromGauge/fromHistogram/fromTimer/fromMeter/fromCounter` methods public static and move to utility class.

@brian-brazil please review and say if the feature fits this project.