### PR TITLE
Yet another labels-to-Child lookup optimization

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>1.21</version>
+            <version>1.22</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.21</version>
+            <version>1.22</version>
         </dependency>
 
         <dependency>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>1.3.2</version>
+            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.3.2</version>
+            <version>1.21</version>
         </dependency>
 
         <dependency>

--- a/benchmark/src/main/java/io/prometheus/benchmark/LabelsToChildLookupBenchmark.java
+++ b/benchmark/src/main/java/io/prometheus/benchmark/LabelsToChildLookupBenchmark.java
@@ -1,0 +1,70 @@
+package io.prometheus.benchmark;
+
+import io.prometheus.client.Counter;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+public class LabelsToChildLookupBenchmark {
+
+    private static final String LABEL1 = "label1", LABEL2 = "label2", LABEL3 = "label3";
+    private static final String LABEL4 = "label4", LABEL5 = "label5";
+ 
+    private Counter noLabelsCollector, oneLabelCollector, twoLabelsCollector, threeLabelsCollector;
+    private Counter fourLabelsCollector, fiveLabelsCollector;
+
+    @Setup
+    public void setup() {
+        Counter.Builder builder = new Counter.Builder().name("testCollector").help("testHelp");
+        noLabelsCollector = builder.create();
+        oneLabelCollector = builder.labelNames("name1").create();
+        twoLabelsCollector = builder.labelNames("name1", "name2").create();
+        threeLabelsCollector = builder.labelNames("name1", "name2", "name3").create();
+        fourLabelsCollector = builder.labelNames("name1", "name2", "name3", "name4").create();
+        fiveLabelsCollector = builder.labelNames("name1", "name2", "name3", "name4", "name5").create();
+    }
+
+    @Benchmark
+    public void baseline(LabelsToChildLookupBenchmark state) {
+        noLabelsCollector.inc();
+    }
+
+    @Benchmark
+    public void oneLabel(LabelsToChildLookupBenchmark state) {
+        oneLabelCollector.labels(LABEL1).inc();
+    }
+
+    @Benchmark
+    public void twoLabels(LabelsToChildLookupBenchmark state) {
+        twoLabelsCollector.labels(LABEL1, LABEL2).inc();
+    }
+
+    @Benchmark
+    public void threeLabels(LabelsToChildLookupBenchmark state) {
+        threeLabelsCollector.labels(LABEL1, LABEL2, LABEL3).inc();
+    }
+
+    @Benchmark
+    public void fourLabels(LabelsToChildLookupBenchmark state) {
+        fourLabelsCollector.labels(LABEL1, LABEL2, LABEL3, LABEL4).inc();
+    }
+
+    @Benchmark
+    public void fiveLabels(LabelsToChildLookupBenchmark state) {
+        fiveLabelsCollector.labels(LABEL1, LABEL2, LABEL3, LABEL4, LABEL5).inc();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder()
+                .include(LabelsToChildLookupBenchmark.class.getSimpleName())
+                .build()).run();
+    }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -112,14 +112,14 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
      * Increment the counter by 1.
      */
     public void inc() {
-      inc(1);
+      inc(1.0);
     }
     /**
      * Increment the counter by the given amount.
      * @throws IllegalArgumentException If amt is negative.
      */
     public void inc(double amt) {
-      if (amt < 0) {
+      if (amt < 0.0) {
         throw new IllegalArgumentException("Amount to increment must be non-negative.");
       }
       value.add(amt);
@@ -137,7 +137,7 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
    * Increment the counter with no labels by 1.
    */
   public void inc() {
-    inc(1);
+    inc(1.0);
   }
   /**
    * Increment the counter with no labels by the given amount.
@@ -156,9 +156,12 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
 
   @Override
   public List<MetricFamilySamples> collect() {
-    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());
-    for(Map.Entry<List<String>, Child> c: children.entrySet()) {
-      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+    final Map.Entry<List<String>, Child>[] children = children();
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.length);
+    for(Map.Entry<List<String>, Child> c : children) {
+      if (c != null) {
+        samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+      }
     }
     return familySamplesList(Type.COUNTER, samples);
   }

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -143,7 +143,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
      * Increment the gauge by 1.
      */
     public void inc() {
-      inc(1);
+      inc(1.0);
     }
     /**
      * Increment the gauge by the given amount.
@@ -155,7 +155,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
      * Decrement the gauge by 1.
      */
     public void dec() {
-      dec(1);
+      dec(1.0);
     }
     /**
      * Decrement the gauge by the given amount.
@@ -238,7 +238,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
    * Increment the gauge with no labels by 1.
    */
   public void inc() {
-    inc(1);
+    inc(1.0);
   }
   /**
    * Increment the gauge with no labels by the given amount.
@@ -250,7 +250,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
    * Decrement the gauge with no labels by 1.
    */
   public void dec() {
-    dec(1);
+    dec(1.0);
   }
   /**
    * Decrement the gauge with no labels by the given amount.
@@ -312,9 +312,12 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
 
   @Override
   public List<MetricFamilySamples> collect() {
-    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());
-    for(Map.Entry<List<String>, Child> c: children.entrySet()) {
-      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+    final Map.Entry<List<String>, Child>[] children = children();
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.length);
+    for(Map.Entry<List<String>, Child> c : children) {
+      if (c != null) {
+        samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+      }
     }
     return familySamplesList(Type.GAUGE, samples);
   }

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -255,7 +255,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
       for (int i = 0; i < upperBounds.length; ++i) {
         // The last bucket is +Inf, so we always increment.
         if (amt <= upperBounds[i]) {
-          cumulativeCounts[i].add(1);
+          cumulativeCounts[i].add(1.0);
           break;
         }
       }
@@ -323,8 +323,12 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
 
   @Override
   public List<MetricFamilySamples> collect() {
-    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
-    for(Map.Entry<List<String>, Child> c: children.entrySet()) {
+    final Map.Entry<List<String>, Child>[] children = children();
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.length);
+    for(Map.Entry<List<String>,Child> c : children) {
+      if (c == null) {
+        continue;
+      }
       Child.Value v = c.getValue().get();
       List<String> labelNamesWithLe = new ArrayList<String>(labelNames);
       labelNamesWithLe.add("le");

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -275,7 +275,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
      * Observe the given amount.
      */
     public void observe(double amt) {
-      count.add(1);
+      count.add(1.0);
       sum.add(amt);
       if (quantileValues != null) {
         quantileValues.insert(amt);
@@ -346,8 +346,12 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
 
   @Override
   public List<MetricFamilySamples> collect() {
-    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
-    for(Map.Entry<List<String>, Child> c: children.entrySet()) {
+    final Map.Entry<List<String>, Child>[] children = children();
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.length);
+    for(Map.Entry<List<String>,Child> c : children) {
+      if (c == null) {
+        continue;
+      }
       Child.Value v = c.getValue().get();
       List<String> labelNamesWithQuantile = new ArrayList<String>(labelNames);
       labelNamesWithQuantile.add("quantile");


### PR DESCRIPTION
This is an optimization of the `SimpleCollector.labels(...)` lookups with a similar goal to #445 and #459.

It has some things in common with those PRs (including overridden fixed-args versions) but aims to provide best of all worlds - zero garbage and higher throughput for all label counts, without any reliance on thread reuse.

To achieve this, `ConcurrentHashMap` is abandoned in favour of a custom copy-on-write linear-probe hashtable.

Benchmark results:

Before:
```
Benchmark     Mode  Cnt         Score         Error  Units
baseline     thrpt   20  84731357.558 ±  535745.023  ops/s
oneLabel     thrpt   20  36415789.294 ±  441116.974  ops/s
twoLabels    thrpt   20  33301282.259 ±  313669.132  ops/s
threeLabels  thrpt   20  24560630.904 ± 2247040.286  ops/s
fourLabels   thrpt   20  24424456.896 ±  288989.596  ops/s
fiveLabels   thrpt   20  18356036.944 ±  949244.712  ops/s
```

After:
```
Benchmark     Mode  Cnt         Score         Error  Units
baseline     thrpt   20  84866162.495 ±  823753.503  ops/s
oneLabel     thrpt   20  84554174.645 ±  804735.949  ops/s
twoLabels    thrpt   20  85004332.529 ±  689559.035  ops/s
threeLabels  thrpt   20  73395533.440 ± 3022384.940  ops/s
fourLabels   thrpt   20  68736143.734 ± 1872048.923  ops/s
fiveLabels   thrpt   20  53482207.003 ±  488751.990  ops/s
```

This benchmark, like the prior ones, only tests with a single sequence of labels for each count. It would be good to extend it to cover cases where the map is populated with a larger number of children.