### PR TITLE
Custom labels for caffeine cache

### DIFF
--- a/simpleclient_caffeine/pom.xml
+++ b/simpleclient_caffeine/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.6</version>
         </dependency>
         
 


### PR DESCRIPTION
Adds an option to specify custom labels for metrics. This may be (and is!) useful in microservice environment where service caches are being used in different domains. Using custom labels, users will be able to distinguish different cache metrics without [pre/post]fixing `cache` (`cacheName`) parameter.

Also upgrades caffeine cache to v2.8.6

This feature keeps backwards binary & source compatibility.