### PR TITLE
Do not throw IllegalArgumentException on null label or less number labels than predefined

### DIFF
--- a/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
@@ -29,19 +29,22 @@ public class SimpleCollectorTest {
     return registry.getSampleValue("nolabels");
   }
 
-  @Test(expected=IllegalArgumentException.class)
-  public void testTooFewLabelsThrows() {
-    metric.labels();
+  @Test
+  public void testTooFewLabelsSilent() {
+    metric.labels().inc();
+    assertEquals(getValue(SimpleCollector.DEFAULT_LABEL_VALUE), 1.0, .001);
   }
 
-  @Test(expected=IllegalArgumentException.class)
-  public void testNullLabelThrows() {
-    metric.labels(new String[]{null});
+  @Test
+  public void testNullLabelSilent() {
+    metric.labels(new String[]{null}).inc();
+    assertEquals(getValue(SimpleCollector.DEFAULT_LABEL_VALUE), 1.0, .001);
   }
 
-  @Test(expected=IllegalArgumentException.class)
-  public void testTooManyLabelsThrows() {
-    metric.labels("a", "b");
+  @Test
+  public void testTooManyLabelsSilent() {
+    metric.labels("a", "b").inc();
+    assertEquals(getValue("a"), 1.0, .001);
   }
   
   @Test


### PR DESCRIPTION
Hi everyone, 

Recently, I got some error on null label exception in production, and it caused some impact on our customers. 

```
Caused by: java.lang.IllegalArgumentException: Label cannot be null.
	at io.prometheus.client.SimpleCollector.labels(SimpleCollector.java:68)
```

First I admit the error should never happened in production, it should be well tested before rolling out to production. Then I begun to think that how to prevent this error from begining.

So I wrote this pull request to silent any instrumentation exception on null label or unequals labels. 
I have docuemented well for this change, for best undertanding, I picked piece of changed code here. 

I think this change may not be agreed from some developers, but it's fine, let's disucss here.  I was open for that. 

Thank you. 

```
  /**
   * Return the Child with the given labels, creating it if needed.
   * <p>
   * It should be passed the same number of labels are were passed to {@link #labelNames}.
   * If null or less than number of labels defined, a default label {@link #DEFAULT_LABEL_VALUE} value was applied
   * to the label value.
   */
  public Child labels(String... labelValues) {
    /*
      For best practise, we should void any fatal exception on instrumentation
      The basic principal was that the instrumentation code in application should never impact the business logic
      We can accept monitoring data error but no application fault on instrumentation error
      The silent strategy may case some metric data error, but it's a trade off between service error and monitoring data error
    */
    List<String> key = new ArrayList<String>(labelNames.size());
    for (int i = 0; i< labelNames.size(); i++) {
        if (labelValues != null
                && labelValues.length > i
                && labelValues[i] != null) {
          key.add(labelValues[i]);
        } else {
          key.add(DEFAULT_LABEL_VALUE);
        }
    }
``` 


