### PR TITLE
Fix thread state metrics not being exposed

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -90,6 +90,7 @@ public class ThreadExports extends Collector {
         entry.getValue()
       );
     }
+    sampleFamilies.add(threadStateFamily);
   }
 
   private Map<Thread.State, Integer> getThreadStateCountMap() {

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/ThreadExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/ThreadExportsTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mockito;
 
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
@@ -16,8 +17,16 @@ public class ThreadExportsTest {
   private ThreadMXBean mockThreadsBean = Mockito.mock(ThreadMXBean.class);
   private CollectorRegistry registry = new CollectorRegistry();
   private ThreadExports collectorUnderTest;
+  private ThreadInfo mockThreadInfoBlocked = Mockito.mock(ThreadInfo.class);
+  private ThreadInfo mockThreadInfoRunnable1 = Mockito.mock(ThreadInfo.class);
+  private ThreadInfo mockThreadInfoRunnable2 = Mockito.mock(ThreadInfo.class);
 
   private static final String[] EMPTY_LABEL = new String[0];
+  private static final String[] STATE_LABEL = {"state"};
+  private static final String[] STATE_BLOCKED_LABEL = {Thread.State.BLOCKED.toString()};
+  private static final String[] STATE_RUNNABLE_LABEL = {Thread.State.RUNNABLE.toString()};
+  private static final String[] STATE_TERMINATED_LABEL = {Thread.State.TERMINATED.toString()};
+
 
   @Before
   public void setUp() {
@@ -28,7 +37,12 @@ public class ThreadExportsTest {
     when(mockThreadsBean.findDeadlockedThreads()).thenReturn(new long[]{1L,2L,3L});
     when(mockThreadsBean.findMonitorDeadlockedThreads()).thenReturn(new long[]{2L,3L,4L});
     when(mockThreadsBean.getAllThreadIds()).thenReturn(new long[]{3L,4L,5L});
-    when(mockThreadsBean.getThreadInfo(new long[]{3L,4L,5L}, 0)).thenReturn(new ThreadInfo[] {});
+    when(mockThreadInfoBlocked.getThreadState()).thenReturn(Thread.State.BLOCKED);
+    when(mockThreadInfoRunnable1.getThreadState()).thenReturn(Thread.State.RUNNABLE);
+    when(mockThreadInfoRunnable2.getThreadState()).thenReturn(Thread.State.RUNNABLE);
+    when(mockThreadsBean.getThreadInfo(new long[]{3L, 4L, 5L}, 0)).thenReturn(new ThreadInfo[]{
+            mockThreadInfoBlocked, mockThreadInfoRunnable1, mockThreadInfoRunnable2
+    });
     collectorUnderTest = new ThreadExports(mockThreadsBean).register(registry);
   }
 
@@ -63,6 +77,24 @@ public class ThreadExportsTest {
             3L,
             registry.getSampleValue(
             "jvm_threads_deadlocked_monitor", EMPTY_LABEL, EMPTY_LABEL),
+            .0000001);
+
+    assertEquals(
+            1L,
+            registry.getSampleValue(
+                    "jvm_threads_state", STATE_LABEL, STATE_BLOCKED_LABEL),
+            .0000001);
+
+    assertEquals(
+            2L,
+            registry.getSampleValue(
+                    "jvm_threads_state", STATE_LABEL, STATE_RUNNABLE_LABEL),
+            .0000001);
+
+    assertEquals(
+            0L,
+            registry.getSampleValue(
+                    "jvm_threads_state", STATE_LABEL, STATE_TERMINATED_LABEL),
             .0000001);
   }
 }


### PR DESCRIPTION
@brian-brazil

#391 introduced thread state metrics, however while they are collected, they are not actually exposed. Adding this line should fix that.