### PR TITLE
Add a class cast check to avoid ClassCastException

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryAllocationExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryAllocationExports.java
@@ -25,8 +25,10 @@ public class MemoryAllocationExports extends Collector {
 
   public MemoryAllocationExports() {
     AllocationCountingNotificationListener listener = new AllocationCountingNotificationListener(allocatedCounter);
-    for (GarbageCollectorMXBean garbageCollectorMXBean : ManagementFactory.getGarbageCollectorMXBeans()) {
-      ((NotificationEmitter) garbageCollectorMXBean).addNotificationListener(listener, null, null);
+    for (GarbageCollectorMXBean garbageCollectorMXBean : getGarbageCollectorMXBeans()) {
+      if (garbageCollectorMXBean instanceof NotificationEmitter) {
+        ((NotificationEmitter) garbageCollectorMXBean).addNotificationListener(listener, null, null);
+      }
     }
   }
 
@@ -96,5 +98,9 @@ public class MemoryAllocationExports extends Collector {
       Long last = map.put(key, value);
       return last == null ? 0 : last;
     }
+  }
+
+  protected List<GarbageCollectorMXBean> getGarbageCollectorMXBeans() {
+    return ManagementFactory.getGarbageCollectorMXBeans();
   }
 }


### PR DESCRIPTION
FIX #504
I added the method **getGarbageCollectorMXBeans** to be able to test my modifications (otherwise I don't know how to fake **ManagementFactory.getGarbageCollectorMXBeans()**).