### PR TITLE
Extend JVM metrics with thread states

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -84,27 +84,28 @@ public class ThreadExports extends Collector {
       Collections.singletonList("state"));
 
     Map<Thread.State, Integer> threadStateCounts = getThreadStateCountMap();
-    for (Thread.State state : Thread.State.values()) {
-      String stateName = state.toString().toLowerCase();
+    for (Map.Entry<Thread.State, Integer> entry : threadStateCounts.entrySet()) {
       threadStateFamily.addMetric(
-        Collections.singletonList(stateName),
-        (threadStateCounts.containsKey(stateName)) ? threadStateCounts.get(stateName) : 0.0d
+        Collections.singletonList(entry.getKey().toString()),
+        entry.getValue()
       );
     }
   }
 
   private Map<Thread.State, Integer> getThreadStateCountMap() {
     ThreadInfo[] allThreads = threadBean.getThreadInfo(threadBean.getAllThreadIds(), StackTraceDepth);
-    HashMap<Thread.State, Integer> threadCounts = new HashMap<Thread.State, Integer>();
 
+    // Initialize the map with all thread states
+    HashMap<Thread.State, Integer> threadCounts = new HashMap<Thread.State, Integer>();
+    for (Thread.State state : Thread.State.values()) {
+      threadCounts.put(state, 0);
+    }
+
+    // Collect the actual thread counts
     for (ThreadInfo curThread : allThreads) {
       if (curThread != null) {
         Thread.State threadState = curThread.getThreadState();
-        if (threadCounts.containsKey(threadState)) {
-          threadCounts.put(threadState, threadCounts.get(threadState) + 1);
-        } else {
-          threadCounts.put(threadState, 1);
-        }
+        threadCounts.put(threadState, threadCounts.get(threadState) + 1);
       }
     }
 

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -7,7 +7,11 @@ import io.prometheus.client.GaugeMetricFamily;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Exports metrics about JVM thread areas.

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -7,7 +7,10 @@ import io.prometheus.client.GaugeMetricFamily;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Exports metrics about JVM thread areas.

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -93,7 +93,8 @@ public class ThreadExports extends Collector {
   }
 
   private Map<Thread.State, Integer> getThreadStateCountMap() {
-    ThreadInfo[] allThreads = threadBean.getThreadInfo(threadBean.getAllThreadIds(), StackTraceDepth);
+    // Get thread information without computing any stack traces
+    ThreadInfo[] allThreads = threadBean.getThreadInfo(threadBean.getAllThreadIds(), 0);
 
     // Initialize the map with all thread states
     HashMap<Thread.State, Integer> threadCounts = new HashMap<Thread.State, Integer>();
@@ -111,8 +112,6 @@ public class ThreadExports extends Collector {
 
     return threadCounts;
   }
-
-  private static int StackTraceDepth = 0; // Don't compute any stack traces
 
   private static double nullSafeArrayLength(long[] array) {
     return null == array ? 0 : array.length;

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/ThreadExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/ThreadExportsTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 
 import static org.junit.Assert.assertEquals;
@@ -26,6 +27,8 @@ public class ThreadExportsTest {
     when(mockThreadsBean.getTotalStartedThreadCount()).thenReturn(503L);
     when(mockThreadsBean.findDeadlockedThreads()).thenReturn(new long[]{1L,2L,3L});
     when(mockThreadsBean.findMonitorDeadlockedThreads()).thenReturn(new long[]{2L,3L,4L});
+    when(mockThreadsBean.getAllThreadIds()).thenReturn(new long[]{3L,4L,5L});
+    when(mockThreadsBean.getThreadInfo(new long[]{3L,4L,5L}, 0)).thenReturn(new ThreadInfo[] {});
     collectorUnderTest = new ThreadExports(mockThreadsBean).register(registry);
   }
 


### PR DESCRIPTION
@brian-brazil 

Hi,

at work we found it quite useful to get an insight in the number of existing threads and their state. I created this PR, in case other want to use this feature as well. I could also change this PR and implement it as a separate `Collector`. 

Looking forward to your feedback.

I attached an exemplary grafana dashboard showing the threads grouped by state: 

![screenshot 2018-06-21 10 22 22](https://user-images.githubusercontent.com/2549326/41707064-8f172ae2-753d-11e8-9c9a-4912afee0ee6.png)
 