### PR TITLE
Unregistering a collector that is present at the registry should not throw an NPE

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -67,6 +67,7 @@ public class CollectorRegistry {
   public void unregister(Collector m) {
     synchronized (namesCollectorsLock) {
       List<String> names = collectorsToNames.remove(m);
+      if (names == null) return;
       for (String name : names) {
         namesToCollectors.remove(name);
       }

--- a/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
@@ -139,6 +139,13 @@ public class CollectorRegistryTest {
     registry.register(h);
   }
 
+  @Test
+  public void testUnregisterWhenItIsNotRegisteredIsANoOp() {
+    Histogram h = Histogram.build().name("s").help("h").create();
+    // This doesn't throw.
+    registry.unregister(h);
+  }
+
   class MyCollector extends Collector {
     public List<MetricFamilySamples> collect() {
       List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();


### PR DESCRIPTION
@brian-brazil got this in a system that was using `clear` to _shutdown_  the `registry`, but another place was `unregister`ing the metric, and the getting an NPE.