### PR TITLE
Add support for using non-default CollectorRegistry with the logback …

### DIFF
--- a/simpleclient_logback/pom.xml
+++ b/simpleclient_logback/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         

--- a/simpleclient_logback/src/main/java/io/prometheus/client/logback/InstrumentedAppender.java
+++ b/simpleclient_logback/src/main/java/io/prometheus/client/logback/InstrumentedAppender.java
@@ -3,24 +3,35 @@ package io.prometheus.client.logback;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 
 public class InstrumentedAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   public static final String COUNTER_NAME = "logback_appender_total";
   
-  private static final Counter COUNTER;
-  private static final Counter.Child TRACE_LABEL;
-  private static final Counter.Child DEBUG_LABEL;
-  private static final Counter.Child INFO_LABEL;
-  private static final Counter.Child WARN_LABEL;
-  private static final Counter.Child ERROR_LABEL;
-  
-  static {
+  private final Counter COUNTER;
+  private final Counter.Child TRACE_LABEL;
+  private final Counter.Child DEBUG_LABEL;
+  private final Counter.Child INFO_LABEL;
+  private final Counter.Child WARN_LABEL;
+  private final Counter.Child ERROR_LABEL;
+
+  /**
+   * Create a new instrumented appender using the default registry.
+   */
+  public InstrumentedAppender() {
+    this(CollectorRegistry.defaultRegistry);
+  }
+
+  /**
+   * Create a new instrumented appender using the specified registry.
+   */
+  public InstrumentedAppender(CollectorRegistry registry) {
     COUNTER = Counter.build().name(COUNTER_NAME)
             .help("Logback log statements at various log levels")
             .labelNames("level")
-            .register();
+            .register(registry);
 
     TRACE_LABEL = COUNTER.labels("trace");
     DEBUG_LABEL = COUNTER.labels("debug");
@@ -28,13 +39,6 @@ public class InstrumentedAppender extends UnsynchronizedAppenderBase<ILoggingEve
     WARN_LABEL = COUNTER.labels("warn");
     ERROR_LABEL = COUNTER.labels("error");
   }
-
-  /**
-   * Create a new instrumented appender using the default registry.
-   */
-  public InstrumentedAppender() {
-  }
-
 
   @Override
   public void start() {

--- a/simpleclient_logback/src/test/java/io/prometheus/client/logback/InstrumentedAppenderTest.java
+++ b/simpleclient_logback/src/test/java/io/prometheus/client/logback/InstrumentedAppenderTest.java
@@ -7,18 +7,38 @@ import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
 public class InstrumentedAppenderTest {
 
   private InstrumentedAppender appender;
   private ILoggingEvent event;
 
+  @Parameterized.Parameters
+  public static CollectorRegistry[] data() {
+    return new CollectorRegistry[]{
+      CollectorRegistry.defaultRegistry,
+      new CollectorRegistry(true)
+    };
+  }
+
+  @Parameterized.Parameter
+  public CollectorRegistry registry;
+
   @Before
   public void setUp() throws Exception {
-    appender = new InstrumentedAppender();
+    registry.clear();
+
+    appender = new InstrumentedAppender(registry);
     appender.start();
     
     event = mock(ILoggingEvent.class);
@@ -70,7 +90,7 @@ public class InstrumentedAppenderTest {
   }
 
   private int getLogLevelCount(String level) {
-    return CollectorRegistry.defaultRegistry.getSampleValue(COUNTER_NAME, 
+    return registry.getSampleValue(COUNTER_NAME,
             new String[]{"level"}, new String[]{level}).intValue();
   }
 }


### PR DESCRIPTION
…InstrumentedAppender

We have need of specifying a non-default CollectorRegistry to use with the logback InstrumentedAppender. Only added to logback, can port to log4j / log4j2 too if preferred.

Tests updated to support both defaultRegistry and a newly created one.

First time contributor - I believe I need to ping @brian-brazil on pull requests!?