### PR TITLE
Avoid NullPointerException when double unregister

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -67,6 +67,10 @@ public class CollectorRegistry {
   public void unregister(Collector m) {
     synchronized (namesCollectorsLock) {
       List<String> names = collectorsToNames.remove(m);
+      if (names == null) {
+        return;
+      }
+      
       for (String name : names) {
         namesToCollectors.remove(name);
       }


### PR DESCRIPTION
If unregister one collector twice, it will throw NullPointException when do for `(String name : names)`.