### PR TITLE
Use atomics instead of synchronized for TimeWindowQuantiles

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/TimeWindowQuantiles.java
+++ b/simpleclient/src/main/java/io/prometheus/client/TimeWindowQuantiles.java
@@ -50,19 +50,18 @@ class TimeWindowQuantiles {
 
   private void rotate() {
     // On concurrent `rotate` and `rotate`:
-    //  - `currentTimeMillis` is cached to reduce thread contention.
-    //  - `lastRotateTimestampMillis` is used to ensure the correct number of rotations.
-    long currentTimeMillis = System.currentTimeMillis();
-    long lastRotateTimestampMillis = this.lastRotateTimestampMillis.get();
-    while (currentTimeMillis - lastRotateTimestampMillis > durationBetweenRotatesMillis) {
-      if (this.lastRotateTimestampMillis.compareAndSet(
-          lastRotateTimestampMillis, lastRotateTimestampMillis + durationBetweenRotatesMillis)) {
+    //  - `currentTime` is cached to reduce thread contention.
+    //  - `lastRotate` is used to ensure the correct number of rotations.
+    long currentTime = System.currentTimeMillis();
+    long lastRotate = lastRotateTimestampMillis.get();
+    while (currentTime - lastRotate > durationBetweenRotatesMillis) {
+      if (lastRotateTimestampMillis.compareAndSet(lastRotate, lastRotate + durationBetweenRotatesMillis)) {
         CKMSQuantiles bucket = new CKMSQuantiles(quantiles);
         // rotate buckets (not atomic)
         buckets.add(bucket);
         buckets.remove();
       }
-      lastRotateTimestampMillis = this.lastRotateTimestampMillis.get();
+      lastRotate = lastRotateTimestampMillis.get();
     }
   }
 


### PR DESCRIPTION
Idea:
> We could implement `TimeWindowQuantiles#rotate` with atomics (`compare-and-swap`, `retry-loop`), as `buckets` are only rotated occasionally (every 2 minutes by default).

Pros:
* avoids suspending threads for highly concurrent workloads (`get`, `insert`)
* reduces constant overhead (`get`, `insert`)

Cons:
* introduces busy waiting and retry-loop (`rotate`)
* ~reduces locality (`CKMSQuantiles[]` vs `ConcurrentLinkedQueue<CKMSQuantiles>`)~

Neutral:
* changes thread contention characteristics (`synchronized` vs `CAS & retry`)

Please check the code comments for considerations about correctness.

Relates to #480 , #481