### PR TITLE
Remove the mention of JMX from the included connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ class YourClass {
 
 ## Included Collectors
 
-The Java client includes collectors for garbage collection, memory pools, JMX, classloading, and thread counts.
+The Java client includes collectors for garbage collection, memory pools, classloading, and thread counts.
 These can be added individually or just use the `DefaultExports` to conveniently register them.
 
 ```java


### PR DESCRIPTION
This is a very minor PR but I think it is still important. Currently the README suggests that simply calling `DefaultExports.initialize()` will enable JMX metrics collection.

This is not the case though and has led to some issues opened here in that past (it did not just confuse me is what I am saying I guess). JMX metrics are not collected when calling the above. Only garbage collection, memory pools, class loading and thread counts are collected.