### PR TITLE
Don't sanitize away colons in metric names

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -183,8 +183,8 @@ public abstract class Collector {
     }
   }
 
-  private static final Pattern SANITIZE_PREFIX_PATTERN = Pattern.compile("^[^a-zA-Z_]");
-  private static final Pattern SANITIZE_BODY_PATTERN = Pattern.compile("[^a-zA-Z0-9_]");
+  private static final Pattern SANITIZE_PREFIX_PATTERN = Pattern.compile("^[^a-zA-Z_:]");
+  private static final Pattern SANITIZE_BODY_PATTERN = Pattern.compile("[^a-zA-Z0-9_:]");
 
   /**
    * Sanitize metric name

--- a/simpleclient/src/test/java/io/prometheus/client/CollectorTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CollectorTest.java
@@ -9,5 +9,6 @@ public class CollectorTest {
   public void sanitizeMetricName() throws Exception {
       assertEquals("_hoge", Collector.sanitizeMetricName("0hoge"));
       assertEquals("foo_bar0", Collector.sanitizeMetricName("foo.bar0"));
+      assertEquals(":baz::", Collector.sanitizeMetricName(":baz::"));
   }
 }


### PR DESCRIPTION
The [docs](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels) specify that colons (`:`) are allowed in metric names, but `Collector.sanitizeMetricName` removes them.
This PR makes it keep the colons.

cc @brian-brazil 