### PR TITLE
fix unit tests failing in the Vertx module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: java
 jdk:
   - oraclejdk8
 
+cache:
+  directories:
+  - $HOME/.m2
+
 script:
 - ./mvnw test
 - ./mvnw javadoc:aggregate


### PR DESCRIPTION
Hi @brian-brazil,

Currently the Vert.x module unit tests often crash on Travis-CI, since it wasn't waiting for the Vert.x server to be ready.

This fix should solve this.

Additionally, this branch allows (commit 3aa591b) Travis-CI to use a Maven cache between two runs.

Voilà,
Cheers,

Raphaël