### PR TITLE
make fields in SimpleCollector.Builder visible for other packages.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -179,14 +179,14 @@ public abstract class SimpleCollector<Child> extends Collector {
    * Builders let you configure and then create collectors.
    */
   public abstract static class Builder<B extends Builder<B, C>, C extends SimpleCollector> {
-    String namespace = "";
-    String subsystem = "";
-    String name = "";
-    String fullname = "";
-    String help = "";
-    String[] labelNames = new String[]{};
+    protected String namespace = "";
+    protected String subsystem = "";
+    protected String name = "";
+    protected String fullname = "";
+    protected String help = "";
+    protected String[] labelNames = new String[]{};
     // Some metrics require additional setup before the initialization can be done.
-    boolean dontInitializeNoLabelsChild;
+    protected boolean dontInitializeNoLabelsChild;
 
     /**
      * Set the name of the metric. Required.


### PR DESCRIPTION
Fields in SimpleCollector.Builder should be 'protected' so that custom Builder class in other packages can do some validation or set dontInitializeNoLabelsChild flag. Otherwise, we have to do the dirty work in constructor of our CustomCollector.