### PR TITLE
Fix #536 - Allow log4j2 appenders to have filters

### DIFF
--- a/simpleclient_log4j2/pom.xml
+++ b/simpleclient_log4j2/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
 

--- a/simpleclient_log4j2/src/main/java/io/prometheus/client/log4j2/InstrumentedAppender.java
+++ b/simpleclient_log4j2/src/main/java/io/prometheus/client/log4j2/InstrumentedAppender.java
@@ -2,11 +2,17 @@ package io.prometheus.client.log4j2;
 
 import io.prometheus.client.Counter;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import java.io.Serializable;
 
 import static org.apache.logging.log4j.Level.*;
 
@@ -67,8 +73,9 @@ public final class InstrumentedAppender extends AbstractAppender {
     /**
      * Create a new instrumented appender using the default registry.
      */
-    protected InstrumentedAppender(String name) {
-        super(name, null, null);
+    protected InstrumentedAppender(String name, Filter filter, Layout<? extends Serializable> layout,
+                                   boolean ignoreExceptions) {
+        super(name, filter, layout, ignoreExceptions);
     }
 
     @Override
@@ -84,12 +91,20 @@ public final class InstrumentedAppender extends AbstractAppender {
 
     @PluginFactory
     public static InstrumentedAppender createAppender(
-            @PluginAttribute("name") String name) {
+            @PluginAttribute("name") String name,
+            @PluginAttribute("ignoreExceptions") boolean ignoreExceptions,
+            @PluginElement("Layout") Layout<? extends Serializable> layout,
+            @PluginElement("Filters") Filter filter) {
         if (name == null) {
             LOGGER.error("No name provided for InstrumentedAppender");
             return null;
         }
-        return new InstrumentedAppender(name);
+
+        if (layout == null) {
+            layout = PatternLayout.createDefaultLayout();
+        }
+
+        return new InstrumentedAppender(name, filter, layout, ignoreExceptions);
     }
 
 }

--- a/simpleclient_log4j2/src/test/java/io/prometheus/client/log4j2/FilterAppenderTest.java
+++ b/simpleclient_log4j2/src/test/java/io/prometheus/client/log4j2/FilterAppenderTest.java
@@ -1,0 +1,48 @@
+package io.prometheus.client.log4j2;
+
+import io.prometheus.client.CollectorRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static io.prometheus.client.log4j2.InstrumentedAppender.COUNTER_NAME;
+import static org.junit.Assert.assertEquals;
+
+public class FilterAppenderTest
+{
+    private static Logger logger;
+
+    @BeforeClass
+    public static void setUp() {
+        System.setProperty("log4j.configurationFile", "log4j2-filtered-appender-test.xml");
+        logger = LogManager.getLogger();
+    }
+
+    @Test
+    public void testFilteredEvents() {
+
+        // WHEN: some log messages are logged at various levels
+        logger.trace("out");
+        logger.debug("out");
+        logger.info("in");
+        logger.warn("in");
+        logger.error("in");
+        logger.fatal("in");
+
+        // THEN: there are no messages below INFO because they are configured to be filtered out
+        assertEquals(0, getLogLevelCount("trace"));
+        assertEquals(0, getLogLevelCount("debug"));
+
+        // AND: there are messages at INFO and above
+        assertEquals(1, getLogLevelCount("info"));
+        assertEquals(1, getLogLevelCount("warn"));
+        assertEquals(1, getLogLevelCount("error"));
+        assertEquals(1, getLogLevelCount("fatal"));
+    }
+
+    private int getLogLevelCount(String level) {
+        return CollectorRegistry.defaultRegistry.getSampleValue(COUNTER_NAME,
+                new String[]{"level"}, new String[]{level}).intValue();
+    }
+}

--- a/simpleclient_log4j2/src/test/java/io/prometheus/client/log4j2/InstrumentedAppenderTest.java
+++ b/simpleclient_log4j2/src/test/java/io/prometheus/client/log4j2/InstrumentedAppenderTest.java
@@ -19,7 +19,8 @@ public class InstrumentedAppenderTest {
 
     @Before
     public void setUp() throws Exception {
-        appender = InstrumentedAppender.createAppender("Prometheus-Appender");
+        appender = InstrumentedAppender.createAppender("Prometheus-Appender",
+                true, null, null);
         event = mock(LogEvent.class);
     }
 

--- a/simpleclient_log4j2/src/test/java/io/prometheus/client/log4j2/LogCounter.java
+++ b/simpleclient_log4j2/src/test/java/io/prometheus/client/log4j2/LogCounter.java
@@ -1,0 +1,61 @@
+package io.prometheus.client.log4j2;
+
+import io.prometheus.client.CollectorRegistry;
+import org.apache.logging.log4j.Level;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static io.prometheus.client.log4j2.InstrumentedAppender.COUNTER_NAME;
+import static org.junit.Assert.assertEquals;
+
+final class LogCounter
+{
+    Map<String, Integer> snapshot = getSnapshot();
+
+    void assertLogLevelCountIncreasedByOne(Level level) {
+        int[] result = getExpectedAndActual(level);
+
+        assertEquals(result[0], result[1]);
+    }
+
+    void assertLogLevelCountNotIncreased(Level level) {
+        int[] result = getExpectedAndActual(level, 0);
+
+        assertEquals(result[0], result[1]);
+    }
+
+    private int[] getExpectedAndActual(Level level) {
+        return getExpectedAndActual(level, 1);
+    }
+
+    private int[] getExpectedAndActual(Level level, int increase) {
+        int[] result = new int[2];
+        String l = level.name().toLowerCase(Locale.US);
+
+        result[0] = snapshot.get(l) + increase;
+        result[1] = getLogLevelCount(l);
+
+        return result;
+    }
+
+    private static int getLogLevelCount(String level) {
+        return CollectorRegistry.defaultRegistry.getSampleValue(COUNTER_NAME,
+                new String[]{"level"}, new String[]{level}).intValue();
+    }
+
+    private static Map<String, Integer> getSnapshot() {
+        Map<String, Integer> map = new HashMap<String, Integer>(6);
+
+        map.put("trace", getLogLevelCount("trace"));
+        map.put("debug", getLogLevelCount("debug"));
+        map.put("info", getLogLevelCount("info"));
+        map.put("warn", getLogLevelCount("warn"));
+        map.put("error", getLogLevelCount("error"));
+        map.put("fatal", getLogLevelCount("fatal"));
+
+        return Collections.unmodifiableMap(map);
+    }
+}

--- a/simpleclient_log4j2/src/test/resources/log4j2-filtered-appender-test.xml
+++ b/simpleclient_log4j2/src/test/resources/log4j2-filtered-appender-test.xml
@@ -1,0 +1,12 @@
+<Configuration monitorInterval="30" packages="io.prometheus.client.log4j2">
+    <Appenders>
+        <Prometheus name="metrics">
+            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+        </Prometheus>
+    </Appenders>
+    <Loggers>
+        <Root level="TRACE">
+            <AppenderRef ref="metrics"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This PR fixes the log4j2 appender to support filtering.