### PR TITLE
Formatter fixed and unified for Quantile and Item classes

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
@@ -267,7 +267,7 @@ class CKMSQuantiles {
 
         @Override
         public String toString() {
-            return String.format("%d, %d, %d", value, g, delta);
+            return String.format("I{val=%.3f, g=%d, del=%d}", value, g, delta);
         }
     }
 
@@ -286,7 +286,7 @@ class CKMSQuantiles {
 
         @Override
         public String toString() {
-            return String.format("Q{q=%.3f, eps=%.3f})", quantile, error);
+            return String.format("Q{q=%.3f, eps=%.3f}", quantile, error);
         }
     }
 


### PR DESCRIPTION
@brian-brazil 
Minor fix of formatter in [CKMSQuantiles](https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java) *Item* and *Quantile* classes. Now both use the same format.