### PR TITLE
MetricsFilter to report on HTTP status code

### DIFF
--- a/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
@@ -110,7 +110,7 @@ public class MetricsFilter implements Filter {
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         Histogram.Builder builder = Histogram.build()
-                .labelNames("path", "method", "status_code");
+                .labelNames("path", "method", "status");
 
         if (filterConfig == null && isEmpty(metricName)) {
             throw new ServletException("No configuration object provided, and no metricName passed via constructor");

--- a/simpleclient_servlet/src/main/java/io/prometheus/client/filter/StatusAwareMetricsFilter.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/filter/StatusAwareMetricsFilter.java
@@ -1,0 +1,53 @@
+package io.prometheus.client.filter;
+
+import io.prometheus.client.Histogram;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * The StatusAwareMetricsFilter class provides an histogram metrics with the following labels : path, method, and status.
+ *
+ * This filter behave similarly than MetricsFilter with an extra label that report the status.
+ *
+ * Do not use MetricsFilter and StatusAwareMetricsFilter with the same metric name. Due to their different labels doing
+ * so would raise cardinality issues.
+ *
+ * {@code
+ * <filter>
+ *   <filter-name>statusAwarePrometheusFilter</filter-name>
+ *   <filter-class>io.prometheus.client.filter.StatusAwareMetricsFilter</filter-class>
+ *   <init-param>
+ *      <param-name>metric-name</param-name>
+ *      <param-value>webapp_metrics_filter</param-value>
+ *   </init-param>
+ *    <init-param>
+ *      <param-name>help</param-name>
+ *      <param-value>The time taken fulfilling servlet requests</param-value>
+ *   </init-param>
+ *   <init-param>
+ *      <param-name>buckets</param-name>
+ *      <param-value>0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10</param-value>
+ *   </init-param>
+ *   <init-param>
+ *      <param-name>path-components</param-name>
+ *      <param-value>0</param-value>
+ *   </init-param>
+ * </filter>
+ * }
+ */
+public class StatusAwareMetricsFilter extends MetricsFilter {
+
+    @Override
+    Histogram.Builder addLabelsNames(Histogram.Builder builder) {
+        return builder.labelNames("path", "method", "status");
+    }
+
+    @Override
+    Histogram.Child addLabelsValues(Histogram builder, HttpServletRequest request, HttpServletResponse response) {
+        String path = request.getRequestURI();
+        String status = Integer.toString((response).getStatus());
+        return builder.labels(getComponents(path), request.getMethod(), status);
+    }
+
+}

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterCommonTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterCommonTest.java
@@ -1,0 +1,36 @@
+package io.prometheus.client.filter;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import org.eclipse.jetty.http.HttpMethods;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Enumeration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+abstract public class MetricsFilterCommonTest {
+    MetricsFilter f =getMetricsFilter();
+
+    abstract public MetricsFilter getMetricsFilter();
+
+    @After
+    public void clear() {
+        CollectorRegistry.defaultRegistry.clear();
+    }
+
+
+}

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
@@ -51,13 +51,15 @@ public class MetricsFilterTest {
         when(req.getMethod()).thenReturn(HttpMethods.GET);
 
         HttpServletResponse res = mock(HttpServletResponse.class);
+        when(res.getStatus()).thenReturn(HttpServletResponse.SC_OK);
+
         FilterChain c = mock(FilterChain.class);
 
         f.doFilter(req, res, c);
 
         verify(c).doFilter(req, res);
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(metricName + "_count", new String[]{"path", "method"}, new String[]{"/foo/bar/baz/bang", HttpMethods.GET});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(metricName + "_count", new String[]{"path", "method", "status_code"}, new String[]{"/foo/bar/baz/bang", HttpMethods.GET,Integer.toString(HttpServletResponse.SC_OK)});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -71,6 +73,8 @@ public class MetricsFilterTest {
         when(req.getMethod()).thenReturn(HttpMethods.GET);
 
         HttpServletResponse res = mock(HttpServletResponse.class);
+        when(res.getStatus()).thenReturn(HttpServletResponse.SC_OK);
+
         FilterChain c = mock(FilterChain.class);
 
         String name = "foo";
@@ -84,7 +88,7 @@ public class MetricsFilterTest {
         verify(c).doFilter(req, res);
 
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(name + "_count", new String[]{"path", "method"}, new String[]{path, HttpMethods.GET});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(name + "_count", new String[]{"path", "method","status_code"}, new String[]{path, HttpMethods.GET,Integer.toString(HttpServletResponse.SC_OK)});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -114,9 +118,11 @@ public class MetricsFilterTest {
         constructed.init(mock(FilterConfig.class));
 
         HttpServletResponse res = mock(HttpServletResponse.class);
+        when(res.getStatus()).thenReturn(HttpServletResponse.SC_OK);
+
         constructed.doFilter(req, res, c);
 
-        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foobar_baz_filter_duration_seconds_sum", new String[]{"path", "method"}, new String[]{path, HttpMethods.POST});
+        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foobar_baz_filter_duration_seconds_sum", new String[]{"path", "method","status_code"}, new String[]{path, HttpMethods.POST,Integer.toString(HttpServletResponse.SC_OK)});
         assertNotNull(sum);
         assertEquals(0.1, sum, 0.01);
     }
@@ -143,18 +149,19 @@ public class MetricsFilterTest {
         when(cfg.getInitParameter(MetricsFilter.METRIC_NAME_PARAM)).thenReturn("foo");
 
         HttpServletResponse res = mock(HttpServletResponse.class);
+        when(res.getStatus()).thenReturn(HttpServletResponse.SC_OK);
 
         f.init(cfg);
 
         f.doFilter(req, res, c);
 
-        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foo_sum", new String[]{"path", "method"}, new String[]{"/foo", HttpMethods.POST});
+        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foo_sum", new String[]{"path", "method", "status_code"}, new String[]{"/foo", HttpMethods.POST,Integer.toString(HttpServletResponse.SC_OK)});
         assertEquals(0.1, sum, 0.01);
 
-        final Double le05 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "le"}, new String[]{"/foo", HttpMethods.POST, "0.05"});
+        final Double le05 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "status_code", "le"}, new String[]{"/foo", HttpMethods.POST,Integer.toString(HttpServletResponse.SC_OK), "0.05"});
         assertNotNull(le05);
         assertEquals(0, le05, 0.01);
-        final Double le15 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "le"}, new String[]{"/foo", HttpMethods.POST, "0.15"});
+        final Double le15 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "status_code", "le"}, new String[]{"/foo", HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK),"0.15"});
         assertNotNull(le15);
         assertEquals(1, le15, 0.01);
 

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
@@ -53,15 +53,13 @@ public class MetricsFilterTest {
         when(req.getMethod()).thenReturn(HttpMethods.GET);
 
         HttpServletResponse res = mock(HttpServletResponse.class);
-        when(res.getStatus()).thenReturn(HttpServletResponse.SC_OK);
-
         FilterChain c = mock(FilterChain.class);
 
         f.doFilter(req, res, c);
 
         verify(c).doFilter(req, res);
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(metricName + "_count", new String[]{"path", "method", "status"}, new String[]{"/foo/bar/baz/bang", HttpMethods.GET, Integer.toString(HttpServletResponse.SC_OK)});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(metricName + "_count", new String[]{"path", "method"}, new String[]{"/foo/bar/baz/bang", HttpMethods.GET});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -75,8 +73,6 @@ public class MetricsFilterTest {
         when(req.getMethod()).thenReturn(HttpMethods.GET);
 
         HttpServletResponse res = mock(HttpServletResponse.class);
-        when(res.getStatus()).thenReturn(HttpServletResponse.SC_OK);
-
         FilterChain c = mock(FilterChain.class);
 
         String name = "foo";
@@ -90,7 +86,7 @@ public class MetricsFilterTest {
         verify(c).doFilter(req, res);
 
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(name + "_count", new String[]{"path", "method", "status"}, new String[]{path, HttpMethods.GET, Integer.toString(HttpServletResponse.SC_OK)});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(name + "_count", new String[]{"path", "method"}, new String[]{path, HttpMethods.GET});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -120,11 +116,9 @@ public class MetricsFilterTest {
         constructed.init(mock(FilterConfig.class));
 
         HttpServletResponse res = mock(HttpServletResponse.class);
-        when(res.getStatus()).thenReturn(HttpServletResponse.SC_OK);
-
         constructed.doFilter(req, res, c);
 
-        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foobar_baz_filter_duration_seconds_sum", new String[]{"path", "method", "status"}, new String[]{path, HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK)});
+        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foobar_baz_filter_duration_seconds_sum", new String[]{"path", "method"}, new String[]{path, HttpMethods.POST});
         assertNotNull(sum);
         assertEquals(0.1, sum, 0.01);
     }
@@ -151,26 +145,25 @@ public class MetricsFilterTest {
         when(cfg.getInitParameter(MetricsFilter.METRIC_NAME_PARAM)).thenReturn("foo");
 
         HttpServletResponse res = mock(HttpServletResponse.class);
-        when(res.getStatus()).thenReturn(HttpServletResponse.SC_OK);
 
         f.init(cfg);
 
         f.doFilter(req, res, c);
 
-        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foo_sum", new String[]{"path", "method", "status"}, new String[]{"/foo", HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK)});
+        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foo_sum", new String[]{"path", "method"}, new String[]{"/foo", HttpMethods.POST});
         assertEquals(0.1, sum, 0.01);
 
-        final Double le05 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "status", "le"}, new String[]{"/foo", HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK), "0.05"});
+        final Double le05 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "le"}, new String[]{"/foo", HttpMethods.POST, "0.05"});
         assertNotNull(le05);
         assertEquals(0, le05, 0.01);
-        final Double le15 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "status", "le"}, new String[]{"/foo", HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK), "0.15"});
+        final Double le15 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "le"}, new String[]{"/foo", HttpMethods.POST, "0.15"});
         assertNotNull(le15);
         assertEquals(1, le15, 0.01);
 
 
         final Enumeration<Collector.MetricFamilySamples> samples = CollectorRegistry.defaultRegistry.metricFamilySamples();
         Collector.MetricFamilySamples sample = null;
-        while (samples.hasMoreElements()) {
+        while(samples.hasMoreElements()) {
             sample = samples.nextElement();
             if (sample.name.equals("foo")) {
                 break;
@@ -186,9 +179,8 @@ public class MetricsFilterTest {
             }
         }
         // +1 because of the final le=+infinity bucket
-        assertEquals(buckets.split(",").length + 1, count);
+        assertEquals(buckets.split(",").length+1, count);
     }
-
 
     @Test
     public void testStatusCode() throws Exception {
@@ -202,6 +194,7 @@ public class MetricsFilterTest {
 
         String metricName = "foo";
 
+        when(cfg.getInitParameter(MetricsFilter.REPORT_STATUS)).thenReturn("true");
         when(cfg.getInitParameter(MetricsFilter.METRIC_NAME_PARAM)).thenReturn(metricName);
         when(cfg.getInitParameter(MetricsFilter.PATH_COMPONENT_PARAM)).thenReturn("4");
 

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
@@ -61,7 +61,7 @@ public class MetricsFilterTest {
 
         verify(c).doFilter(req, res);
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(metricName + "_count", new String[]{"path", "method", "status_code"}, new String[]{"/foo/bar/baz/bang", HttpMethods.GET, Integer.toString(HttpServletResponse.SC_OK)});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(metricName + "_count", new String[]{"path", "method", "status"}, new String[]{"/foo/bar/baz/bang", HttpMethods.GET, Integer.toString(HttpServletResponse.SC_OK)});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -90,7 +90,7 @@ public class MetricsFilterTest {
         verify(c).doFilter(req, res);
 
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(name + "_count", new String[]{"path", "method", "status_code"}, new String[]{path, HttpMethods.GET, Integer.toString(HttpServletResponse.SC_OK)});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(name + "_count", new String[]{"path", "method", "status"}, new String[]{path, HttpMethods.GET, Integer.toString(HttpServletResponse.SC_OK)});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -124,7 +124,7 @@ public class MetricsFilterTest {
 
         constructed.doFilter(req, res, c);
 
-        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foobar_baz_filter_duration_seconds_sum", new String[]{"path", "method", "status_code"}, new String[]{path, HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK)});
+        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foobar_baz_filter_duration_seconds_sum", new String[]{"path", "method", "status"}, new String[]{path, HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK)});
         assertNotNull(sum);
         assertEquals(0.1, sum, 0.01);
     }
@@ -157,13 +157,13 @@ public class MetricsFilterTest {
 
         f.doFilter(req, res, c);
 
-        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foo_sum", new String[]{"path", "method", "status_code"}, new String[]{"/foo", HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK)});
+        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foo_sum", new String[]{"path", "method", "status"}, new String[]{"/foo", HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK)});
         assertEquals(0.1, sum, 0.01);
 
-        final Double le05 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "status_code", "le"}, new String[]{"/foo", HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK), "0.05"});
+        final Double le05 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "status", "le"}, new String[]{"/foo", HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK), "0.05"});
         assertNotNull(le05);
         assertEquals(0, le05, 0.01);
-        final Double le15 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "status_code", "le"}, new String[]{"/foo", HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK), "0.15"});
+        final Double le15 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "status", "le"}, new String[]{"/foo", HttpMethods.POST, Integer.toString(HttpServletResponse.SC_OK), "0.15"});
         assertNotNull(le15);
         assertEquals(1, le15, 0.01);
 
@@ -227,7 +227,7 @@ public class MetricsFilterTest {
 
             final Double sampleValue = CollectorRegistry.defaultRegistry
                     .getSampleValue(metricName + "_count",
-                            new String[]{"path", "method", "status_code"},
+                            new String[]{"path", "method", "status"},
                             new String[]{uri, HttpMethods.GET,
                                     Integer.toString(sampleStatusCodes.get(uri))});
             assertNotNull(sampleValue);

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/filter/StatusAwareMetricsFilterTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/filter/StatusAwareMetricsFilterTest.java
@@ -1,0 +1,75 @@
+package io.prometheus.client.filter;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import org.eclipse.jetty.http.HttpMethods;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class StatusAwareMetricsFilterTest extends MetricsFilterCommonTest {
+    public MetricsFilter getMetricsFilter(){
+        return new StatusAwareMetricsFilter();
+    }
+
+    @Test
+    public void testStatusCode() throws Exception {
+        Map<String, Integer> sampleStatusCodes = new HashMap<String, Integer>();
+        sampleStatusCodes.put("/a/page/that/exists", HttpServletResponse.SC_OK);
+        sampleStatusCodes.put("/a/page/that/doesn-t-exist", HttpServletResponse.SC_NOT_FOUND);
+        sampleStatusCodes.put("/a/page/that/crashes", HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+
+        FilterConfig cfg = mock(FilterConfig.class);
+        when(cfg.getInitParameter(anyString())).thenReturn(null);
+
+        String metricName = "foo";
+
+        when(cfg.getInitParameter(MetricsFilter.METRIC_NAME_PARAM)).thenReturn(metricName);
+        when(cfg.getInitParameter(MetricsFilter.PATH_COMPONENT_PARAM)).thenReturn("4");
+
+        f.init(cfg);
+
+        for (String uri : sampleStatusCodes.keySet()) {
+            HttpServletRequest req = mock(HttpServletRequest.class);
+
+            when(req.getRequestURI()).thenReturn(uri);
+            when(req.getMethod()).thenReturn(HttpMethods.GET);
+
+            HttpServletResponse res = mock(HttpServletResponse.class);
+            when(res.getStatus()).thenReturn(sampleStatusCodes.get(uri));
+
+            FilterChain c = mock(FilterChain.class);
+
+            f.doFilter(req, res, c);
+
+            verify(c).doFilter(req, res);
+        }
+
+        for (String uri : sampleStatusCodes.keySet()) {
+
+            final Double sampleValue = CollectorRegistry.defaultRegistry
+                    .getSampleValue(metricName + "_count",
+                            new String[]{"path", "method", "status"},
+                            new String[]{uri, HttpMethods.GET,
+                                    Integer.toString(sampleStatusCodes.get(uri))});
+            assertNotNull(sampleValue);
+            assertEquals(1, sampleValue, 0.0001);
+        }
+    }
+
+}


### PR DESCRIPTION
Hi @brian-brazil,

As other users mentioned in [issue 381](https://github.com/prometheus/client_java/issues/381), it would be quite convenient to have the servlet's MetricsFilter reporting on HTTP status code.

I implemented it and wrote a dedicated unit test.

Thanks.