### PR TITLE
Add metrics for Retrofit 2 calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,22 @@ new QueuedThreadPoolStatisticsCollector()
     .register();
 ```
 
+### Retrofit
+
+There is an interceptor for OkHttp which allows for the measuring the duration taken for
+Retrofit requests. You can do it by registering the interceptor with OkHttp like this:
+
+```java
+OkHttpClient client = new OkHttpClient.Builder()
+    .addInterceptor(new MetricsInterceptor("retrofit_calls", null, null))
+    .build();
+
+  Retrofit retrofit = new Retrofit.Builder()
+    .baseUrl("http://acme.com")
+    .client(client)
+    .build();
+```
+
 #### Servlet Filter
 
 There is a servlet filter available for measuring the duration taken by servlet

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ OkHttpClient client = new OkHttpClient.Builder()
     .addInterceptor(new MetricsInterceptor("retrofit_calls", null, null))
     .build();
 
-  Retrofit retrofit = new Retrofit.Builder()
+Retrofit retrofit = new Retrofit.Builder()
     .baseUrl("http://acme.com")
     .client(client)
     .build();

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>simpleclient_log4j2</module>
         <module>simpleclient_logback</module>
         <module>simpleclient_pushgateway</module>
+        <module>simpleclient_retrofit2</module>
         <module>simpleclient_servlet</module>
         <module>simpleclient_spring_web</module>
         <module>simpleclient_spring_boot</module>

--- a/simpleclient_retrofit2/pom.xml
+++ b/simpleclient_retrofit2/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.6.1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.prometheus</groupId>
+    <artifactId>simpleclient_retrofit2</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Prometheus Java Simpleclient Retrofit 2</name>
+    <description>
+        Metrics collector for Retrofit 2 client
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>kendombeck</id>
+            <name>Ken Dombeck</name>
+            <email>kdombeck@gmail.com</email>
+        </developer>
+    </developers>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.6.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>retrofit</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-scalars</artifactId>
+            <version>2.5.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>3.12.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/simpleclient_retrofit2/src/main/java/io/prometheus/client/retrofit2/MetricsInterceptor.java
+++ b/simpleclient_retrofit2/src/main/java/io/prometheus/client/retrofit2/MetricsInterceptor.java
@@ -1,0 +1,99 @@
+package io.prometheus.client.retrofit2;
+
+import io.prometheus.client.Histogram;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import retrofit2.Invocation;
+import retrofit2.http.*;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+
+/**
+ * Collect metrics from Retrofit when using OkHttp. Metrics will include path and HTTP method.
+ *
+ * <p>Modeled after {@code io.prometheus.client.filter.MetricsFilter}
+ *
+ * <p>
+ * Usage example:
+ * <pre>
+ * OkHttpClient client = new OkHttpClient.Builder()
+ *     .addInterceptor(new MetricsInterceptor("retrofit_calls", null, null))
+ *     .build();
+ *
+ *  Retrofit retrofit = new Retrofit.Builder()
+ *     .baseUrl("http://acme.com")
+ *     .client(client)
+ *     .build();
+ * </pre>
+ *
+ * Requires a minimum of Retrofit 2.5.0 and OkHttp 3.11
+ * <p>
+ */
+public class MetricsInterceptor implements Interceptor {
+    private final Histogram histogram;
+
+    public MetricsInterceptor(String metricName, String help, double[] buckets) {
+        Histogram.Builder builder = Histogram.build().name(metricName).labelNames("path", "method");
+
+        if (help == null) {
+            help = "The time taken fulfilling retrofit requests";
+        }
+        builder.help(help);
+
+        if (buckets != null) {
+            builder.buckets(buckets);
+        }
+
+        this.histogram = builder.register();
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        String method = "";
+        String path = "";
+
+        Invocation invocation = request.tag(Invocation.class);
+        if (invocation != null) {
+            for (Annotation annotation : invocation.method().getAnnotations()) {
+                if (annotation instanceof DELETE) {
+                    method = "DELETE";
+                    path = ((DELETE) annotation).value();
+                } else if (annotation instanceof GET) {
+                    method = "GET";
+                    path = ((GET) annotation).value();
+                } else if (annotation instanceof HEAD) {
+                    method = "HEAD";
+                    path = ((HEAD) annotation).value();
+                } else if (annotation instanceof PATCH) {
+                    method = "PATCH";
+                    path = ((PATCH) annotation).value();
+                } else if (annotation instanceof POST) {
+                    method = "POST";
+                    path = ((POST) annotation).value();
+                } else if (annotation instanceof PUT) {
+                    method = "PUT";
+                    path = ((PUT) annotation).value();
+                } else if (annotation instanceof OPTIONS) {
+                    method = "OPTIONS";
+                    path = ((OPTIONS) annotation).value();
+                } else if (annotation instanceof HTTP) {
+                    method = ((HTTP) annotation).method();
+                    path = ((HTTP) annotation).path();
+                }
+            }
+        }
+
+        Histogram.Timer timer = histogram
+                .labels(path, method)
+                .startTimer();
+
+        try {
+            return chain.proceed(request);
+        } finally {
+            timer.observeDuration();
+        }
+    }
+}

--- a/simpleclient_retrofit2/src/test/java/io/prometheus/client/retrofit2/MetricsInteceptorTest.java
+++ b/simpleclient_retrofit2/src/test/java/io/prometheus/client/retrofit2/MetricsInteceptorTest.java
@@ -1,0 +1,142 @@
+package io.prometheus.client.retrofit2;
+
+import io.prometheus.client.CollectorRegistry;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.scalars.ScalarsConverterFactory;
+import retrofit2.http.*;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class MetricsInteceptorTest {
+    private RetrofitService service;
+
+    @Before
+    public void setup() throws IOException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody("foo"));
+        server.start();
+
+        OkHttpClient client = new OkHttpClient.Builder()
+                .addInterceptor(new MetricsInterceptor("retrofit_calls", null, null))
+                .build();
+
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(server.url("/"))
+                .client(client)
+                .addConverterFactory(ScalarsConverterFactory.create())
+                .build();
+
+        service = retrofit.create(RetrofitService.class);
+    }
+
+    @After
+    public void clear() {
+        CollectorRegistry.defaultRegistry.clear();
+    }
+
+    @Test
+    public void testHttpDeleteMethod() throws IOException {
+        Response<String> response = service.deleteMethod("blah").execute();
+
+        assertEquals("foo", response.body());
+        assertMetric("delete/{param}", "DELETE");
+    }
+
+    @Test
+    public void testHttpGetMethod() throws IOException {
+        Response<String> response = service.getMethod("blah").execute();
+
+        assertEquals("foo", response.body());
+        assertMetric("get/{param}", "GET");
+    }
+
+    @Test
+    public void testHttpHeadMethod() throws IOException {
+        service.headMethod("blah").execute();
+
+        assertMetric("head/{param}", "HEAD");
+    }
+
+    @Test
+    public void testHttpPatchMethod() throws IOException {
+        Response<String> response = service.patchMethod("blah").execute();
+
+        assertEquals("foo", response.body());
+        assertMetric("patch/{param}", "PATCH");
+    }
+
+    @Test
+    public void testHttpPostMethod() throws IOException {
+        Response<String> response = service.postMethod("blah").execute();
+
+        assertEquals("foo", response.body());
+        assertMetric("post/{param}", "POST");
+    }
+
+    @Test
+    public void testHttpPutMethod() throws IOException {
+        Response<String> response = service.putMethod("blah").execute();
+
+        assertEquals("foo", response.body());
+        assertMetric("put/{param}", "PUT");
+    }
+
+    @Test
+    public void testHttpOptionsMethod() throws IOException {
+        Response<String> response = service.optionsMethod("blah").execute();
+
+        assertEquals("foo", response.body());
+        assertMetric("options/{param}", "OPTIONS");
+    }
+
+    @Test
+    public void testHttpMethod() throws IOException {
+        Response<String> response = service.httpMethod("blah").execute();
+
+        assertEquals("foo", response.body());
+        assertMetric("http/{param}", "GET");
+    }
+
+    private void assertMetric(String path, String method) {
+        Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("retrofit_calls_count", new String[]{"path", "method"}, new String[]{path, method});
+        assertNotNull("Metric not found", sampleValue);
+        assertEquals(1, sampleValue, 0.0001);
+    }
+
+    private interface RetrofitService {
+        @DELETE("delete/{param}")
+        Call<String> deleteMethod(@Path("param") String param);
+
+        @GET("get/{param}")
+        Call<String> getMethod(@Path("param") String param);
+
+        @HEAD("head/{param}")
+        Call<Void> headMethod(@Path("param") String param);
+
+        @PATCH("patch/{param}")
+        Call<String> patchMethod(@Path("param") String param);
+
+        @POST("post/{param}")
+        Call<String> postMethod(@Path("param") String param);
+
+        @PUT("put/{param}")
+        Call<String> putMethod(@Path("param") String param);
+
+        @OPTIONS("options/{param}")
+        Call<String> optionsMethod(@Path("param") String param);
+
+        @HTTP(method = "GET", path = "http/{param}")
+        Call<String> httpMethod(@Path("param") String param);
+    }
+}


### PR DESCRIPTION
This creates an interceptor for [Retrofit](https://square.github.io/retrofit/). It was modeled after the [MetricsFilter](https://github.com/prometheus/client_java/blob/master/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java)

It was made possible after the implementation of these issues
https://github.com/square/okhttp/issues/270
https://github.com/square/okhttp/issues/4087
https://github.com/square/retrofit/issues/2732