### PR TITLE
Adding the _sum metric to histogram

### DIFF
--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -79,7 +79,8 @@ public class DropwizardExports extends io.prometheus.client.Collector implements
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.98"), snapshot.get98thPercentile() * factor),
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.99"), snapshot.get99thPercentile() * factor),
                 new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.999"), snapshot.get999thPercentile() * factor),
-                new MetricFamilySamples.Sample(name + "_count", new ArrayList<String>(), new ArrayList<String>(), count)
+                new MetricFamilySamples.Sample(name + "_count", new ArrayList<String>(), new ArrayList<String>(), count),
+                new MetricFamilySamples.Sample(name + "_sum", new ArrayList<String>(), new ArrayList<String>(), Arrays.stream(snapshot.getValues()).sum())
         );
         return Arrays.asList(
                 new MetricFamilySamples(name, Type.SUMMARY, helpMessage, samples)

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
@@ -130,6 +130,7 @@ public class DropwizardExportsTest {
             i += 1;
         }
         assertEquals(new Double(100), registry.getSampleValue("hist_count"));
+        assertEquals(new Double(4950), registry.getSampleValue("hist_sum"));
         for (Double d : Arrays.asList(0.75, 0.95, 0.98, 0.99)) {
             assertEquals(new Double((d - 0.01) * 100), registry.getSampleValue("hist",
                     new String[]{"quantile"}, new String[]{d.toString()}));


### PR DESCRIPTION
As some prometheus parsers will crash if they don’t see it.

e.g. https://github.com/Stackdriver/stackdriver-prometheus/issues/5