### PR TITLE
allow Histograms and Summaries to time Callables (2)

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * Gauge metric, to report instantaneous values.
@@ -193,7 +194,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
     }
 
     /**
-     * Executes runnable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+     * Executes runnable code (e.g. a Java 8 Lambda) and observes a duration of how long it took to run.
      *
      * @param timeable Code that is being timed
      * @return Measured duration in seconds for timeable to complete.
@@ -209,6 +210,24 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
       }
 
       return elapsed;
+    }
+
+    /**
+     * Executes callable code (e.g. a Java 8 Lambda) and observes a duration of how long it took to run.
+     *
+     * @param timeable Code that is being timed
+     * @return Result returned by callable.
+     */
+    public <E> E setToTime(Callable<E> timeable){
+      Timer timer = startTimer();
+
+      try {
+        return timeable.call();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      } finally {
+        timer.setDuration();
+      }
     }
 
     /**
@@ -272,7 +291,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
   }
 
   /**
-   * Executes runnable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+   * Executes runnable code (e.g. a Java 8 Lambda) and observes a duration of how long it took to run.
    *
    * @param timeable Code that is being timed
    * @return Measured duration in seconds for timeable to complete.
@@ -280,7 +299,17 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
   public double setToTime(Runnable timeable){
     return noLabelsChild.setToTime(timeable);
   }
-  
+
+  /**
+   * Executes callable code (e.g. a Java 8 Lambda) and observes a duration of how long it took to run.
+   *
+   * @param timeable Code that is being timed
+   * @return Result returned by callable.
+   */
+  public <E> E setToTime(Callable<E> timeable){
+    return noLabelsChild.setToTime(timeable);
+  }
+
   /**
    * Get the value of the gauge.
    */

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -197,7 +198,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
   public static class Child {
 
     /**
-     * Executes runnable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+     * Executes runnable code (e.g. a Java 8 Lambda) and observes a duration of how long it took to run.
      *
      * @param timeable Code that is being timed
      * @return Measured duration in seconds for timeable to complete.
@@ -212,6 +213,24 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
         elapsed = timer.observeDuration();
       }
       return elapsed;
+    }
+
+    /**
+     * Executes callable code (e.g. a Java 8 Lambda) and observes a duration of how long it took to run.
+     *
+     * @param timeable Code that is being timed
+     * @return Result returned by callable.
+     */
+    public <E> E time(Callable<E> timeable) {
+      Timer timer = startTimer();
+
+      try {
+        return timeable.call();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      } finally {
+        timer.observeDuration();
+      }
     }
 
     public static class Value {
@@ -297,7 +316,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
   }
 
   /**
-   * Executes runnable code (i.e. a Java 8 Lambda) and observes a duration of how long it took to run.
+   * Executes runnable code (e.g. a Java 8 Lambda) and observes a duration of how long it took to run.
    *
    * @param timeable Code that is being timed
    * @return Measured duration in seconds for timeable to complete.
@@ -305,7 +324,17 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
   public double time(Runnable timeable){
     return noLabelsChild.time(timeable);
   }
-  
+
+  /**
+   * Executes callable code (e.g. a Java 8 Lambda) and observes a duration of how long it took to run.
+   *
+   * @param timeable Code that is being timed
+   * @return Result returned by callable.
+   */
+  public <E> E time(Callable<E> timeable){
+    return noLabelsChild.time(timeable);
+  }
+
   /**
    * Get the value of the Summary.
    * <p>

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +30,7 @@ public class GaugeTest {
   private double getValue() {
     return registry.getSampleValue("nolabels").doubleValue();
   }
-  
+
   @Test
   public void testIncrement() {
     noLabels.inc();
@@ -45,7 +46,7 @@ public class GaugeTest {
     assertEquals(8.0, getValue(), .001);
     assertEquals(8.0, noLabels.get(), .001);
   }
-    
+
   @Test
   public void testDecrement() {
     noLabels.dec();
@@ -57,7 +58,7 @@ public class GaugeTest {
     noLabels.labels().dec();
     assertEquals(-8.0, getValue(), .001);
   }
-  
+
   @Test
   public void testSet() {
     noLabels.set(42);
@@ -93,7 +94,17 @@ public class GaugeTest {
         //no op
       }
     });
+    assertEquals(10, getValue(), .001);
     assertEquals(10, elapsed, .001);
+
+    int result = noLabels.setToTime(new Callable<Integer>() {
+      @Override
+      public Integer call() {
+        return 123;
+      }
+    });
+    assertEquals(123, result);
+    assertEquals(10, getValue(), .001);
 
     Gauge.Timer timer = noLabels.startTimer();
     elapsed = timer.setDuration();
@@ -105,7 +116,7 @@ public class GaugeTest {
   public void noLabelsDefaultZeroValue() {
     assertEquals(0.0, getValue(), .001);
   }
-  
+
   private Double getLabelsValue(String labelValue) {
     return registry.getSampleValue("labels", new String[]{"l"}, new String[]{labelValue});
   }
@@ -126,7 +137,7 @@ public class GaugeTest {
   public void testCollect() {
     labels.labels("a").inc();
     List<Collector.MetricFamilySamples> mfs = labels.collect();
-    
+
     ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
     ArrayList<String> labelNames = new ArrayList<String>();
     labelNames.add("l");

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -124,19 +125,27 @@ public class SummaryTest {
     });
     assertEquals(10, elapsed, .001);
 
+    int result = noLabels.time(new Callable<Integer>() {
+      @Override
+      public Integer call() {
+        return 123;
+      }
+    });
+    assertEquals(123, result);
+
     Summary.Timer timer = noLabels.startTimer();
     elapsed = timer.observeDuration();
-    assertEquals(2, getCount(), .001);
-    assertEquals(20, getSum(), .001);
+    assertEquals(3, getCount(), .001);
+    assertEquals(30, getSum(), .001);
     assertEquals(10, elapsed, .001);
   }
-  
+
   @Test
   public void noLabelsDefaultZeroValue() {
     assertEquals(0.0, getCount(), .001);
     assertEquals(0.0, getSum(), .001);
   }
-  
+
   private Double getLabelsCount(String labelValue) {
     return registry.getSampleValue("labels_count", new String[]{"l"}, new String[]{labelValue});
   }


### PR DESCRIPTION
@brian-brazil Recreated #368 from squashed branch + signed-off

Another usability enhancement allowing instead of:

    String v;
    try (Summary.Timer timer = summary.startTimer()) {
      v = someMethod();
    }
to write:

    String v = summary.time(this::someMethod);
This is especially useful when programming (reactive) streams.

Trying to make metric code as unobtrusive as possible.

BTW Micrometer already does that.