### PR TITLE
Fixing filtering with CollertorRegistry

### DIFF
--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -32,7 +32,8 @@ public class DropwizardExports extends io.prometheus.client.Collector implements
         String name = sanitizeMetricName(dropwizardName);
         MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name, new ArrayList<String>(), new ArrayList<String>(),
                 new Long(counter.getCount()).doubleValue());
-        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(dropwizardName, counter), Arrays.asList(sample)));
+        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(dropwizardName, counter),
+                new ArrayList<MetricFamilySamples.Sample>(Arrays.asList(sample))));
     }
 
     private static String getHelpMessage(String metricName, Metric metric){
@@ -58,7 +59,8 @@ public class DropwizardExports extends io.prometheus.client.Collector implements
         }
         MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample(name,
                 new ArrayList<String>(), new ArrayList<String>(), value);
-        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(dropwizardName, gauge), Arrays.asList(sample)));
+        return Arrays.asList(new MetricFamilySamples(name, Type.GAUGE, getHelpMessage(dropwizardName, gauge),
+                new ArrayList<MetricFamilySamples.Sample>(Arrays.asList(sample))));
     }
 
     /**
@@ -72,15 +74,16 @@ public class DropwizardExports extends io.prometheus.client.Collector implements
      */
     List<MetricFamilySamples> fromSnapshotAndCount(String dropwizardName, Snapshot snapshot, long count, double factor, String helpMessage) {
         String name = sanitizeMetricName(dropwizardName);
-        List<MetricFamilySamples.Sample> samples = Arrays.asList(
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.5"), snapshot.getMedian() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.75"), snapshot.get75thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.95"), snapshot.get95thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.98"), snapshot.get98thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.99"), snapshot.get99thPercentile() * factor),
-                new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.999"), snapshot.get999thPercentile() * factor),
-                new MetricFamilySamples.Sample(name + "_count", new ArrayList<String>(), new ArrayList<String>(), count)
-        );
+        List<MetricFamilySamples.Sample> samples =
+                new ArrayList<MetricFamilySamples.Sample>(
+                    Arrays.asList(
+                        new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.5"), snapshot.getMedian() * factor),
+                        new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.75"), snapshot.get75thPercentile() * factor),
+                        new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.95"), snapshot.get95thPercentile() * factor),
+                        new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.98"), snapshot.get98thPercentile() * factor),
+                        new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.99"), snapshot.get99thPercentile() * factor),
+                        new MetricFamilySamples.Sample(name, Arrays.asList("quantile"), Arrays.asList("0.999"), snapshot.get999thPercentile() * factor),
+                        new MetricFamilySamples.Sample(name + "_count", new ArrayList<String>(), new ArrayList<String>(), count)));
         return Arrays.asList(
                 new MetricFamilySamples(name, Type.SUMMARY, helpMessage, samples)
         );
@@ -109,12 +112,11 @@ public class DropwizardExports extends io.prometheus.client.Collector implements
         String name = sanitizeMetricName(dropwizardName);
         return Arrays.asList(
                 new MetricFamilySamples(name + "_total", Type.COUNTER, getHelpMessage(dropwizardName, meter),
-                        Arrays.asList(new MetricFamilySamples.Sample(name + "_total",
-                                new ArrayList<String>(),
-                                new ArrayList<String>(),
-                                meter.getCount())))
-
-        );
+                        new ArrayList<MetricFamilySamples.Sample>(
+                                Arrays.asList(new MetricFamilySamples.Sample(name + "_total",
+                                    new ArrayList<String>(),
+                                    new ArrayList<String>(),
+                                    meter.getCount())))));
     }
 
     private static final Pattern METRIC_NAME_RE = Pattern.compile("[^a-zA-Z0-9:_]");
@@ -157,6 +159,6 @@ public class DropwizardExports extends io.prometheus.client.Collector implements
 
     @Override
     public List<MetricFamilySamples> describe() {
-      return new ArrayList<MetricFamilySamples>();
+        return collect();
     }
 }

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
@@ -2,16 +2,14 @@ package io.prometheus.client.dropwizard;
 
 
 import com.codahale.metrics.*;
+import com.codahale.metrics.Timer;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -207,6 +205,46 @@ public class DropwizardExportsTest {
         assertThat(elements.get("my_application_namedGauge1").help,
                 is("Generated from Dropwizard metric import (metric=my.application.namedGauge1, type=io.prometheus.client.dropwizard.DropwizardExportsTest$ExampleDoubleGauge)"));
 
+    }
+
+    @Test
+    public void testFilter() {
+        metricRegistry.counter("counter_foo").inc();
+        metricRegistry.counter("counter_bar").inc();
+        metricRegistry.register("gauge_foo", new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return 1234;
+            }
+        });
+        metricRegistry.register("gauge_bar", new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return 1234;
+            }
+        });
+        metricRegistry.histogram("hist_foo");
+        metricRegistry.histogram("hist_bar");
+        metricRegistry.timer("timer_foo");
+        metricRegistry.timer("timer_bar");
+        metricRegistry.meter("meter_foo");
+        metricRegistry.meter("meter_bar");
+
+        Set<String> expected = new HashSet<String>(Arrays.asList("counter_foo", "gauge_foo", "hist_foo", "timer_foo", "meter_foo_total"));
+
+        registry.register(new DropwizardExports(metricRegistry));
+
+        HashSet<String> metrics = new HashSet<String>();
+        HashSet<String> series = new HashSet<String>();
+        for (Collector.MetricFamilySamples metricFamilySamples : Collections.list(registry.filteredMetricFamilySamples(
+                expected))) {
+            metrics.add(metricFamilySamples.name);
+            for (Collector.MetricFamilySamples.Sample sample : metricFamilySamples.samples) {
+                series.add(sample.name);
+            }
+        }
+
+        assertEquals(expected, metrics);
     }
 
     private static class ExampleDoubleGauge implements Gauge<Double> {

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
@@ -9,7 +9,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
It would cause an unsupported expection on an interator [here](https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java#L201) when there is more than one metric in a collector since `Arrays.asList` will produce an immutable list.

see https://stackoverflow.com/questions/2965747/why-do-i-get-an-unsupportedoperationexception-when-trying-to-remove-an-element-f

Also, the `describe` method was always returning an empty list causing the filtering [here](https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java#L98) to not find anything.