### PR TITLE
Count HTTP statuses returned along with the HTTP response times

### DIFF
--- a/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
@@ -1,5 +1,6 @@
 package io.prometheus.client.filter;
 
+import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
 
 import javax.servlet.Filter;
@@ -9,13 +10,14 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
  * The MetricsFilter class exists to provide a high-level filter that enables tunable collection of metrics for Servlet
  * performance.
  *
- * <p>The Histogram name itself is required, and configured with a {@code metric-name} init parameter.
+ * <p>The metric name itself is required, and configured with a {@code metric-name} init parameter.
  *
  * <p>The help parameter, configured with the {@code help} init parameter, is not required but strongly recommended.
  *
@@ -26,6 +28,8 @@ import java.io.IOException;
  * <p>The Histogram buckets can be configured with a {@code buckets} init parameter whose value is a comma-separated list
  * of valid {@code double} values.
  *
+ * <p>HTTP statuses will be aggregated via Counter. The name for this counter will be derived from the {@code metric-name} init parameter.
+ *
  * <pre>{@code
  * <filter>
  *   <filter-name>prometheusFilter</filter-name>
@@ -34,7 +38,7 @@ import java.io.IOException;
  *      <param-name>metric-name</param-name>
  *      <param-value>webapp_metrics_filter</param-value>
  *   </init-param>
- *    <init-param>
+ *   <init-param>
  *      <param-name>help</param-name>
  *      <param-value>The time taken fulfilling servlet requests</param-value>
  *   </init-param>
@@ -56,8 +60,10 @@ public class MetricsFilter implements Filter {
     static final String HELP_PARAM = "help";
     static final String METRIC_NAME_PARAM = "metric-name";
     static final String BUCKET_CONFIG_PARAM = "buckets";
+    static final String UNKNOWN_HTTP_STATUS_CODE = "";
 
     private Histogram histogram = null;
+    private Counter statusCounter = null;
 
     // Package-level for testing purposes.
     int pathComponents = 1;
@@ -149,6 +155,10 @@ public class MetricsFilter implements Filter {
                 .help(help)
                 .name(metricName)
                 .register();
+
+        statusCounter = Counter.build(metricName + "_status", "HTTP status codes of " + help)
+                .labelNames("path", "method", "status")
+                .register();
     }
 
     @Override
@@ -162,15 +172,26 @@ public class MetricsFilter implements Filter {
 
         String path = request.getRequestURI();
 
+        String components = getComponents(path);
+        String method = request.getMethod();
         Histogram.Timer timer = histogram
-            .labels(getComponents(path), request.getMethod())
+            .labels(components, method)
             .startTimer();
 
         try {
             filterChain.doFilter(servletRequest, servletResponse);
         } finally {
             timer.observeDuration();
+            statusCounter.labels(components, method, getStatusCode(servletResponse)).inc();
         }
+    }
+
+    private String getStatusCode(ServletResponse servletResponse) {
+        if (!(servletResponse instanceof HttpServletResponse)) {
+            return UNKNOWN_HTTP_STATUS_CODE;
+        }
+
+        return Integer.toString(((HttpServletResponse) servletResponse).getStatus());
     }
 
     @Override

--- a/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
@@ -156,7 +156,7 @@ public class MetricsFilter implements Filter {
                 .name(metricName)
                 .register();
 
-        statusCounter = Counter.build(metricName + "_status", "HTTP status codes of " + help)
+        statusCounter = Counter.build(metricName + "_total", "HTTP status codes of " + help)
                 .labelNames("path", "method", "status")
                 .register();
     }

--- a/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
@@ -156,7 +156,7 @@ public class MetricsFilter implements Filter {
                 .name(metricName)
                 .register();
 
-        statusCounter = Counter.build(metricName + "_total", "HTTP status codes of " + help)
+        statusCounter = Counter.build(metricName + "_status_total", "HTTP status codes of " + help)
                 .labelNames("path", "method", "status")
                 .register();
     }

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
@@ -202,7 +202,7 @@ public class MetricsFilterTest {
 
         constructed.doFilter(req, res, c);
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_status", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, "200"});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_total", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, "200"});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -227,7 +227,7 @@ public class MetricsFilterTest {
 
         constructed.doFilter(req, res, c);
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_status", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, MetricsFilter.UNKNOWN_HTTP_STATUS_CODE});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_total", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, MetricsFilter.UNKNOWN_HTTP_STATUS_CODE});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
@@ -10,6 +10,7 @@ import org.mockito.stubbing.Answer;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Enumeration;
@@ -180,4 +181,54 @@ public class MetricsFilterTest {
         assertEquals(buckets.split(",").length+1, count);
     }
 
+    @Test
+    public void testStatusCode() throws Exception {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang");
+        when(req.getMethod()).thenReturn(HttpMethods.GET);
+
+        HttpServletResponse res = mock(HttpServletResponse.class);
+        when(res.getStatus()).thenReturn(200);
+
+        FilterChain c = mock(FilterChain.class);
+
+        MetricsFilter constructed = new MetricsFilter(
+                "foobar_filter",
+                "Help for my filter",
+                2,
+                null
+        );
+        constructed.init(mock(FilterConfig.class));
+
+        constructed.doFilter(req, res, c);
+
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_status", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, "200"});
+        assertNotNull(sampleValue);
+        assertEquals(1, sampleValue, 0.0001);
+    }
+
+    @Test
+    public void testStatusCodeWithNonHttpServletResponse() throws Exception {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang");
+        when(req.getMethod()).thenReturn(HttpMethods.GET);
+
+        ServletResponse res = mock(ServletResponse.class);
+
+        FilterChain c = mock(FilterChain.class);
+
+        MetricsFilter constructed = new MetricsFilter(
+                "foobar_filter",
+                "Help for my filter",
+                2,
+                null
+        );
+        constructed.init(mock(FilterConfig.class));
+
+        constructed.doFilter(req, res, c);
+
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_status", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, MetricsFilter.UNKNOWN_HTTP_STATUS_CODE});
+        assertNotNull(sampleValue);
+        assertEquals(1, sampleValue, 0.0001);
+    }
 }

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
@@ -202,7 +202,7 @@ public class MetricsFilterTest {
 
         constructed.doFilter(req, res, c);
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_total", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, "200"});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_status_total", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, "200"});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -227,7 +227,7 @@ public class MetricsFilterTest {
 
         constructed.doFilter(req, res, c);
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_total", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, MetricsFilter.UNKNOWN_HTTP_STATUS_CODE});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_status_total", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, MetricsFilter.UNKNOWN_HTTP_STATUS_CODE});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }


### PR DESCRIPTION
This will add metrics for HTTP status codes like the following along side the existing Histogram.
```
# HELP http_request_status HTTP status codes of The time taken fulfilling servlet requests
# TYPE http_request_status counter
http_request_status{path="/my/api/1",method="GET",status="200",} 4.0
http_request_status{path="/my/api/2",method="GET",status="500",} 2.0
```

@brian-brazil I currently have the code deriving the **name** and **help** for the Counter from the existing parameters that are used in the constructor or init. Would you prefer I add 2 new parameters for the name and help for the counter or leave it like it is?