### PR TITLE
More sophisticated path to label mapping configuration in MetricsFilter

### DIFF
--- a/simpleclient_servlet/src/main/java/io/prometheus/client/filter/PathToLabelMapper.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/filter/PathToLabelMapper.java
@@ -1,0 +1,5 @@
+package io.prometheus.client.filter;
+
+public interface PathToLabelMapper {
+    String getLabel(String path);
+}

--- a/simpleclient_servlet/src/main/java/io/prometheus/client/filter/SlashLimitingPathMapper.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/filter/SlashLimitingPathMapper.java
@@ -1,0 +1,28 @@
+package io.prometheus.client.filter;
+
+public class SlashLimitingPathMapper implements PathToLabelMapper {
+    private int pathComponents = 1;
+
+    SlashLimitingPathMapper(int pathComponents) {
+        this.pathComponents = pathComponents;
+    }
+
+    @Override
+    public String getLabel(String path) {
+        if (path == null || pathComponents < 1) {
+            return path;
+        }
+        int count = 0;
+        int i = -1;
+        do {
+            i = path.indexOf("/", i + 1);
+            if (i < 0) {
+                // Path is longer than specified pathComponents.
+                return path;
+            }
+            count++;
+        } while (count <= pathComponents);
+
+        return path.substring(0, i);
+    }
+}


### PR DESCRIPTION
Specifying number of path components that is taken into account may not be enough for some projects where number of components in different endpoints differs.
This commit allows passing a custom path to label mapper from the java code into the MetricsFilter constructor.