### PR TITLE
Added per-query metrics in HibernateStatisticsCollector

### DIFF
--- a/simpleclient_hibernate/pom.xml
+++ b/simpleclient_hibernate/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>5.3.1.Final</version>
+            <version>5.2.0.Final</version>
             <scope>provided</scope>
         </dependency>
 

--- a/simpleclient_hibernate/pom.xml
+++ b/simpleclient_hibernate/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>4.2.0.Final</version>
+            <version>5.3.1.Final</version>
             <scope>provided</scope>
         </dependency>
 

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -557,6 +557,16 @@ public class HibernateStatisticsCollector extends Collector {
                         .getExecutionAvgTime();
               }
             }
+        ),
+        createGaugeForQuery("hibernate_per_query_execution_total_time",
+            "Accumulated execution time of query in milliseconds (getExecutionTotalTime)",
+            new ValueProviderPerQuery() {
+              @Override
+              public double getValue(Statistics statistics, String query) {
+                return statistics.getQueryStatistics(query)
+                    .getExecutionTotalTime();
+              }
+            }
         )
     ));
 

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -505,7 +505,7 @@ public class HibernateStatisticsCollector extends Collector {
               }
             }
         ),
-        createCounterForQuery("hibernate_per_query_executions_total",
+        createCounterForQuery("hibernate_per_query_execution_total",
                 "Global number of executions for query (getExecutionCount)",
             new ValueProviderPerQuery() {
               @Override

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -528,33 +528,33 @@ public class HibernateStatisticsCollector extends Collector {
               }
             }
         ),
-        createGaugeForQuery("hibernate_per_query_execution_min_time_ms",
-                "Minimum execution time of query in milliseconds (getExecutionMinTime)",
+        createGaugeForQuery("hibernate_per_query_execution_min_time",
+                "Minimum execution time of query in seconds (based on getExecutionMinTime)",
             new ValueProviderPerQuery() {
               @Override
               public double getValue(Statistics statistics, String query) {
-                return statistics.getQueryStatistics(query)
-                        .getExecutionMinTime();
+                return toSeconds(statistics.getQueryStatistics(query)
+                        .getExecutionMinTime());
               }
             }
         ),
-        createGaugeForQuery("hibernate_per_query_execution_max_time_ms",
-                "Maximum execution time of query in milliseconds (getExecutionMaxTime)",
+        createGaugeForQuery("hibernate_per_query_execution_max_time",
+                "Maximum execution time of query in seconds (based on getExecutionMaxTime)",
             new ValueProviderPerQuery() {
               @Override
               public double getValue(Statistics statistics, String query) {
-                return statistics.getQueryStatistics(query)
-                        .getExecutionMaxTime();
+                return toSeconds(statistics.getQueryStatistics(query)
+                        .getExecutionMaxTime());
               }
             }
         ),
-        createGaugeForQuery("hibernate_per_query_execution_time_ms",
-            "Accumulated execution time of query in milliseconds (getExecutionTotalTime)",
+        createGaugeForQuery("hibernate_per_query_execution_time",
+            "Accumulated execution time of query in seconds (based on getExecutionTotalTime)",
             new ValueProviderPerQuery() {
               @Override
               public double getValue(Statistics statistics, String query) {
-                return statistics.getQueryStatistics(query)
-                    .getExecutionTotalTime();
+                return toSeconds(statistics.getQueryStatistics(query)
+                    .getExecutionTotalTime());
               }
             }
         )
@@ -619,6 +619,10 @@ public class HibernateStatisticsCollector extends Collector {
         samples.addMetric(Arrays.asList(unitName, query), provider.getValue(stats, query));
       }
     }
+  }
+
+  private double toSeconds(long milliseconds){
+    return milliseconds / 1000d;
   }
 
   private interface PerQuerySamples {

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -3,6 +3,7 @@ package io.prometheus.client.hibernate;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.GaugeMetricFamily;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,6 +33,10 @@ import org.hibernate.stat.Statistics;
  * SessionFactory sessionFactory =
  *     entityManagerFactory.unwrap(SessionFactory.class);
  * </pre>
+ * <p>
+ * When {@code enablePerQueryMetrics()} has been called, certain metrics like execution
+ * time are collected per query. This may create a lot of monitoring data, so it should
+ * be used with caution.
  *
  * @author Christian Kaltepoth
  */
@@ -39,7 +44,11 @@ public class HibernateStatisticsCollector extends Collector {
 
   private static final List<String> LABEL_NAMES = Collections.singletonList("unit");
 
+  private static final List<String> LABEL_NAMES_PER_QUERY = Arrays.asList("unit", "query");
+
   private final Map<String, SessionFactory> sessionFactories = new ConcurrentHashMap<String, SessionFactory>();
+
+  private boolean perQueryMetricsEnabled;
 
   /**
    * Creates an empty collector. If you use this constructor, you have to add one or more
@@ -74,6 +83,16 @@ public class HibernateStatisticsCollector extends Collector {
     return this;
   }
 
+  /**
+   * Enables collection of per-query metrics. Produces a lot of monitoring data, so use with caution.
+   *
+   * @return Returns the collector
+   */
+  public HibernateStatisticsCollector enablePerQueryMetrics() {
+    this.perQueryMetricsEnabled = true;
+    return this;
+  }
+
   @Override
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples> metrics = new ArrayList<MetricFamilySamples>();
@@ -82,6 +101,9 @@ public class HibernateStatisticsCollector extends Collector {
     metrics.addAll(getCacheMetrics());
     metrics.addAll(getEntityMetrics());
     metrics.addAll(getQueryExecutionMetrics());
+    if (perQueryMetricsEnabled) {
+      metrics.addAll(getPerQueryMetrics());
+    }
     return metrics;
   }
 
@@ -448,14 +470,104 @@ public class HibernateStatisticsCollector extends Collector {
     );
   }
 
+  private List<MetricFamilySamples> getPerQueryMetrics() {
+    List<MetricFamilySamples> metrics = new ArrayList<MetricFamilySamples>();
+
+    metrics.addAll(Arrays.asList(
+
+        createCounterForQuery("hibernate_per_query_cache_hit_total",
+                "Global number of cache hits for query (getCacheHitCount)",
+            new ValueProviderPerQuery() {
+              @Override
+              public double getValue(Statistics statistics, String query) {
+                return statistics.getQueryStatistics(query)
+                        .getCacheHitCount();
+              }
+            }
+        ),
+        createCounterForQuery("hibernate_per_query_cache_miss_total",
+                "Global number of cache misses for query (getCacheMissCount)",
+            new ValueProviderPerQuery() {
+              @Override
+              public double getValue(Statistics statistics, String query) {
+                return statistics.getQueryStatistics(query)
+                        .getCacheMissCount();
+              }
+            }
+        ),
+        createCounterForQuery("hibernate_per_query_cache_put_total",
+                "Global number of cache puts for query (getCachePutCount)",
+            new ValueProviderPerQuery() {
+              @Override
+              public double getValue(Statistics statistics, String query) {
+                return statistics.getQueryStatistics(query)
+                        .getCachePutCount();
+              }
+            }
+        ),
+        createCounterForQuery("hibernate_per_query_executions_total",
+                "Global number of executions for query (getExecutionCount)",
+            new ValueProviderPerQuery() {
+              @Override
+              public double getValue(Statistics statistics, String query) {
+                return statistics.getQueryStatistics(query)
+                        .getExecutionCount();
+              }
+            }
+        ),
+        createCounterForQuery("hibernate_per_query_execution_rows_total",
+                "Global number of rows for all executions of query (getExecutionRowCount)",
+            new ValueProviderPerQuery() {
+              @Override
+              public double getValue(Statistics statistics, String query) {
+                return statistics.getQueryStatistics(query)
+                        .getExecutionRowCount();
+              }
+            }
+        ),
+        createGaugeForQuery("hibernate_per_query_execution_min_time",
+                "Minimum execution time of query (getExecutionMinTime)",
+            new ValueProviderPerQuery() {
+              @Override
+              public double getValue(Statistics statistics, String query) {
+                return statistics.getQueryStatistics(query)
+                        .getExecutionMinTime();
+              }
+            }
+        ),
+        createGaugeForQuery("hibernate_per_query_execution_max_time",
+                "Maximum execution time of query (getExecutionMaxTime)",
+            new ValueProviderPerQuery() {
+              @Override
+              public double getValue(Statistics statistics, String query) {
+                return statistics.getQueryStatistics(query)
+                        .getExecutionMaxTime();
+              }
+            }
+        ),
+        createGaugeForQuery("hibernate_per_query_execution_avg_time",
+                "Average execution time of query (getExecutionAvgTime)",
+            new ValueProviderPerQuery() {
+              @Override
+              public double getValue(Statistics statistics, String query) {
+                return statistics.getQueryStatistics(query)
+                        .getExecutionAvgTime();
+              }
+            }
+        )
+    ));
+
+    return metrics;
+  }
+
   private CounterMetricFamily createCounter(String metric, String help, ValueProvider provider) {
 
     CounterMetricFamily metricFamily = new CounterMetricFamily(metric, help, LABEL_NAMES);
 
     for (Entry<String, SessionFactory> entry : sessionFactories.entrySet()) {
       metricFamily.addMetric(
-          Collections.singletonList(entry.getKey()),
-          provider.getValue(entry.getValue().getStatistics())
+              Collections.singletonList(entry.getKey()),
+              provider.getValue(entry.getValue().getStatistics())
       );
     }
 
@@ -463,10 +575,67 @@ public class HibernateStatisticsCollector extends Collector {
 
   }
 
+  private CounterMetricFamily createCounterForQuery(String metric, String help, ValueProviderPerQuery provider) {
+
+    final CounterMetricFamily counters = new CounterMetricFamily(metric, help, LABEL_NAMES_PER_QUERY);
+
+    addMetricsForQuery(new PerQuerySamples() {
+      @Override
+      public void addMetric(List<String> labelValues, double value) {
+        counters.addMetric(labelValues, value);
+      }
+    }, provider);
+
+    return counters;
+
+  }
+
+  private GaugeMetricFamily createGaugeForQuery(String metric, String help, ValueProviderPerQuery provider) {
+
+    final GaugeMetricFamily gauges = new GaugeMetricFamily(metric, help, LABEL_NAMES_PER_QUERY);
+
+    addMetricsForQuery(new PerQuerySamples() {
+      @Override
+      public void addMetric(List<String> labelValues, double value) {
+        gauges.addMetric(labelValues, value);
+      }
+    }, provider);
+
+    return gauges;
+
+  }
+
+  private void addMetricsForQuery(PerQuerySamples samples, ValueProviderPerQuery provider) {
+
+    for (Entry<String, SessionFactory> entry : sessionFactories.entrySet()) {
+      SessionFactory sessionFactory = entry.getValue();
+      Statistics stats = sessionFactory.getStatistics();
+      String unitName = entry.getKey();
+
+      for (String query : stats.getQueries()) {
+        samples.addMetric(Arrays.asList(unitName, query), provider.getValue(stats, query));
+      }
+    }
+  }
+
+  private interface PerQuerySamples {
+
+    void addMetric(List<String> labelValues, double value);
+
+  }
+
+
   private interface ValueProvider {
 
     double getValue(Statistics statistics);
 
   }
+
+  private interface ValueProviderPerQuery {
+
+    double getValue(Statistics statistics, String query);
+
+  }
+
 
 }

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -548,7 +548,7 @@ public class HibernateStatisticsCollector extends Collector {
               }
             }
         ),
-        createGaugeForQuery("hibernate_per_query_execution_seconds",
+        createCounterForQuery("hibernate_per_query_execution_seconds_total",
             "Accumulated execution time of query in seconds (based on getExecutionTotalTime)",
             new ValueProviderPerQuery() {
               @Override

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -86,8 +86,8 @@ public class HibernateStatisticsCollector extends Collector {
   /**
    * Enables collection of per-query metrics. Produces a lot of monitoring data, so use with caution.
    * <p>
-   * Per-query metrics have a label "query" with the actual HQL query as value. Parameters within
-   * the query will not be replaced (example: {@code select u from User u where id=?}).
+   * Per-query metrics have a label "query" with the actual HQL query as value. The query will contain
+   * placeholders ("?") instead of the real parameter values (example: {@code select u from User u where id=?}).
    *
    * @return Returns the collector
    */
@@ -528,7 +528,7 @@ public class HibernateStatisticsCollector extends Collector {
               }
             }
         ),
-        createGaugeForQuery("hibernate_per_query_execution_min_time",
+        createGaugeForQuery("hibernate_per_query_execution_min_time_ms",
                 "Minimum execution time of query in milliseconds (getExecutionMinTime)",
             new ValueProviderPerQuery() {
               @Override
@@ -538,7 +538,7 @@ public class HibernateStatisticsCollector extends Collector {
               }
             }
         ),
-        createGaugeForQuery("hibernate_per_query_execution_max_time",
+        createGaugeForQuery("hibernate_per_query_execution_max_time_ms",
                 "Maximum execution time of query in milliseconds (getExecutionMaxTime)",
             new ValueProviderPerQuery() {
               @Override
@@ -548,17 +548,7 @@ public class HibernateStatisticsCollector extends Collector {
               }
             }
         ),
-        createGaugeForQuery("hibernate_per_query_execution_avg_time",
-                "Average execution time of query in milliseconds (getExecutionAvgTime)",
-            new ValueProviderPerQuery() {
-              @Override
-              public double getValue(Statistics statistics, String query) {
-                return statistics.getQueryStatistics(query)
-                        .getExecutionAvgTime();
-              }
-            }
-        ),
-        createGaugeForQuery("hibernate_per_query_execution_total_time",
+        createGaugeForQuery("hibernate_per_query_execution_time_ms",
             "Accumulated execution time of query in milliseconds (getExecutionTotalTime)",
             new ValueProviderPerQuery() {
               @Override

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -85,6 +85,9 @@ public class HibernateStatisticsCollector extends Collector {
 
   /**
    * Enables collection of per-query metrics. Produces a lot of monitoring data, so use with caution.
+   * <p>
+   * Per-query metrics have a label "query" with the actual HQL query as value. Parameters within
+   * the query will not be replaced (example: {@code select u from User u where id=?}).
    *
    * @return Returns the collector
    */
@@ -526,7 +529,7 @@ public class HibernateStatisticsCollector extends Collector {
             }
         ),
         createGaugeForQuery("hibernate_per_query_execution_min_time",
-                "Minimum execution time of query (getExecutionMinTime)",
+                "Minimum execution time of query in milliseconds (getExecutionMinTime)",
             new ValueProviderPerQuery() {
               @Override
               public double getValue(Statistics statistics, String query) {
@@ -536,7 +539,7 @@ public class HibernateStatisticsCollector extends Collector {
             }
         ),
         createGaugeForQuery("hibernate_per_query_execution_max_time",
-                "Maximum execution time of query (getExecutionMaxTime)",
+                "Maximum execution time of query in milliseconds (getExecutionMaxTime)",
             new ValueProviderPerQuery() {
               @Override
               public double getValue(Statistics statistics, String query) {
@@ -546,7 +549,7 @@ public class HibernateStatisticsCollector extends Collector {
             }
         ),
         createGaugeForQuery("hibernate_per_query_execution_avg_time",
-                "Average execution time of query (getExecutionAvgTime)",
+                "Average execution time of query in milliseconds (getExecutionAvgTime)",
             new ValueProviderPerQuery() {
               @Override
               public double getValue(Statistics statistics, String query) {

--- a/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
+++ b/simpleclient_hibernate/src/main/java/io/prometheus/client/hibernate/HibernateStatisticsCollector.java
@@ -528,7 +528,7 @@ public class HibernateStatisticsCollector extends Collector {
               }
             }
         ),
-        createGaugeForQuery("hibernate_per_query_execution_min_time",
+        createGaugeForQuery("hibernate_per_query_execution_min_seconds",
                 "Minimum execution time of query in seconds (based on getExecutionMinTime)",
             new ValueProviderPerQuery() {
               @Override
@@ -538,7 +538,7 @@ public class HibernateStatisticsCollector extends Collector {
               }
             }
         ),
-        createGaugeForQuery("hibernate_per_query_execution_max_time",
+        createGaugeForQuery("hibernate_per_query_execution_max_seconds",
                 "Maximum execution time of query in seconds (based on getExecutionMaxTime)",
             new ValueProviderPerQuery() {
               @Override
@@ -548,7 +548,7 @@ public class HibernateStatisticsCollector extends Collector {
               }
             }
         ),
-        createGaugeForQuery("hibernate_per_query_execution_time",
+        createGaugeForQuery("hibernate_per_query_execution_seconds",
             "Accumulated execution time of query in seconds (based on getExecutionTotalTime)",
             new ValueProviderPerQuery() {
               @Override

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -181,7 +181,7 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_execution_min_seconds", "factory6", query), is(0.123d));
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory6", query), is(7.0));
     assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory6", query), is(8.0));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_seconds", "factory6", query), is(102.540d));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_seconds_total", "factory6", query), is(102.540d));
 
   }
 

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -181,7 +181,7 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_execution_max_time", "factory6", query), is(5.0));
     assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory6", query), is(6.0));
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory6", query), is(7.0));
-    assertThat(getSampleForQuery("hibernate_per_query_executions_total", "factory6", query), is(8.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory6", query), is(8.0));
 
   }
 
@@ -201,7 +201,7 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_execution_max_time", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_executions_total", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory7", query), nullValue());
 
   }
 

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -202,6 +202,7 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_total_time", "factory7", query), nullValue());
 
   }
 
@@ -216,6 +217,7 @@ public class HibernateStatisticsCollectorTest {
     when(queryStatistics.getExecutionMinTime()).thenReturn(6L);
     when(queryStatistics.getExecutionRowCount()).thenReturn(7L);
     when(queryStatistics.getExecutionCount()).thenReturn(8L);
+    when(queryStatistics.getExecutionTotalTime()).thenReturn(9L);
   }
 
   @Test

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -177,11 +177,11 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_cache_hit_total", "factory6", query), is(1.0));
     assertThat(getSampleForQuery("hibernate_per_query_cache_miss_total", "factory6", query), is(2.0));
     assertThat(getSampleForQuery("hibernate_per_query_cache_put_total", "factory6", query), is(3.0));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time", "factory6", query), is(0.555d));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory6", query), is(0.123d));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_max_seconds", "factory6", query), is(0.555d));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_min_seconds", "factory6", query), is(0.123d));
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory6", query), is(7.0));
     assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory6", query), is(8.0));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_time", "factory6", query), is(102.540d));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_seconds", "factory6", query), is(102.540d));
 
   }
 
@@ -197,11 +197,11 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_cache_hit_total", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_cache_miss_total", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_cache_put_total", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_max_seconds", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_min_seconds", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_execution_time", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_seconds", "factory7", query), nullValue());
 
   }
 

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -1,12 +1,15 @@
 package io.prometheus.client.hibernate;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.prometheus.client.CollectorRegistry;
 import org.hibernate.SessionFactory;
+import org.hibernate.stat.QueryStatistics;
 import org.hibernate.stat.Statistics;
 import org.junit.Before;
 import org.junit.Rule;
@@ -20,6 +23,7 @@ public class HibernateStatisticsCollectorTest {
 
   private SessionFactory sessionFactory;
   private Statistics statistics;
+  private QueryStatistics queryStatistics;
   private CollectorRegistry registry;
 
   @Before
@@ -27,6 +31,7 @@ public class HibernateStatisticsCollectorTest {
     registry = new CollectorRegistry();
     sessionFactory = mock(SessionFactory.class);
     statistics = mock(Statistics.class);
+    queryStatistics = mock(QueryStatistics.class);
     when(sessionFactory.getStatistics()).thenReturn(statistics);
   }
 
@@ -160,6 +165,60 @@ public class HibernateStatisticsCollectorTest {
   }
 
   @Test
+  public void shouldPublishPerQueryMetricsWhenEnabled() {
+    String query = "query";
+    mockQueryStatistics(query);
+
+    new HibernateStatisticsCollector()
+            .add(sessionFactory, "factory6")
+            .enablePerQueryMetrics()
+            .register(registry);
+
+    assertThat(getSampleForQuery("hibernate_per_query_cache_hit_total", "factory6", query), is(1.0));
+    assertThat(getSampleForQuery("hibernate_per_query_cache_miss_total", "factory6", query), is(2.0));
+    assertThat(getSampleForQuery("hibernate_per_query_cache_put_total", "factory6", query), is(3.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_avg_time", "factory6", query), is(4.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time", "factory6", query), is(5.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory6", query), is(6.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory6", query), is(7.0));
+    assertThat(getSampleForQuery("hibernate_per_query_executions_total", "factory6", query), is(8.0));
+
+  }
+
+  @Test
+  public void shouldNotPublishPerQueryMetricsByDefault() {
+    String query = "query";
+    mockQueryStatistics(query);
+
+    new HibernateStatisticsCollector()
+            .add(sessionFactory, "factory7")
+            .register(registry);
+
+    assertThat(getSampleForQuery("hibernate_per_query_cache_hit_total", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_cache_miss_total", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_cache_put_total", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_avg_time", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_executions_total", "factory7", query), nullValue());
+
+  }
+
+  private void mockQueryStatistics(String query) {
+    when(statistics.getQueries()).thenReturn(new String[]{query});
+    when(statistics.getQueryStatistics(eq(query))).thenReturn(queryStatistics);
+    when(queryStatistics.getCacheHitCount()).thenReturn(1L);
+    when(queryStatistics.getCacheMissCount()).thenReturn(2L);
+    when(queryStatistics.getCachePutCount()).thenReturn(3L);
+    when(queryStatistics.getExecutionAvgTime()).thenReturn(4L);
+    when(queryStatistics.getExecutionMaxTime()).thenReturn(5L);
+    when(queryStatistics.getExecutionMinTime()).thenReturn(6L);
+    when(queryStatistics.getExecutionRowCount()).thenReturn(7L);
+    when(queryStatistics.getExecutionCount()).thenReturn(8L);
+  }
+
+  @Test
   public void shouldFailIfNoSessionFactoriesAreRegistered() {
 
     expectedException.expect(IllegalStateException.class);
@@ -172,6 +231,12 @@ public class HibernateStatisticsCollectorTest {
   private Double getSample(String metric, String factory) {
     return registry.getSampleValue(
         metric, new String[]{"unit"}, new String[]{factory}
+    );
+  }
+
+  private Double getSampleForQuery(String metric, String factory, String query) {
+    return registry.getSampleValue(
+            metric, new String[]{"unit", "query"}, new String[]{factory, query}
     );
   }
 

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -177,12 +177,11 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_cache_hit_total", "factory6", query), is(1.0));
     assertThat(getSampleForQuery("hibernate_per_query_cache_miss_total", "factory6", query), is(2.0));
     assertThat(getSampleForQuery("hibernate_per_query_cache_put_total", "factory6", query), is(3.0));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_avg_time", "factory6", query), is(4.0));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time", "factory6", query), is(5.0));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory6", query), is(6.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time_ms", "factory6", query), is(5.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time_ms", "factory6", query), is(6.0));
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory6", query), is(7.0));
     assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory6", query), is(8.0));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_total_time", "factory6", query), is(9.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_time_ms", "factory6", query), is(9.0));
 
   }
 
@@ -198,12 +197,11 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_cache_hit_total", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_cache_miss_total", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_cache_put_total", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_execution_avg_time", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time_ms", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time_ms", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_execution_total_time", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_time_ms", "factory7", query), nullValue());
 
   }
 

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -182,6 +182,7 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory6", query), is(6.0));
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory6", query), is(7.0));
     assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory6", query), is(8.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_total_time", "factory6", query), is(9.0));
 
   }
 

--- a/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
+++ b/simpleclient_hibernate/src/test/java/io/prometheus/client/hibernate/HibernateStatisticsCollectorTest.java
@@ -177,11 +177,11 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_cache_hit_total", "factory6", query), is(1.0));
     assertThat(getSampleForQuery("hibernate_per_query_cache_miss_total", "factory6", query), is(2.0));
     assertThat(getSampleForQuery("hibernate_per_query_cache_put_total", "factory6", query), is(3.0));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time_ms", "factory6", query), is(5.0));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time_ms", "factory6", query), is(6.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time", "factory6", query), is(0.555d));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory6", query), is(0.123d));
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory6", query), is(7.0));
     assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory6", query), is(8.0));
-    assertThat(getSampleForQuery("hibernate_per_query_execution_time_ms", "factory6", query), is(9.0));
+    assertThat(getSampleForQuery("hibernate_per_query_execution_time", "factory6", query), is(102.540d));
 
   }
 
@@ -197,11 +197,11 @@ public class HibernateStatisticsCollectorTest {
     assertThat(getSampleForQuery("hibernate_per_query_cache_hit_total", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_cache_miss_total", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_cache_put_total", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time_ms", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time_ms", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_max_time", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_min_time", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_execution_rows_total", "factory7", query), nullValue());
     assertThat(getSampleForQuery("hibernate_per_query_execution_total", "factory7", query), nullValue());
-    assertThat(getSampleForQuery("hibernate_per_query_execution_time_ms", "factory7", query), nullValue());
+    assertThat(getSampleForQuery("hibernate_per_query_execution_time", "factory7", query), nullValue());
 
   }
 
@@ -211,12 +211,11 @@ public class HibernateStatisticsCollectorTest {
     when(queryStatistics.getCacheHitCount()).thenReturn(1L);
     when(queryStatistics.getCacheMissCount()).thenReturn(2L);
     when(queryStatistics.getCachePutCount()).thenReturn(3L);
-    when(queryStatistics.getExecutionAvgTime()).thenReturn(4L);
-    when(queryStatistics.getExecutionMaxTime()).thenReturn(5L);
-    when(queryStatistics.getExecutionMinTime()).thenReturn(6L);
+    when(queryStatistics.getExecutionMaxTime()).thenReturn(555L);
+    when(queryStatistics.getExecutionMinTime()).thenReturn(123L);
     when(queryStatistics.getExecutionRowCount()).thenReturn(7L);
     when(queryStatistics.getExecutionCount()).thenReturn(8L);
-    when(queryStatistics.getExecutionTotalTime()).thenReturn(9L);
+    when(queryStatistics.getExecutionTotalTime()).thenReturn(102540L);
   }
 
   @Test


### PR DESCRIPTION
This PR extends the `HibernateStatisticsCollector` so that it collects metrics per query from Hibernate's `QueryStatistics` object. 

Collecting metrics on a per-query basis is disabled by default and must be enabled by calling `enablePerQueryMetrics()`. 

We used the so created per-query metrics in a test system in combination with Grafana and successfully tracked down a database issue with long-lasting database queries.

I thought you might find it useful as well, so I created this PR :).