### PR TITLE
Support custom metrics contexts

### DIFF
--- a/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestDaemonFlags.java
+++ b/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestDaemonFlags.java
@@ -26,6 +26,16 @@ public class TestDaemonFlags {
         assertThat(usesDaemonExecutor(new HTTPServer(0, false))).isFalse();
     }
 
+    @Test
+    public void testDaemonWithMetricsContext() throws IOException, ExecutionException, InterruptedException {
+        assertThat(usesDaemonExecutor(new HTTPServer(0, true, "/metricz"))).isTrue();
+    }
+
+    @Test
+    public void testNonDaemonWithMetricsContext() throws IOException, ExecutionException, InterruptedException {
+        assertThat(usesDaemonExecutor(new HTTPServer(0, "/metricz"))).isFalse();
+    }
+
     private boolean usesDaemonExecutor(HTTPServer httpServer) throws IOException, InterruptedException, ExecutionException {
         try {
             FutureTask<Boolean> task = new FutureTask<Boolean>(new Callable<Boolean>() {

--- a/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestHTTPServer.java
+++ b/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestHTTPServer.java
@@ -131,4 +131,24 @@ public class TestHTTPServer {
     String response = requestWithCompression("/-/healthy", "");
     assertThat(response).contains("Exporter is Healthy");
   }
+
+  @Test
+  public void testMetricsContext() throws IOException {
+    final String metricsContext = "/metricz";
+    s = new HTTPServer(new InetSocketAddress(0), registry, true, metricsContext);
+    String response = request(metricsContext, "");
+    assertThat(response).contains("a 0.0");
+    assertThat(response).contains("b 0.0");
+    assertThat(response).contains("c 0.0");
+  }
+
+  @Test
+  public void testMetricsContextGzipCompression() throws IOException {
+    final String metricsContext = "/metricz";
+    s = new HTTPServer(new InetSocketAddress(0), registry, metricsContext);
+    String response = requestWithCompression(metricsContext, "");
+    assertThat(response).contains("a 0.0");
+    assertThat(response).contains("b 0.0");
+    assertThat(response).contains("c 0.0");
+  }
 }

--- a/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestHTTPServer.java
+++ b/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestHTTPServer.java
@@ -15,18 +15,18 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 public class TestHTTPServer {
 
   HTTPServer s;
+  private final CollectorRegistry registry = new CollectorRegistry();
 
   @Before
   public void init() throws IOException {
-    CollectorRegistry registry = new CollectorRegistry();
     Gauge.build("a", "a help").register(registry);
     Gauge.build("b", "a help").register(registry);
     Gauge.build("c", "a help").register(registry);
+
     s = new HTTPServer(new InetSocketAddress(0), registry);
   }
 


### PR DESCRIPTION
Hi there,

We recently starting using thie lib which is a life saver but has one small limitation which I'm addressing here.
That's the ability to support a user-provided metrics context.
At the moment the handler is instantiated in the constructor and there's no accessor, so retrieving metrics is only available when hitting "/metrics" which I guess should be fine for most people.

Unfortunately there are use cases where a prometheus configuration is outside of one's control and Prometheus is then configured to look for and scrape for metrics under a custom path, i.e. "/metricz" is a common one. Hence, the changes here add support for using something other than just "/metrics".

@brian-brazil  hope this makes sense and is in accordance with the contributing guidelines.