### PR TITLE
Specify the charset of HTTPServer response

### DIFF
--- a/simpleclient_graphite_bridge/src/main/java/io/prometheus/client/bridge/Graphite.java
+++ b/simpleclient_graphite_bridge/src/main/java/io/prometheus/client/bridge/Graphite.java
@@ -5,8 +5,10 @@ import io.prometheus.client.CollectorRegistry;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -50,7 +52,7 @@ public class Graphite {
    */
   public void push(CollectorRegistry registry) throws IOException {
     Socket s = new Socket(host, port);
-    BufferedWriter writer = new BufferedWriter(new PrintWriter(s.getOutputStream()));
+    BufferedWriter writer = new BufferedWriter(new PrintWriter(new OutputStreamWriter(s.getOutputStream(), Charset.forName("UTF-8"))));
     Matcher m = INVALID_GRAPHITE_CHARS.matcher("");
     long now = System.currentTimeMillis() / 1000;
     for (Collector.MetricFamilySamples metricFamilySamples: Collections.list(registry.metricFamilySamples())) {

--- a/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
+++ b/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
@@ -9,6 +9,7 @@ import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
@@ -61,7 +62,7 @@ public class HTTPServer {
             String contextPath = t.getHttpContext().getPath();
             ByteArrayOutputStream response = this.response.get();
             response.reset();
-            OutputStreamWriter osw = new OutputStreamWriter(response);
+            OutputStreamWriter osw = new OutputStreamWriter(response, Charset.forName("UTF-8"));
             if ("/-/healthy".equals(contextPath)) {
                 osw.write(HEALTHY_RESPONSE);
             } else {


### PR DESCRIPTION
In some Operational Systems (Like IBM Z/OS and IBM Z/Unix) the JRE runs with a charset different of UTF-8, those default charsets produce wrong behavior and truncated responses.

To avoid this kind of situations I put the specifc charset in the output writer.

This create a consistent response between different platforms.