### PR TITLE
Mockito Matchers has been deprecated and replaced with ArgumentMatchers

### DIFF
--- a/simpleclient_caffeine/src/test/java/io/prometheus/client/cache/caffeine/CacheMetricsCollectorTest.java
+++ b/simpleclient_caffeine/src/test/java/io/prometheus/client/cache/caffeine/CacheMetricsCollectorTest.java
@@ -1,6 +1,5 @@
 package io.prometheus.client.cache.caffeine;
 
-import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -8,11 +7,10 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.Test;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/simpleclient_guava/src/test/java/io/prometheus/client/guava/cache/CacheMetricsCollectorTest.java
+++ b/simpleclient_guava/src/test/java/io/prometheus/client/guava/cache/CacheMetricsCollectorTest.java
@@ -7,11 +7,8 @@ import com.google.common.cache.LoadingCache;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.Test;
 
-
-import java.util.Arrays;
-
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
@@ -14,7 +14,7 @@ import java.io.StringWriter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
@@ -16,8 +16,8 @@ import java.util.Enumeration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
https://github.com/mockito/mockito/blob/release/3.x/src/main/java/org/mockito/Matchers.java

Also removed a couple of unused imports in the test classes I was already modifying.