### PR TITLE
Fix overlap between invoke() and value() in Spring MVC

### DIFF
--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMvcEndpoint.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMvcEndpoint.java
@@ -1,6 +1,9 @@
 package io.prometheus.client.spring.boot;
 
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
 import io.prometheus.client.exporter.common.TextFormat;
+
 import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.ResponseEntity;
@@ -9,9 +12,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.util.Collections;
 import java.util.Set;
-
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 @ConfigurationProperties("endpoints.prometheus")
 public class PrometheusMvcEndpoint extends EndpointMvcAdapter {
@@ -25,11 +27,12 @@ public class PrometheusMvcEndpoint extends EndpointMvcAdapter {
 
   @RequestMapping(
           method = {RequestMethod.GET},
-          produces = {TextFormat.CONTENT_TYPE_004}
+          produces = { "*/*" }
   )
+  @ResponseBody
   @Override
   public Object invoke() {
-    return super.invoke();
+    return value(Collections.<String>emptySet());
   }
 
   @RequestMapping(

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMvcEndpoint.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMvcEndpoint.java
@@ -25,6 +25,16 @@ public class PrometheusMvcEndpoint extends EndpointMvcAdapter {
 
   @RequestMapping(
           method = {RequestMethod.GET},
+          produces = {TextFormat.CONTENT_TYPE_004}
+  )
+  @Override
+  public Object invoke() {
+    return super.invoke();
+  }
+
+  @RequestMapping(
+          value = "/filtered",
+          method = {RequestMethod.GET},
           produces = { "*/*" }
   )
   @ResponseBody

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusMvcEndpointTest.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusMvcEndpointTest.java
@@ -44,6 +44,15 @@ public class PrometheusMvcEndpointTest {
     }
 
     @Test
+    public void testInvokeWithOtherAcceptHeader() {
+        ResponseEntity metricsResponse = template.exchange(getBaseUrl() + INVOKE_PATH, HttpMethod.GET,
+                getEntityWithAlternateAcceptHeader(), String.class);
+
+        assertEquals(HttpStatus.OK, metricsResponse.getStatusCode());
+        assertEquals(StringUtils.deleteWhitespace(TextFormat.CONTENT_TYPE_004), metricsResponse.getHeaders().getContentType().toString().toLowerCase());
+    }
+
+    @Test
     public void testNameParamIsNull() throws Exception {
         ResponseEntity metricsResponse = template.exchange(getBaseUrl() + FILTERED_PATH, HttpMethod.GET, getEntity(), String.class);
 
@@ -76,6 +85,12 @@ public class PrometheusMvcEndpointTest {
     public HttpEntity getEntity() {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Accept", "text/plain; version=0.0.4; charset=utf-8");
+        return new HttpEntity(headers);
+    }
+
+    public HttpEntity getEntityWithAlternateAcceptHeader() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", "text/html");
         return new HttpEntity(headers);
     }
 


### PR DESCRIPTION
I found that sometimes when I hit the `/prometheus` endpoint on my Spring Boot application, I got a blank page back. Other times it returned the expected set of complete results. This behavior seemed to change between restarts.

After investigation, I think the problem is that `EndpointMvcAdapter.invoke()` has a default `@RequestMapping` that matches the `@RequestMapping` of the value(name) method defined on `PrometheusMvcEndpoint`.

https://github.com/spring-projects/spring-boot/blob/5863e6f78c78f840127b2ae64ea9c422a06df9f3/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/mvc/EndpointMvcAdapter.java#L41-L46

Defining a distinct `/filtered` request mapping on the value method allows filtered results to consistently work by hitting the URL `/prometheus/filtered?name[]=foo`, while not having the issue of unfiltered results sometimes not working when hitting `/prometheus`.

For whatever reason, with my version of Spring Boot (1.3.7) and Spring Framework (4.2.7), the defaultValue of "" for value does not turn into an empty Set. I do see other people on the Internet claiming this works, so I'm guessing it is a behavior that was added in a later version of Spring. This change thus also improves compatibility with older spring versions.

Edit: made adjustments to the code once I realized there were some unit tests that were failing.