### PR TITLE
Add port public getter in HTTPServer

### DIFF
--- a/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
+++ b/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
@@ -220,5 +220,12 @@ public class HTTPServer {
         server.stop(0);
         executorService.shutdown(); // Free any (parked/idle) threads in pool
     }
+
+    /**
+     * Gets the port number.
+     */
+    public int getPort() {
+        return server.getAddress().getPort();
+    }
 }
 


### PR DESCRIPTION
If I don't want to configurate port for metrics I can pass '0' and it means use random avalible port, it's very useful but how I can know which port was used?
