### PR TITLE
Fixing filtering with CollectorRegistry

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -195,16 +195,17 @@ public class CollectorRegistry {
       if (includedNames.isEmpty()) {
         return next;
       } else {
-        Iterator<Collector.MetricFamilySamples.Sample> it = next.samples.iterator();
-        while (it.hasNext()) {
-            if (!includedNames.contains(it.next().name)) {
-                it.remove();
-            }
+        List<Collector.MetricFamilySamples.Sample> filteredSamples = new ArrayList<Collector.MetricFamilySamples.Sample>();
+
+        for (Collector.MetricFamilySamples.Sample sample : next.samples) {
+          if(includedNames.contains(sample.name)) { filteredSamples.add(sample); }
         }
-        if (next.samples.size() == 0) {
+
+        if (filteredSamples.size() > 0) {
+          return new Collector.MetricFamilySamples(next.name, next.type, next.help, filteredSamples);
+        } else {
           return null;
         }
-        return next;
       }
     }
 

--- a/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
+++ b/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java
@@ -157,6 +157,6 @@ public class DropwizardExports extends io.prometheus.client.Collector implements
 
     @Override
     public List<MetricFamilySamples> describe() {
-      return new ArrayList<MetricFamilySamples>();
+      return collect();
     }
 }

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
@@ -9,9 +9,12 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -207,6 +210,46 @@ public class DropwizardExportsTest {
         assertThat(elements.get("my_application_namedGauge1").help,
                 is("Generated from Dropwizard metric import (metric=my.application.namedGauge1, type=io.prometheus.client.dropwizard.DropwizardExportsTest$ExampleDoubleGauge)"));
 
+    }
+
+    @Test
+    public void testFilter() {
+        metricRegistry.counter("counter_foo").inc();
+        metricRegistry.counter("counter_bar").inc();
+        metricRegistry.register("gauge_foo", new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return 1234;
+            }
+        });
+        metricRegistry.register("gauge_bar", new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return 1234;
+            }
+        });
+        metricRegistry.histogram("hist_foo");
+        metricRegistry.histogram("hist_bar");
+        metricRegistry.timer("timer_foo");
+        metricRegistry.timer("timer_bar");
+        metricRegistry.meter("meter_foo");
+        metricRegistry.meter("meter_bar");
+
+        Set<String> expected = new HashSet<String>(Arrays.asList("counter_foo", "gauge_foo", "hist_foo", "timer_foo", "meter_foo_total"));
+
+        registry.register(new DropwizardExports(metricRegistry));
+
+        HashSet<String> metrics = new HashSet<String>();
+        HashSet<String> series = new HashSet<String>();
+        for (Collector.MetricFamilySamples metricFamilySamples : Collections.list(registry.filteredMetricFamilySamples(
+                expected))) {
+            metrics.add(metricFamilySamples.name);
+            for (Collector.MetricFamilySamples.Sample sample : metricFamilySamples.samples) {
+                series.add(sample.name);
+            }
+        }
+
+        assertEquals(expected, metrics);
     }
 
     private static class ExampleDoubleGauge implements Gauge<Double> {


### PR DESCRIPTION
Using `iterator.remove()` can cause a problem with Lists that are produced using `Arrays.asList`. e.g. https://github.com/prometheus/client_java/blob/master/simpleclient_dropwizard/src/main/java/io/prometheus/client/dropwizard/DropwizardExports.java#L75-L83

see https://stackoverflow.com/questions/2965747/why-do-i-get-an-unsupportedoperationexception-when-trying-to-remove-an-element-f

Also, the `describe` method of `DropwizardExports` was always returning an empty list causing the filtering to not find anything.