### PR TITLE
Don't throw NPE if `.help()` wasn't called

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -162,7 +162,7 @@ public abstract class SimpleCollector<Child> extends Collector {
     }
     fullname = name;
     checkMetricName(fullname);
-    if (b.help.isEmpty()) throw new IllegalStateException("Help hasn't been set.");
+    if (b.help != null && b.help.isEmpty()) throw new IllegalStateException("Help hasn't been set.");
     help = b.help;
     labelNames = Arrays.asList(b.labelNames);
 


### PR DESCRIPTION
See issue #457