### PR TITLE
Removed exception handling (test smell)

### DIFF
--- a/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestHTTPServer.java
+++ b/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestHTTPServer.java
@@ -65,15 +65,11 @@ public class TestHTTPServer {
     return s.hasNext() ? s.next() : "";
   }
 
-  @Test
-  public void testUnbound() throws IOException {
+  @Test(expected = IllegalArgumentException.class)
+  public void testRefuseUsingUnbound() throws IOException {
     CollectorRegistry registry = new CollectorRegistry();
-    try {
-      HTTPServer s = new HTTPServer(HttpServer.create(), registry, true);
-      s.stop();
-      fail("Should refuse to use an unbound HttpServer");
-    } catch (IllegalArgumentException expected) {
-    }
+    HTTPServer s = new HTTPServer(HttpServer.create(), registry, true);
+    s.stop();
   }
 
   @Test


### PR DESCRIPTION
This is a test refactoring.

**Problem:**
The Exception Handling test smell occurs when explicitly a passing or failing of a test method is dependent on the production method throwing an exception.

**Solution:**
The use of JUnit's exception handling to automatically pass/fail the test instead of writing custom exception handling code or throwing an exception is encouraged.

**Result:**
_Before:_
```
  @Test
  public void testUnbound() throws IOException {
    CollectorRegistry registry = new CollectorRegistry();
    try {
      HTTPServer s = new HTTPServer(HttpServer.create(), registry, true);
      s.stop();
      fail("Should refuse to use an unbound HttpServer");
    } catch (IllegalArgumentException expected) {
    }
  }
```
_After:_
```
  @Test(expected = IllegalArgumentException.class)
  public void testRefuseUsingUnbound() throws IOException {
    CollectorRegistry registry = new CollectorRegistry();
    HTTPServer s = new HTTPServer(HttpServer.create(), registry, true);
    s.stop();
  }
```