### PR TITLE
Fix HTTP header content-length when using compression

### DIFF
--- a/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
+++ b/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
@@ -65,8 +65,6 @@ public class HTTPServer {
 
             t.getResponseHeaders().set("Content-Type",
                     TextFormat.CONTENT_TYPE_004);
-            t.getResponseHeaders().set("Content-Length",
-                    String.valueOf(response.size()));
             if (shouldUseCompression(t)) {
                 t.getResponseHeaders().set("Content-Encoding", "gzip");
                 t.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);
@@ -74,6 +72,8 @@ public class HTTPServer {
                 response.writeTo(os);
                 os.finish();
             } else {
+                t.getResponseHeaders().set("Content-Length",
+                        String.valueOf(response.size()));
                 t.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.size());
                 response.writeTo(t.getResponseBody());
             }


### PR DESCRIPTION
This PR fix issues: prometheus/client_java#412 and prometheus/jmx_exporter#304