### PR TITLE
Make it easier to customize serialization of registry data.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -28,7 +28,7 @@ public class CollectorRegistry {
   public static final CollectorRegistry defaultRegistry = new CollectorRegistry(true);
 
   private final Object namesCollectorsLock = new Object();
-  private final Map<Collector, List<String>> collectorsToNames = new HashMap<Collector, List<String>>();
+  protected final Map<Collector, List<String>> collectorsToNames = new HashMap<Collector, List<String>>();
   private final Map<String, Collector> namesToCollectors = new HashMap<String, Collector>();
 
   private final boolean autoDescribe;
@@ -86,7 +86,7 @@ public class CollectorRegistry {
   /**
    * A snapshot of the current collectors.
    */
-  private Set<Collector> collectors() {
+  protected Set<Collector> collectors() {
     synchronized (namesCollectorsLock) {
       return new HashSet<Collector>(collectorsToNames.keySet());
     }

--- a/simpleclient_servlet/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
@@ -20,7 +20,7 @@ import java.util.Set;
  */
 public class MetricsServlet extends HttpServlet {
 
-  private CollectorRegistry registry;
+  protected CollectorRegistry registry;
 
   /**
    * Construct a MetricsServlet for the default registry.


### PR DESCRIPTION
This would allow applications to subclass `MetricsServlet` and access registry data to serve them in non http endpoints such as gRPC or different formats that Prometheus/gRPC based collectors use.

I wasn't too sure how to bump up the version. Do I need to bump up the version in all pom.xml files?