### PR TITLE
Added support to set an externally available timestamp to the metrics

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -108,6 +108,8 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
    */
   public static class Child {
     private final DoubleAdder value = new DoubleAdder();
+    
+    private Long timestampMs;
     /**
      * Increment the counter by 1.
      */
@@ -130,6 +132,19 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
     public double get() {
       return value.sum();
     }
+    /**
+     * Get the optionally defined timestamp for the counter.
+     */
+	public Long getTimestampMs() {
+		return timestampMs;
+	}
+    /**
+     * Optionally sets an external timestamp for the counter. 
+     */
+	public Child setTimestampMs(Long timestampMs) {
+		this.timestampMs = timestampMs;
+		return this;
+	}
   }
 
   // Convenience methods.
@@ -158,7 +173,7 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
-      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get(), c.getValue().getTimestampMs()));
     }
     return familySamplesList(Type.COUNTER, samples);
   }

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -135,6 +135,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
    */
   public static class Child {
     private final DoubleAdder value = new DoubleAdder();
+    private Long timestampMs = null;
 
     static TimeProvider timeProvider = new TimeProvider();
 
@@ -238,6 +239,19 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
         return value.sum();
       }
     }
+    /**
+     * Get the optionally defined timestamp for the gauge.
+     */
+	public Long getTimestampMs() {
+		return timestampMs;
+	}
+    /**
+     * Optionally sets an external timestamp for the gauge. 
+     */
+	public Child setTimestampMs(Long timestampMs) {
+		this.timestampMs = timestampMs;
+		return this;
+	}
   }
 
   // Convenience methods.
@@ -321,7 +335,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
-      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get(), c.getValue().getTimestampMs()));
     }
     return familySamplesList(Type.GAUGE, samples);
   }

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -246,6 +246,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
     private final double[] upperBounds;
     private final DoubleAdder[] cumulativeCounts;
     private final DoubleAdder sum = new DoubleAdder();
+    private Long timestampMs;
 
 
     /**
@@ -283,6 +284,19 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
       }
       return new Value(sum.sum(), buckets);
     }
+    /**
+     * Get the optionally defined timestamp for the histogram.
+     */
+	public Long getTimestampMs() {
+		return timestampMs;
+	}
+    /**
+     * Optionally sets an external timestamp for the histogram. 
+     */
+	public Child setTimestampMs(Long timestampMs) {
+		this.timestampMs = timestampMs;
+		return this;
+	}
   }
 
   // Convenience methods.
@@ -331,10 +345,10 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
       for (int i = 0; i < v.buckets.length; ++i) {
         List<String> labelValuesWithLe = new ArrayList<String>(c.getKey());
         labelValuesWithLe.add(doubleToGoString(buckets[i]));
-        samples.add(new MetricFamilySamples.Sample(fullname + "_bucket", labelNamesWithLe, labelValuesWithLe, v.buckets[i]));
+        samples.add(new MetricFamilySamples.Sample(fullname + "_bucket", labelNamesWithLe, labelValuesWithLe, v.buckets[i], c.getValue().getTimestampMs()));
       }
-      samples.add(new MetricFamilySamples.Sample(fullname + "_count", labelNames, c.getKey(), v.buckets[buckets.length-1]));
-      samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum));
+      samples.add(new MetricFamilySamples.Sample(fullname + "_count", labelNames, c.getKey(), v.buckets[buckets.length-1], c.getValue().getTimestampMs()));
+      samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum, c.getValue().getTimestampMs()));
     }
 
     return familySamplesList(Type.HISTOGRAM, samples);


### PR DESCRIPTION
@brian-brazil 

I see this requirement has been discussed since a while and you wrote some time ago you would be happy to accept a PR to make it possible to take over already available timestamp information.

Some background about my use-case:
I can't instrument the code of an application directly as I don't own it, but the application provides me regular Metric-Information including a timestamp. The metric data is streamed to my Custom-Exporter almost in realtime, but there might be slight delays between the original event and when it is finally received by Prometheus.
That's the reason, why I would prefer to take over the given timestamp information into the exposed Metrics for Prometheus.