### PR TITLE
Wrap PrintWriter with BufferedWriter

### DIFF
--- a/simpleclient_servlet/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
@@ -7,6 +7,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
@@ -43,7 +44,7 @@ public class MetricsServlet extends HttpServlet {
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentType(TextFormat.CONTENT_TYPE_004);
 
-    Writer writer = resp.getWriter();
+    Writer writer = new BufferedWriter(resp.getWriter());
     try {
       TextFormat.write004(writer, registry.filteredMetricFamilySamples(parse(req)));
       writer.flush();

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
@@ -23,13 +23,13 @@ public class ExampleBenchmark {
         context.setContextPath("/");
         context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
 
-        Server server = new Server(1234);
+        Server server = new Server(0);
         server.setHandler(context);
         server.start();
         Thread.sleep(1000);
 
         byte[] bytes = new byte[8192];
-        URL url = new URL("http://localhost:1234/metrics");
+        URL url = new URL("http", "localhost", server.getConnectors()[0].getLocalPort(), "/metrics");
 
         long start = System.nanoTime();
         for (int i = 0; i < 100; i++) {

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
@@ -1,0 +1,52 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.Gauge;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.UUID;
+
+public class ExampleBenchmark {
+
+    public static void main(String[] args) throws Exception {
+
+        Gauge gauge = Gauge.build().name("labels").help("foo").labelNames("bar").register();
+        for (int i = 0; i < 10000; i++) {
+            gauge.labels(UUID.randomUUID().toString()).set(Math.random());
+        }
+
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+
+        Server server = new Server(1234);
+        server.setHandler(context);
+        server.start();
+        Thread.sleep(1000);
+
+        byte[] bytes = new byte[8192];
+        URL url = new URL("http://localhost:1234/metrics");
+
+        long start = System.nanoTime();
+        for (int i = 0; i < 100; i++) {
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            InputStream in = connection.getInputStream();
+            try {
+                while (in.read(bytes) != -1) in.available();
+            } finally {
+                in.close();
+            }
+            connection.disconnect();
+        }
+        System.out.println(String.format("%,3d ns", System.nanoTime() - start));
+
+        server.stop();
+        server.join();
+
+    }
+
+}

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
@@ -12,9 +12,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.Matchers.anyChar;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -63,8 +62,7 @@ public class MetricsServletTest {
     HttpServletResponse resp = mock(HttpServletResponse.class);
     PrintWriter writer = mock(PrintWriter.class);
     when(resp.getWriter()).thenReturn(writer);
-    doThrow(new RuntimeException()).when(writer).write(anyChar());
-    doThrow(new RuntimeException()).when(writer).write(anyInt());
+    doThrow(new RuntimeException()).when(writer).write(any(char[].class), anyInt(), anyInt());
     CollectorRegistry registry = new CollectorRegistry();
     Gauge a = Gauge.build("a", "a help").register(registry);
 


### PR DESCRIPTION
Hi @brian-brazil,

Generating servlet output for a large number of metrics seems to be inefficient, since the underlying `PrintWriter` implementation is generating too many `org.eclipse.jetty.io.ByteArrayBuffer` instances.

Performance improved by simply wrapping the `PrintWriter` with `BufferedWriter`. Microbenchmark (`ExampleBenchmark`, 10k gauges, 100 iterations, laptop machine) shows that it takes around 2.5 sec with the wrapper, and around 5.5 sec without the wrapper.