### PR TITLE
Convert client_java to OpenMetrics

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -20,7 +20,7 @@ public abstract class Collector {
    */
   public abstract List<MetricFamilySamples> collect();
   public enum Type {
-    UNTYPED, // XXX This is Unknown in OpenMetrics.
+    UNKNOWN, // This is untyped in Prometheus text format.
     COUNTER,
     GAUGE,
     STATE_SET,

--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -19,11 +19,14 @@ public abstract class Collector {
    */
   public abstract List<MetricFamilySamples> collect();
   public enum Type {
+    UNTYPED, // XXX This is Unknown in OpenMetrics.
     COUNTER,
     GAUGE,
-    SUMMARY,
+    STATE_SET,
+    INFO,
     HISTOGRAM,
-    UNTYPED,
+    GAUGE_HISTOGRAM,
+    SUMMARY,
   }
 
   /**
@@ -31,15 +34,27 @@ public abstract class Collector {
    */
   static public class MetricFamilySamples {
     public final String name;
+    public final String unit;
     public final Type type;
     public final String help;
     public final List<Sample> samples;
 
-    public MetricFamilySamples(String name, Type type, String help, List<Sample> samples) {
+    public MetricFamilySamples(String name, String unit, Type type, String help, List<Sample> samples) {
+      if (!unit.isEmpty() && !name.endsWith("_" + unit)) {
+        throw new IllegalArgumentException("Metric's unit is not the suffix of the metric name: " + name);
+      }
+      if ((type == Type.INFO || type == Type.STATE_SET) && !unit.isEmpty()) {
+        throw new IllegalArgumentException("Metric is of a type that cannot have a unit: " + name);
+      }
       this.name = name;
+      this.unit = unit;
       this.type = type;
       this.help = help;
       this.samples = samples;
+    }
+
+    public MetricFamilySamples(String name, Type type, String help, List<Sample> samples) {
+      this(name, "", type, help, samples);
     }
 
     @Override
@@ -49,14 +64,18 @@ public abstract class Collector {
       }
       MetricFamilySamples other = (MetricFamilySamples) obj;
       
-      return other.name.equals(name) && other.type.equals(type)
-        && other.help.equals(help) && other.samples.equals(samples) ;
+      return other.name.equals(name)
+        && other.unit.equals(unit)
+        && other.type.equals(type)
+        && other.help.equals(help)
+        && other.samples.equals(samples);
     }
 
     @Override
     public int hashCode() {
       int hash = 1;
       hash = 37 * hash + name.hashCode();
+      hash = 37 * hash + unit.hashCode();
       hash = 37 * hash + type.hashCode();
       hash = 37 * hash + help.hashCode();
       hash = 37 * hash + samples.hashCode();
@@ -65,7 +84,7 @@ public abstract class Collector {
 
     @Override
     public String toString() {
-      return "Name: " + name + " Type: " + type + " Help: " + help + 
+      return "Name: " + name + " Unit:" + unit + " Type: " + type + " Help: " + help +
         " Samples: " + samples;
     }
 

--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -105,6 +105,11 @@ public class CollectorRegistry {
     List<String> names = new ArrayList<String>();
     for (Collector.MetricFamilySamples family : mfs) {
       switch (family.type) {
+        case COUNTER:
+          names.add(family.name + "_total");
+          names.add(family.name + "_created");
+          names.add(family.name);
+          break;
         case SUMMARY:
           names.add(family.name + "_count");
           names.add(family.name + "_sum");

--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -113,11 +113,19 @@ public class CollectorRegistry {
         case SUMMARY:
           names.add(family.name + "_count");
           names.add(family.name + "_sum");
+          names.add(family.name + "_created");
           names.add(family.name);
           break;
         case HISTOGRAM:
           names.add(family.name + "_count");
           names.add(family.name + "_sum");
+          names.add(family.name + "_bucket");
+          names.add(family.name + "_created");
+          names.add(family.name);
+          break;
+        case GAUGE_HISTOGRAM:
+          names.add(family.name + "_gcount");
+          names.add(family.name + "_gsum");
           names.add(family.name + "_bucket");
           names.add(family.name);
           break;

--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -129,6 +129,10 @@ public class CollectorRegistry {
           names.add(family.name + "_bucket");
           names.add(family.name);
           break;
+        case INFO:
+          names.add(family.name + "_info");
+          names.add(family.name);
+          break;
         default:
           names.add(family.name);
       }

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -74,6 +74,10 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
   public static class Builder extends SimpleCollector.Builder<Builder, Counter> {
     @Override
     public Counter create() {
+      // Gracefully handle pre-OpenMetrics counters.
+      if (name.endsWith("_total")) {
+        name = name.substring(0, name.length() - 6);
+      }
       return new Counter(this);
     }
   }
@@ -158,7 +162,7 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
-      samples.add(new MetricFamilySamples.Sample(fullname, labelNames, c.getKey(), c.getValue().get()));
+      samples.add(new MetricFamilySamples.Sample(fullname + "_total", labelNames, c.getKey(), c.getValue().get()));
     }
     return familySamplesList(Type.COUNTER, samples);
   }

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -64,6 +64,12 @@ import java.util.Map;
  * </pre>
  * These can be aggregated and processed together much more easily in the Prometheus
  * server than individual metrics for each labelset.
+ *
+ * If there is a suffix of <code>_total</code> on the metric name, it will be
+ * removed. When exposing the time series for counter value, a
+ * <code>_total</code> suffix will be added. This is for compatibility between
+ * OpenMetrics and the Prometheus text format, as OpenMetrics requires the
+ * <code>_total</code> suffix.
  */
 public class Counter extends SimpleCollector<Counter.Child> implements Collector.Describable {
 

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -112,6 +112,7 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
    */
   public static class Child {
     private final DoubleAdder value = new DoubleAdder();
+    private final long created = System.currentTimeMillis();
     /**
      * Increment the counter by 1.
      */
@@ -133,6 +134,12 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
      */
     public double get() {
       return value.sum();
+    }
+    /**
+     * Get the created time of the counter in milliseconds.
+     */
+    public long created() {
+      return created;
     }
   }
 
@@ -163,6 +170,7 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {
       samples.add(new MetricFamilySamples.Sample(fullname + "_total", labelNames, c.getKey(), c.getValue().get()));
+      samples.add(new MetricFamilySamples.Sample(fullname + "_created", labelNames, c.getKey(), c.getValue().created() / 1000.0));
     }
     return familySamplesList(Type.COUNTER, samples);
   }

--- a/simpleclient/src/main/java/io/prometheus/client/CounterMetricFamily.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CounterMetricFamily.java
@@ -37,7 +37,7 @@ public class CounterMetricFamily extends Collector.MetricFamilySamples {
     labelNames = Collections.emptyList();
     samples.add(
         new Sample(
-          name,
+          this.name + "_total",
           labelNames, 
           Collections.<String>emptyList(),
           value));
@@ -52,7 +52,7 @@ public class CounterMetricFamily extends Collector.MetricFamilySamples {
     if (labelValues.size() != labelNames.size()) {
       throw new IllegalArgumentException("Incorrect number of labels.");
     }
-    samples.add(new Sample(name, labelNames, labelValues, value));
+    samples.add(new Sample(name + "_total", labelNames, labelValues, value));
     return this;
   }
 }

--- a/simpleclient/src/main/java/io/prometheus/client/Enumeration.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Enumeration.java
@@ -1,0 +1,223 @@
+package io.prometheus.client;
+
+import io.prometheus.client.CKMSQuantiles.Quantile;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.LinkedHashSet;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Enumeration metric, to track which of a set of states something is in.
+ *
+ * The first provided state will be the default.
+ *
+ * <p>
+ * Example enumeration:
+ * <pre>
+ * {@code
+ *   class YourClass {
+ *     static final Enumeration taskState = Enumeration.build()
+ *         .name("task_state").help("State of the task.")
+ *         .states("stopped", "starting", "running")
+ *         .register();
+ *
+ *     void stop() {
+ *          // Your code here.
+ *          taskState.state("stopped")
+ *     }
+ *   }
+ * }
+ * </pre>
+ *
+ * You can also use a Java Enum:
+ * <pre>
+ *   class YourClass {
+ *     public enum yourEnum {
+ *       STOPPED,
+ *       STARTING,
+ *       RUNNING,
+ *     }
+ *     static final Enumeration taskState = Enumeration.build()
+ *         .name("task_state").help("State of the task.")
+ *         .states(yourEnum.class)
+ *         .register();
+ *
+ *     void stop() {
+ *          // Your code here.
+ *          taskState.state(yourEnum.STOPPED)
+ *     }
+ *   }
+ * }
+ * </pre>
+ */
+public class Enumeration extends SimpleCollector<Enumeration.Child> implements Counter.Describable {
+  
+  private final Set<String> states;
+
+  Enumeration(Builder b) {
+    super(b);
+    for (String label : labelNames) {
+      if (label.equals(fullname)) {
+        throw new IllegalStateException("Enumeration cannot have a label named the same as its metric name.");
+      }
+    }
+    states = b.states;
+    initializeNoLabelsChild();
+  }
+
+  public static class Builder extends SimpleCollector.Builder<Builder, Enumeration> {
+
+    private Set<String> states;
+
+    public Builder states(String... s) {
+      if (s.length == 0) {
+        throw new IllegalArgumentException("There must be at least one state");
+      }
+      // LinkedHashSet so we can know which was the first state.
+      states = new LinkedHashSet();
+      states.addAll(Arrays.asList(s));
+      return this;
+    }
+
+    /**
+     * Take states from the names of the values in an Enum class.
+     */
+    public Builder states(Class e) {
+      Object[] vals = e.getEnumConstants();
+      String[] s = new String[vals.length];
+      for(int i = 0; i < vals.length; i++) {
+        s[i] = ((Enum)vals[i]).name();
+      }
+      return states(s);
+    }
+
+    @Override
+    public Enumeration create() {
+      if (states == null) {
+        throw new IllegalStateException("Enumeration states must be specified.");
+      }
+      if (!unit.isEmpty()) {
+        throw new IllegalStateException("Enumeration metrics cannot have a unit.");
+      }
+      dontInitializeNoLabelsChild = true;
+      return new Enumeration(this);
+    }
+  }
+
+  /**
+   *  Return a Builder to allow configuration of a new Enumeration. Ensures required fields are provided.
+   *
+   *  @param name The name of the metric
+   *  @param help The help string of the metric
+   */
+  public static Builder build(String name, String help) {
+    return new Builder().name(name).help(help);
+  }
+
+  /**
+   *  Return a Builder to allow configuration of a new Enumeration.
+   */
+  public static Builder build() {
+    return new Builder();
+  }
+
+  @Override
+  protected Child newChild() {
+    return new Child(states);
+  }
+
+
+  /**
+   * The value of a single Enumeration.
+   * <p>
+   * <em>Warning:</em> References to a Child become invalid after using
+   * {@link SimpleCollector#remove} or {@link SimpleCollector#clear}.
+   */
+  public static class Child {
+
+    private String value;
+    private final Set<String> states;
+
+    private Child(Set<String> states) {
+      this.states = states;
+      value = states.iterator().next(); // Initialize with the first state.
+    }
+
+    /**
+     * Set the state.
+     */
+    public void state(String s) {
+      if (!states.contains(s)) {
+        throw new IllegalArgumentException("Unknown state " + s);
+      }
+      value = s;
+    }
+
+    /**
+     * Set the state.
+     */
+    public void state(Enum e) {
+      state(e.name());
+    }
+ 
+    /**
+     * Get the state.
+     */
+    public String get() {
+      return value;
+    }
+  }
+
+  // Convenience methods.
+  /**
+   * Set the state on the enum with no labels.
+   */
+  public void state(String s) {
+    noLabelsChild.state(s);
+  }
+
+  /**
+   * Set the state on the enum with no labels.
+   */
+  public void state(Enum e) {
+    noLabelsChild.state(e);
+  }
+
+  /**
+   * Get the value of the Enumeration.
+   */
+  public String get() {
+    return noLabelsChild.get();
+  }
+
+  @Override
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+    for(Map.Entry<List<String>, Child> c: children.entrySet()) {
+      String v = c.getValue().get();
+      List<String> labelNamesWithState = new ArrayList<String>(labelNames);
+      labelNamesWithState.add(fullname);
+      for(String s : states) {
+        List<String> labelValuesWithState = new ArrayList<String>(c.getKey());
+        labelValuesWithState.add(s);
+        samples.add(new MetricFamilySamples.Sample(fullname, labelNamesWithState, labelValuesWithState, s.equals(v) ? 1.0 : 0.0));
+      }
+    }
+
+    return familySamplesList(Type.STATE_SET, samples);
+  }
+
+  @Override
+  public List<MetricFamilySamples> describe() {
+    return Collections.singletonList(
+            new MetricFamilySamples(fullname, Type.STATE_SET, help, Collections.<MetricFamilySamples.Sample>emptyList()));
+  }
+
+}

--- a/simpleclient/src/main/java/io/prometheus/client/Enumeration.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Enumeration.java
@@ -58,7 +58,7 @@ import java.util.concurrent.TimeUnit;
  * </pre>
  */
 public class Enumeration extends SimpleCollector<Enumeration.Child> implements Counter.Describable {
-  
+
   private final Set<String> states;
 
   Enumeration(Builder b) {
@@ -166,7 +166,7 @@ public class Enumeration extends SimpleCollector<Enumeration.Child> implements C
     public void state(Enum e) {
       state(e.name());
     }
- 
+
     /**
      * Get the state.
      */

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -231,10 +231,12 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
     public static class Value {
       public final double sum;
       public final double[] buckets;
+      public final long created;
 
-      public Value(double sum, double[] buckets) {
+      public Value(double sum, double[] buckets, long created) {
         this.sum = sum;
         this.buckets = buckets;
+        this.created = created;
       }
     }
 
@@ -248,6 +250,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
     private final double[] upperBounds;
     private final DoubleAdder[] cumulativeCounts;
     private final DoubleAdder sum = new DoubleAdder();
+    private final long created = System.currentTimeMillis();
 
 
     /**
@@ -283,7 +286,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
         acc += cumulativeCounts[i].sum();
         buckets[i] = acc;
       }
-      return new Value(sum.sum(), buckets);
+      return new Value(sum.sum(), buckets, created);
     }
   }
 
@@ -337,6 +340,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
       }
       samples.add(new MetricFamilySamples.Sample(fullname + "_count", labelNames, c.getKey(), v.buckets[buckets.length-1]));
       samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum));
+      samples.add(new MetricFamilySamples.Sample(fullname + "_created", labelNames, c.getKey(), v.created / 1000.0));
     }
 
     return familySamplesList(Type.HISTOGRAM, samples);

--- a/simpleclient/src/main/java/io/prometheus/client/Info.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Info.java
@@ -1,0 +1,177 @@
+package io.prometheus.client;
+
+import io.prometheus.client.CKMSQuantiles.Quantile;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Info metric, key-value pairs.
+ *
+ * Examples of Info include, build information, version information, and potential target metadata,
+ * The first provided state will be the default.
+ *
+ * <p>
+ * Example enumeration:
+ * <pre>
+ * {@code
+ *   class YourClass {
+ *     static final Info buildInfo = Info.build()
+ *         .name("your_build_info").help("Build information.")
+ *         .register();
+ *
+ *     void func() {
+ *          // Your code here.
+ *         buildInfo.info("branch", "HEAD", "version", "1.2.3", "revision", "e0704b");
+ *     }
+ *   }
+ * }
+ * </pre>
+ */
+public class Info extends SimpleCollector<Info.Child> implements Counter.Describable {
+  
+  Info(Builder b) {
+    super(b);
+  }
+
+  public static class Builder extends SimpleCollector.Builder<Builder, Info> {
+    @Override
+    public Info create() {
+      if (!unit.isEmpty()) {
+        throw new IllegalStateException("Info metrics cannot have a unit.");
+      }
+      return new Info(this);
+    }
+  }
+
+  /**
+   *  Return a Builder to allow configuration of a new Info. Ensures required fields are provided.
+   *
+   *  @param name The name of the metric
+   *  @param help The help string of the metric
+   */
+  public static Builder build(String name, String help) {
+    return new Builder().name(name).help(help);
+  }
+
+  /**
+   *  Return a Builder to allow configuration of a new Info.
+   */
+  public static Builder build() {
+    return new Builder();
+  }
+
+  @Override
+  protected Child newChild() {
+    return new Child(labelNames);
+  }
+
+
+  /**
+   * The value of a single Info.
+   * <p>
+   * <em>Warning:</em> References to a Child become invalid after using
+   * {@link SimpleCollector#remove} or {@link SimpleCollector#clear}.
+   */
+  public static class Child {
+
+    private Map<String, String> value = Collections.emptyMap();
+    private List<String> labelNames;
+
+    private Child(List<String> labelNames) {
+      this.labelNames = labelNames;
+    }
+
+    /**
+     * Set the info.
+     */
+    public void info(Map<String, String> v) {
+      for (String key : v.keySet()) {
+        checkMetricLabelName(key);
+      }
+      for (String label : labelNames) {
+        if (v.containsKey(label)) {
+          throw new IllegalArgumentException("Info and its value cannot have the same label name.");
+        }
+      }
+      this.value = v;
+    }
+    /**
+     * Set the info.
+     *
+     * @param v labels as pairs of key values
+     */
+    public void info(String... v) {
+      if (v.length % 2 != 0) {
+        throw new IllegalArgumentException("An even number of arguments must be passed");
+      }
+      Map<String, String> m = new TreeMap<String, String>();
+      for (int i = 0; i < v.length; i+=2) {
+        m.put(v[i], v[i+1]);
+      }
+      info(m);
+    }
+
+    /**
+     * Get the info.
+     */
+    public Map<String, String> get() {
+      return value;
+    }
+  }
+
+  // Convenience methods.
+  /**
+   * Set the info on the info with no labels.
+   */
+  public void info(String... v) {
+    noLabelsChild.info(v);
+  }
+
+  /**
+   * Set the info on the info with no labels.
+   *
+   * @param v labels as pairs of key values
+   */
+  public void info(Map<String, String> v) {
+    noLabelsChild.info(v);
+  }
+
+  /**
+   * Get the the info.
+   */
+  public Map<String, String> get() {
+    return noLabelsChild.get();
+  }
+
+  @Override
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+    for(Map.Entry<List<String>, Child> c: children.entrySet()) {
+      Map<String, String> v = c.getValue().get();
+      List<String> names = new ArrayList<String>(labelNames);
+      List<String> values = new ArrayList<String>(c.getKey());
+      for(Map.Entry<String, String> l: v.entrySet()) {
+        names.add(l.getKey());
+        values.add(l.getValue());
+      }
+      samples.add(new MetricFamilySamples.Sample(fullname + "_info", names, values, 1.0));
+    }
+
+    return familySamplesList(Type.INFO, samples);
+  }
+
+  @Override
+  public List<MetricFamilySamples> describe() {
+    return Collections.singletonList(
+            new MetricFamilySamples(fullname, Type.INFO, help, Collections.<MetricFamilySamples.Sample>emptyList()));
+  }
+
+}

--- a/simpleclient/src/main/java/io/prometheus/client/Info.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Info.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
  * </pre>
  */
 public class Info extends SimpleCollector<Info.Child> implements Counter.Describable {
-  
+
   Info(Builder b) {
     super(b);
   }

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -216,7 +216,7 @@ public abstract class SimpleCollector<Child> extends Collector {
       return (B)this;
     }
     /**
-     * Set the uit of the metric. Required.
+     * Set the unit of the metric. Required.
      */
     public B unit(String unit) {
       this.unit = unit;

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -49,6 +49,7 @@ import java.util.List;
 public abstract class SimpleCollector<Child> extends Collector {
   protected final String fullname;
   protected final String help;
+  protected final String unit;
   protected final List<String> labelNames;
 
   protected final ConcurrentMap<List<String>, Child> children = new ConcurrentHashMap<List<String>, Child>();
@@ -145,7 +146,7 @@ public abstract class SimpleCollector<Child> extends Collector {
   protected abstract Child newChild();
 
   protected List<MetricFamilySamples> familySamplesList(Collector.Type type, List<MetricFamilySamples.Sample> samples) {
-    MetricFamilySamples mfs = new MetricFamilySamples(fullname, type, help, samples);
+    MetricFamilySamples mfs = new MetricFamilySamples(fullname, unit, type, help, samples);
     List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>(1);
     mfsList.add(mfs);
     return mfsList;
@@ -159,6 +160,10 @@ public abstract class SimpleCollector<Child> extends Collector {
     }
     if (!b.namespace.isEmpty()) {
       name = b.namespace + '_' + name;
+    }
+    unit = b.unit;
+    if (!unit.isEmpty() && !name.endsWith("_" + unit)) {
+      name += "_" + unit;
     }
     fullname = name;
     checkMetricName(fullname);
@@ -183,6 +188,7 @@ public abstract class SimpleCollector<Child> extends Collector {
     String subsystem = "";
     String name = "";
     String fullname = "";
+    String unit = "";
     String help = "";
     String[] labelNames = new String[]{};
     // Some metrics require additional setup before the initialization can be done.
@@ -207,6 +213,13 @@ public abstract class SimpleCollector<Child> extends Collector {
      */
     public B namespace(String namespace) {
       this.namespace = namespace;
+      return (B)this;
+    }
+    /**
+     * Set the uit of the metric. Required.
+     */
+    public B unit(String unit) {
+      this.unit = unit;
       return (B)this;
     }
     /**

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -239,11 +239,13 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
       public final double count;
       public final double sum;
       public final SortedMap<Double, Double> quantiles;
+      public final long created;
 
-      private Value(double count, double sum, List<Quantile> quantiles, TimeWindowQuantiles quantileValues) {
+      private Value(double count, double sum, List<Quantile> quantiles, TimeWindowQuantiles quantileValues, long created) {
         this.count = count;
         this.sum = sum;
         this.quantiles = Collections.unmodifiableSortedMap(snapshot(quantiles, quantileValues));
+        this.created = created;
       }
 
       private SortedMap<Double, Double> snapshot(List<Quantile> quantiles, TimeWindowQuantiles quantileValues) {
@@ -263,6 +265,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
     private final DoubleAdder sum = new DoubleAdder();
     private final List<Quantile> quantiles;
     private final TimeWindowQuantiles quantileValues;
+    private final long created = System.currentTimeMillis();
 
     private Child(List<Quantile> quantiles, long maxAgeSeconds, int ageBuckets) {
       this.quantiles = quantiles;
@@ -297,7 +300,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
      * <em>Warning:</em> The definition of {@link Value} is subject to change.
      */
     public Value get() {
-      return new Value(count.sum(), sum.sum(), quantiles, quantileValues);
+      return new Value(count.sum(), sum.sum(), quantiles, quantileValues, created);
     }
   }
 
@@ -360,6 +363,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
       }
       samples.add(new MetricFamilySamples.Sample(fullname + "_count", labelNames, c.getKey(), v.count));
       samples.add(new MetricFamilySamples.Sample(fullname + "_sum", labelNames, c.getKey(), v.sum));
+      samples.add(new MetricFamilySamples.Sample(fullname + "_created", labelNames, c.getKey(), v.created / 1000.0));
     }
 
     return familySamplesList(Type.SUMMARY, samples);

--- a/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CollectorRegistryTest.java
@@ -83,7 +83,7 @@ public class CollectorRegistryTest {
     HashSet<String> metrics = new HashSet<String>();
     HashSet<String> series = new HashSet<String>();
     for (Collector.MetricFamilySamples metricFamilySamples : Collections.list(registry.filteredMetricFamilySamples(
-            new HashSet<String>(Arrays.asList("", "s_sum", "c", "part_filter_a", "part_filter_c"))))) {
+            new HashSet<String>(Arrays.asList("", "s_sum", "c_total", "part_filter_a", "part_filter_c"))))) {
       metrics.add(metricFamilySamples.name);
       for (Collector.MetricFamilySamples.Sample sample : metricFamilySamples.samples) {
         series.add(sample.name);
@@ -93,7 +93,7 @@ public class CollectorRegistryTest {
     assertEquals(1, sr.collectCallCount);
     assertEquals(2, pfr.collectCallCount);
     assertEquals(new HashSet<String>(Arrays.asList("s", "c", "part_filter_a", "part_filter_c")), metrics);
-    assertEquals(new HashSet<String>(Arrays.asList("s_sum", "c", "part_filter_a", "part_filter_c")), series);
+    assertEquals(new HashSet<String>(Arrays.asList("s_sum", "c_total", "part_filter_a", "part_filter_c")), series);
   }
 
   @Test

--- a/simpleclient/src/test/java/io/prometheus/client/CollectorTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CollectorTest.java
@@ -1,5 +1,10 @@
 package io.prometheus.client;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -10,5 +15,31 @@ public class CollectorTest {
       assertEquals("_hoge", Collector.sanitizeMetricName("0hoge"));
       assertEquals("foo_bar0", Collector.sanitizeMetricName("foo.bar0"));
       assertEquals(":baz::", Collector.sanitizeMetricName(":baz::"));
+  }
+
+  @Test
+  public void testTotalHandling() throws Exception {
+    class YourCustomCollector extends Collector {
+      public List<MetricFamilySamples> collect() {
+        List<String> emptyList = new ArrayList<String>();
+        return Arrays.<MetricFamilySamples>asList(
+            new MetricFamilySamples("a_total", Type.COUNTER, "help", Arrays.asList(
+                new MetricFamilySamples.Sample("a_total", emptyList, emptyList, 1.0))),
+            new MetricFamilySamples("b", Type.COUNTER, "help", Arrays.asList(
+                new MetricFamilySamples.Sample("b", emptyList, emptyList, 2.0))),
+            new MetricFamilySamples("c_total", Type.COUNTER, "help", Arrays.asList(
+                new MetricFamilySamples.Sample("c", emptyList, emptyList, 3.0))),
+            new MetricFamilySamples("d", Type.COUNTER, "help", Arrays.asList(
+                new MetricFamilySamples.Sample("d_total", emptyList, emptyList, 4.0)))
+        );
+      }
+    }
+    CollectorRegistry registry = new CollectorRegistry();
+    new YourCustomCollector().register(registry);
+
+    assertEquals(1.0, registry.getSampleValue("a_total").doubleValue(), .001);
+    assertEquals(2.0, registry.getSampleValue("b_total").doubleValue(), .001);
+    assertEquals(3.0, registry.getSampleValue("c_total").doubleValue(), .001);
+    assertEquals(4.0, registry.getSampleValue("d_total").doubleValue(), .001);
   }
 }

--- a/simpleclient/src/test/java/io/prometheus/client/CounterMetricFamilyTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterMetricFamilyTest.java
@@ -35,10 +35,10 @@ public class CounterMetricFamilyTest {
     }
     new YourCustomCollector().register(registry);
 
-    assertEquals(42.0, registry.getSampleValue("my_counter").doubleValue(), .001);
-    assertEquals(null, registry.getSampleValue("my_other_counter"));
-    assertEquals(4.0, registry.getSampleValue("my_other_counter", new String[]{"labelname"}, new String[]{"foo"}).doubleValue(), .001);
-    assertEquals(5.0, registry.getSampleValue("my_other_counter", new String[]{"labelname"}, new String[]{"bar"}).doubleValue(), .001);
+    assertEquals(42.0, registry.getSampleValue("my_counter_total").doubleValue(), .001);
+    assertEquals(null, registry.getSampleValue("my_other_counter_total"));
+    assertEquals(4.0, registry.getSampleValue("my_other_counter_total", new String[]{"labelname"}, new String[]{"foo"}).doubleValue(), .001);
+    assertEquals(5.0, registry.getSampleValue("my_other_counter_total", new String[]{"labelname"}, new String[]{"bar"}).doubleValue(), .001);
   }
 
   @Test
@@ -55,11 +55,37 @@ public class CounterMetricFamilyTest {
     new YourCustomCollector().register(registry);
 
     assertEquals(1.0,
-        registry.getSampleValue("my_metric", new String[]{"name"}, new String[]{"value1"})
+        registry.getSampleValue("my_metric_total", new String[]{"name"}, new String[]{"value1"})
             .doubleValue(), .001);
     assertEquals(2.0,
-        registry.getSampleValue("my_metric", new String[]{"name"}, new String[]{"value2"})
+        registry.getSampleValue("my_metric_total", new String[]{"name"}, new String[]{"value2"})
             .doubleValue(), .001);
+  }
+
+  @Test
+  public void testTotalHandling() {
+    class YourCustomCollector extends Collector {
+      public List<MetricFamilySamples> collect() {
+        return Arrays.<MetricFamilySamples>asList(
+            new CounterMetricFamily("a_total", "help", Arrays.asList("name"))
+                .addMetric(Arrays.asList("value"), 1.0),
+            new CounterMetricFamily("b", "help", Arrays.asList("name"))
+                .addMetric(Arrays.asList("value"), 2.0),
+            new CounterMetricFamily("c_total", "help", 3.0),
+            new CounterMetricFamily("d_total", "help", 4.0)
+        );
+      }
+    }
+    new YourCustomCollector().register(registry);
+
+    assertEquals(1.0,
+        registry.getSampleValue("a_total", new String[]{"name"}, new String[]{"value"})
+            .doubleValue(), .001);
+    assertEquals(2.0,
+        registry.getSampleValue("b_total", new String[]{"name"}, new String[]{"value"})
+            .doubleValue(), .001);
+    assertEquals(3.0, registry.getSampleValue("c_total").doubleValue(), .001);
+    assertEquals(4.0, registry.getSampleValue("d_total").doubleValue(), .001);
   }
 
 }

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -97,6 +97,7 @@ public class CounterTest {
     ArrayList<String> labelValues = new ArrayList<String>();
     labelValues.add("a");
     samples.add(new Collector.MetricFamilySamples.Sample("labels_seconds_total", labelNames, labelValues, 1.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_seconds_created", labelNames, labelValues, labels.labels("a").created() / 1000.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels_seconds", "seconds", Collector.Type.COUNTER, "help", samples);
 
     assertEquals(1, mfs.size());

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -23,11 +23,11 @@ public class CounterTest {
   public void setUp() {
     registry = new CollectorRegistry();
     noLabels = Counter.build().name("nolabels").help("help").register(registry);
-    labels = Counter.build().name("labels").help("help").labelNames("l").register(registry);
+    labels = Counter.build().name("labels").unit("seconds").help("help").labelNames("l").register(registry);
   }
 
   private double getValue() {
-    return registry.getSampleValue("nolabels").doubleValue();
+    return registry.getSampleValue("nolabels_total").doubleValue();
   }
   
   @Test
@@ -59,7 +59,7 @@ public class CounterTest {
   }
   
   private Double getLabelsValue(String labelValue) {
-    return registry.getSampleValue("labels", new String[]{"l"}, new String[]{labelValue});
+    return registry.getSampleValue("labels_seconds_total", new String[]{"l"}, new String[]{labelValue});
   }
 
   @Test
@@ -75,6 +75,18 @@ public class CounterTest {
   }
 
   @Test
+  public void testTotalStrippedFromName() {
+    Counter c = Counter.build().name("foo_total").unit("seconds").help("h").create();
+    assertEquals("foo_seconds", c.fullname);
+
+    // This is not a good unit, but test it anyway.
+    c = Counter.build().name("foo_total").unit("total").help("h").create();
+    assertEquals("foo_total", c.fullname);
+    c = Counter.build().name("foo").unit("total").help("h").create();
+    assertEquals("foo_total", c.fullname);
+  }
+
+  @Test
   public void testCollect() {
     labels.labels("a").inc();
     List<Collector.MetricFamilySamples> mfs = labels.collect();
@@ -84,8 +96,8 @@ public class CounterTest {
     labelNames.add("l");
     ArrayList<String> labelValues = new ArrayList<String>();
     labelValues.add("a");
-    samples.add(new Collector.MetricFamilySamples.Sample("labels", labelNames, labelValues, 1.0));
-    Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.COUNTER, "help", samples);
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_seconds_total", labelNames, labelValues, 1.0));
+    Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels_seconds", "seconds", Collector.Type.COUNTER, "help", samples);
 
     assertEquals(1, mfs.size());
     assertEquals(mfsFixture, mfs.get(0));

--- a/simpleclient/src/test/java/io/prometheus/client/EnumerationTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/EnumerationTest.java
@@ -1,0 +1,114 @@
+package io.prometheus.client;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class EnumerationTest {
+
+  CollectorRegistry registry;
+  Enumeration noLabels, labels;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+    noLabels = Enumeration.build().states("foo", "bar").name("nolabels").help("help").register(registry);
+    labels = Enumeration.build().states("foo", "bar").name("labels").help("help").labelNames("l").register(registry);
+  }
+
+  private Double getNoLabelState(String s) {
+    return registry.getSampleValue("nolabels", new String[]{"nolabels"}, new String[]{s});
+  }
+  private Double getLabeledState(String labelValue, String s) {
+    return registry.getSampleValue("labels", new String[]{"l", "labels"}, new String[]{labelValue, s});
+  }
+
+  @Test
+  public void testState() {
+    noLabels.state("bar");
+    assertEquals(0.0, getNoLabelState("foo"), .001);
+    assertEquals(1.0, getNoLabelState("bar"), .001);
+    noLabels.state("foo");
+    assertEquals(1.0, getNoLabelState("foo"), .001);
+    assertEquals(0.0, getNoLabelState("bar"), .001);
+  }
+
+  @Test
+  public void testDefaultValue() {
+    assertEquals(1.0, getNoLabelState("foo"), .001);
+    assertEquals(0.0, getNoLabelState("bar"), .001);
+  }
+
+  @Test
+  public void testLabels() {
+    assertEquals(null, getLabeledState("a", "foo"));
+    assertEquals(null, getLabeledState("a", "bar"));
+    assertEquals(null, getLabeledState("b", "foo"));
+    assertEquals(null, getLabeledState("b", "bar"));
+    labels.labels("a").state("foo");
+    assertEquals(1.0, getLabeledState("a", "foo"), .001);
+    assertEquals(0.0, getLabeledState("a", "bar"), .001);
+    assertEquals(null, getLabeledState("b", "foo"));
+    assertEquals(null, getLabeledState("b", "bar"));
+    labels.labels("b").state("bar");
+    assertEquals(1.0, getLabeledState("a", "foo"), .001);
+    assertEquals(0.0, getLabeledState("a", "bar"), .001);
+    assertEquals(0.0, getLabeledState("b", "foo"), .001);
+    assertEquals(1.0, getLabeledState("b", "bar"), .001);
+  }
+
+  public enum myEnum {
+    FOO,
+    BAR,
+  }
+
+  @Test
+  public void testJavaEnum() {
+    Enumeration metric = Enumeration.build().states(myEnum.class).name("enum").help("help").register(registry);
+    metric.state(myEnum.BAR);
+    assertEquals(0.0, registry.getSampleValue("enum", new String[]{"enum"}, new String[]{"FOO"}), .001);
+    assertEquals(1.0, registry.getSampleValue("enum", new String[]{"enum"}, new String[]{"BAR"}), .001);
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testDuplicateNameLabelThrows() {
+    Enumeration.build().states("foo", "bar").name("labels").help("help").labelNames("labels").create();
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testNoStatesThrows() {
+    Enumeration.build().name("nolabels").help("help").create();
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testEmptyStatesThrows() {
+    Enumeration.build().states().name("nolabels").help("help").create();
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testUnitThrows() {
+    Enumeration.build().states("foo", "bar").unit("seconds").name("nolabels").help("help").create();
+  }
+
+  @Test
+  public void testCollect() {
+    labels.labels("a").state("bar");
+    List<Collector.MetricFamilySamples> mfs = labels.collect();
+
+    ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
+    samples.add(new Collector.MetricFamilySamples.Sample("labels", asList("l", "labels"), asList("a", "foo"), 0.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels", asList("l", "labels"), asList("a", "bar"), 1.0));
+    Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.STATE_SET, "help", samples);
+
+    assertEquals(1, mfs.size());
+    assertEquals(mfsFixture, mfs.get(0));
+  }
+}

--- a/simpleclient/src/test/java/io/prometheus/client/EnumerationTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/EnumerationTest.java
@@ -65,7 +65,7 @@ public class EnumerationTest {
     assertEquals(1.0, getLabeledState("b", "bar"), .001);
   }
 
-  public enum myEnum {
+  enum myEnum {
     FOO,
     BAR,
   }

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -204,6 +204,8 @@ public class HistogramTest {
     }
     samples.add(new Collector.MetricFamilySamples.Sample("labels_count", labelNames, labelValues, 1.0));
     samples.add(new Collector.MetricFamilySamples.Sample("labels_sum", labelNames, labelValues, 2.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_created", labelNames, labelValues, labels.labels("a").get().created / 1000.0));
+
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.HISTOGRAM, "help", samples);
 
     assertEquals(1, mfs.size());

--- a/simpleclient/src/test/java/io/prometheus/client/InfoTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/InfoTest.java
@@ -1,0 +1,96 @@
+package io.prometheus.client;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class InfoTest {
+
+  CollectorRegistry registry;
+  Info noLabels, labels;
+
+  @Before
+  public void setUp() {
+    registry = new CollectorRegistry();
+    noLabels = Info.build().name("nolabels").help("help").register(registry);
+    labels = Info.build().name("labels").help("help").labelNames("l").register(registry);
+  }
+
+  private Double getInfo(String metric, String... labels) {
+    String[] names = new String[labels.length / 2];
+    String[] values = new String[labels.length / 2];
+    for (int i = 0; i < labels.length; i+=2) {
+      names[i/2] = labels[i];
+      values[i/2] = labels[i+1];
+    }
+    return registry.getSampleValue(metric + "_info", names, values);
+  }
+
+  @Test
+  public void testInfo() {
+    assertEquals(null, getInfo("nolabels", "foo", "bar"));
+    noLabels.info("foo", "bar");
+    assertEquals(1.0, getInfo("nolabels", "foo", "bar"), .001);
+    noLabels.info("foo", "bar", "baz", "meh");
+    assertEquals(null, getInfo("nolabels", "foo", "bar"));
+    assertEquals(1.0, getInfo("nolabels", "baz", "meh", "foo", "bar"), .001);
+  }
+
+  @Test
+  public void testDefaultValue() {
+    assertEquals(1.0, getInfo("nolabels"), .001);
+  }
+
+  @Test
+  public void testLabels() {
+    assertEquals(null, getInfo("labels", "l", "a", "foo", "bar"));
+    assertEquals(null, getInfo("labels", "l", "b", "baz", "meh"));
+    labels.labels("a").info("foo", "bar");
+    assertEquals(1.0, getInfo("labels", "l", "a", "foo", "bar"), .001);
+    assertEquals(null, getInfo("labels", "l", "b", "baz", "meh"));
+    labels.labels("b").info("baz", "meh");
+    assertEquals(1.0, getInfo("labels", "l", "a", "foo", "bar"), .001);
+    assertEquals(1.0, getInfo("labels", "l", "b", "baz", "meh"), .001);
+    
+    assertEquals(null, getInfo("nolabels", "l", "a"));
+    assertEquals(null, getInfo("nolabels", "l", "b"));
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testDuplicateNameLabelThrows() {
+    Info i = Info.build().name("labels").help("help").labelNames("l").create();
+    i.labels("a").info("l", "bar");
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testOddInfoThrows() {
+    Info i = Info.build().name("labels").help("help").create();
+    i.info("odd");
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testUnitThrows() {
+    Info.build().unit("seconds").name("nolabels").help("help").create();
+  }
+
+  @Test
+  public void testCollect() {
+    labels.labels("a").info("foo", "bar", "baz", "meh");
+    List<Collector.MetricFamilySamples> mfs = labels.collect();
+
+    ArrayList<Collector.MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_info", asList("l", "baz", "foo"), asList("a", "meh", "bar"), 1.0));
+    Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.INFO, "help", samples);
+
+    assertEquals(1, mfs.size());
+    assertEquals(mfsFixture, mfs.get(0));
+  }
+}

--- a/simpleclient/src/test/java/io/prometheus/client/InfoTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/InfoTest.java
@@ -59,7 +59,7 @@ public class InfoTest {
     labels.labels("b").info("baz", "meh");
     assertEquals(1.0, getInfo("labels", "l", "a", "foo", "bar"), .001);
     assertEquals(1.0, getInfo("labels", "l", "b", "baz", "meh"), .001);
-    
+
     assertEquals(null, getInfo("nolabels", "l", "a"));
     assertEquals(null, getInfo("nolabels", "l", "b"));
   }

--- a/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SimpleCollectorTest.java
@@ -146,6 +146,15 @@ public class SimpleCollectorTest {
   }
 
   @Test
+  public void testUnitsAdded() {
+    Gauge g = Gauge.build().name("a").unit("seconds").help("h").create();
+    assertEquals("a_seconds", g.fullname);
+
+    Gauge g2 = Gauge.build().name("a_seconds").unit("seconds").help("h").create();
+    assertEquals("a_seconds", g2.fullname);
+  }
+
+  @Test
   public void testSetChild() {
     metric.setChild(new Gauge.Child(){
       public double get() {

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -183,6 +183,7 @@ public class SummaryTest {
     labelValues.add("a");
     samples.add(new Collector.MetricFamilySamples.Sample("labels_count", labelNames, labelValues, 1.0));
     samples.add(new Collector.MetricFamilySamples.Sample("labels_sum", labelNames, labelValues, 2.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_created", labelNames, labelValues, labels.labels("a").get().created / 1000.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels", Collector.Type.SUMMARY, "help", samples);
 
     assertEquals(1, mfs.size());
@@ -200,6 +201,7 @@ public class SummaryTest {
     samples.add(new Collector.MetricFamilySamples.Sample("labels_and_quantiles", asList("l", "quantile"), asList("a", "0.99"), 2.0));
     samples.add(new Collector.MetricFamilySamples.Sample("labels_and_quantiles_count", asList("l"), asList("a"), 1.0));
     samples.add(new Collector.MetricFamilySamples.Sample("labels_and_quantiles_sum", asList("l"), asList("a"), 2.0));
+    samples.add(new Collector.MetricFamilySamples.Sample("labels_and_quantiles_created", asList("l"), asList("a"), labelsAndQuantiles.labels("a").get().created / 1000.0));
     Collector.MetricFamilySamples mfsFixture = new Collector.MetricFamilySamples("labels_and_quantiles", Collector.Type.SUMMARY, "help", samples);
 
     assertEquals(1, mfs.size());

--- a/simpleclient_caffeine/src/test/java/io/prometheus/client/cache/caffeine/CacheMetricsCollectorTest.java
+++ b/simpleclient_caffeine/src/test/java/io/prometheus/client/cache/caffeine/CacheMetricsCollectorTest.java
@@ -70,6 +70,7 @@ public class CacheMetricsCollectorTest {
         }
         cache.get("user3");
 
+
         assertMetric(registry, "caffeine_cache_hit_total", "loadingusers", 1.0);
         assertMetric(registry, "caffeine_cache_miss_total", "loadingusers", 3.0);
 

--- a/simpleclient_caffeine/src/test/java/io/prometheus/client/cache/caffeine/CacheMetricsCollectorTest.java
+++ b/simpleclient_caffeine/src/test/java/io/prometheus/client/cache/caffeine/CacheMetricsCollectorTest.java
@@ -70,7 +70,6 @@ public class CacheMetricsCollectorTest {
         }
         cache.get("user3");
 
-
         assertMetric(registry, "caffeine_cache_hit_total", "loadingusers", 1.0);
         assertMetric(registry, "caffeine_cache_miss_total", "loadingusers", 3.0);
 

--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -20,20 +20,27 @@ public class TextFormat {
      * for the output format specification. */
     while(mfs.hasMoreElements()) {
       Collector.MetricFamilySamples metricFamilySamples = mfs.nextElement();
+      String name = metricFamilySamples.name;
+      if (metricFamilySamples.type == Collector.Type.COUNTER) {
+        name += "_total";
+      }
       writer.write("# HELP ");
-      writer.write(metricFamilySamples.name);
+      writer.write(name);
       writer.write(' ');
       writeEscapedHelp(writer, metricFamilySamples.help);
       writer.write('\n');
 
       writer.write("# TYPE ");
-      writer.write(metricFamilySamples.name);
+      writer.write(name);
       writer.write(' ');
       writer.write(typeString(metricFamilySamples.type));
       writer.write('\n');
 
       for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
         writer.write(sample.name);
+        if (metricFamilySamples.type == Collector.Type.COUNTER && sample.name.equals(metricFamilySamples.name)) {
+          writer.write("_total");
+        }
         if (sample.labelNames.size() > 0) {
           writer.write('{');
           for (int i = 0; i < sample.labelNames.size(); ++i) {

--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -69,6 +69,9 @@ public class TextFormat {
       if (metricFamilySamples.type == Collector.Type.COUNTER) {
         writer.write("_total");
       }
+      if (metricFamilySamples.type == Collector.Type.INFO) {
+        writer.write("_info");
+      }
       writer.write(' ');
       writeEscapedHelp(writer, metricFamilySamples.help);
       writer.write('\n');
@@ -77,6 +80,9 @@ public class TextFormat {
       writer.write(name);
       if (metricFamilySamples.type == Collector.Type.COUNTER) {
         writer.write("_total");
+      }
+      if (metricFamilySamples.type == Collector.Type.INFO) {
+        writer.write("_info");
       }
       writer.write(' ');
       writer.write(typeString(metricFamilySamples.type));

--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -218,6 +218,7 @@ public class TextFormat {
         writer.write('\n');
       }
     }
+    writer.write("# EOF\n");
   }
 
   private static String omTypeString(Collector.Type t) {

--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -16,7 +16,7 @@ public class TextFormat {
    * Content-type for Prometheus text version 0.0.4.
    */
   public final static String CONTENT_TYPE_004 = "text/plain; version=0.0.4; charset=utf-8";
-  
+
   /**
    * Content-type for Openmetrics text version 1.0.0.
    */
@@ -29,7 +29,7 @@ public class TextFormat {
     if (acceptHeader == null) {
       return CONTENT_TYPE_004;
     }
- 
+
     for (String accepts : acceptHeader.split(",")) {
       if ("application/openmetrics-text".equals(accepts.split(";")[0].trim())) {
         return CONTENT_TYPE_OPENMETRICS_100;
@@ -193,13 +193,13 @@ public class TextFormat {
     while(mfs.hasMoreElements()) {
       Collector.MetricFamilySamples metricFamilySamples = mfs.nextElement();
       String name = metricFamilySamples.name;
- 
+
       writer.write("# TYPE ");
       writer.write(name);
       writer.write(' ');
       writer.write(omTypeString(metricFamilySamples.type));
       writer.write('\n');
- 
+
       if (!metricFamilySamples.unit.isEmpty()) {
         writer.write("# UNIT ");
         writer.write(name);

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatOpenMetricsTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatOpenMetricsTest.java
@@ -57,7 +57,8 @@ public class TextFormatOpenMetricsTest {
     assertEquals("# TYPE nolabels counter\n"
                  + "# HELP nolabels help\n"
                  + "nolabels_total 1.0\n"
-                 + "# EOF\n", writer.toString());
+                 + "nolabels_created 1234.0\n"
+                 + "# EOF\n", writer.toString().replaceAll("_created [0-9E.]+", "_created 1234.0"));
   }
 
   @Test
@@ -117,7 +118,8 @@ public class TextFormatOpenMetricsTest {
                  + "# HELP nolabels help\n"
                  + "nolabels_count 1.0\n"
                  + "nolabels_sum 2.0\n"
-                 + "# EOF\n", writer.toString());
+                 + "nolabels_created 1234.0\n"
+                 + "# EOF\n", writer.toString().replaceAll("_created [0-9E.]+", "_created 1234.0"));
   }
 
   @Test
@@ -135,7 +137,8 @@ public class TextFormatOpenMetricsTest {
             + "labelsAndQuantiles{l=\"a\",quantile=\"0.99\"} 2.0\n"
             + "labelsAndQuantiles_count{l=\"a\"} 1.0\n"
             + "labelsAndQuantiles_sum{l=\"a\"} 2.0\n"
-            + "# EOF\n", writer.toString());
+            + "labelsAndQuantiles_created{l=\"a\"} 1234.0\n"
+            + "# EOF\n", writer.toString().replaceAll("(_created\\{.*\\}) [0-9E.]+", "$1 1234.0"));
   }
 
   @Test

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatOpenMetricsTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatOpenMetricsTest.java
@@ -108,11 +108,11 @@ public class TextFormatOpenMetricsTest {
         ArrayList<MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
         MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample("nolabels", labelNames, labelValues, 1.0, 1518123006L);
         samples.add(sample);
-        mfs.add(new MetricFamilySamples("nolabels", Collector.Type.UNTYPED, "help", samples));
+        mfs.add(new MetricFamilySamples("nolabels", Collector.Type.UNKNOWN, "help", samples));
         return mfs;
       }
     }
-    
+
     new CustomCollector().register(registry);
     TextFormat.writeOpenMetrics100(writer, registry.metricFamilySamples());
     assertEquals("# TYPE nolabels unknown\n"

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatOpenMetricsTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatOpenMetricsTest.java
@@ -14,6 +14,7 @@ import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+import io.prometheus.client.Info;
 import io.prometheus.client.Summary;
 
 
@@ -59,6 +60,17 @@ public class TextFormatOpenMetricsTest {
                  + "nolabels_total 1.0\n"
                  + "nolabels_created 1234.0\n"
                  + "# EOF\n", writer.toString().replaceAll("_created [0-9E.]+", "_created 1234.0"));
+  }
+
+  @Test
+  public void testInfoOutput() throws IOException {
+    Info noLabels = Info.build().name("nolabels").help("help").register(registry);
+    noLabels.info("foo", "bar");
+    TextFormat.writeOpenMetrics100(writer, registry.metricFamilySamples());
+    assertEquals("# TYPE nolabels info\n"
+                 + "# HELP nolabels help\n"
+                 + "nolabels_info{foo=\"bar\"} 1.0\n"
+                 + "# EOF\n", writer.toString());
   }
 
   @Test

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
@@ -121,7 +121,7 @@ public class TextFormatTest {
         ArrayList<MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
         MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample("nolabels", labelNames, labelValues, 1.0, 1518123456L);
         samples.add(sample);
-        mfs.add(new MetricFamilySamples("nolabels", Collector.Type.UNTYPED, "help", samples));
+        mfs.add(new MetricFamilySamples("nolabels", Collector.Type.UNKNOWN, "help", samples));
         return mfs;
       }
     }

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
@@ -52,9 +52,32 @@ public class TextFormatTest {
     Counter noLabels = Counter.build().name("nolabels").help("help").register(registry);
     noLabels.inc();
     TextFormat.write004(writer, registry.metricFamilySamples());
-    assertEquals("# HELP nolabels help\n"
-                 + "# TYPE nolabels counter\n"
-                 + "nolabels 1.0\n", writer.toString());
+    assertEquals("# HELP nolabels_total help\n"
+                 + "# TYPE nolabels_total counter\n"
+                 + "nolabels_total 1.0\n", writer.toString());
+  }
+
+  @Test
+  public void testCounterSamplesMissingTotal() throws IOException {
+
+    class CustomCollector extends Collector {
+      public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+        ArrayList<String> labelNames = new ArrayList<String>();
+        ArrayList<String> labelValues = new ArrayList<String>();
+        ArrayList<MetricFamilySamples.Sample> samples = new ArrayList<Collector.MetricFamilySamples.Sample>();
+        MetricFamilySamples.Sample sample = new MetricFamilySamples.Sample("nolabels", labelNames, labelValues, 1.0);
+        samples.add(sample);
+        mfs.add(new MetricFamilySamples("nolabels", Collector.Type.COUNTER, "help", samples));
+        return mfs;
+      }
+    }
+
+    new CustomCollector().register(registry);
+    TextFormat.write004(writer, registry.metricFamilySamples());
+    assertEquals("# HELP nolabels_total help\n"
+                 + "# TYPE nolabels_total counter\n"
+                 + "nolabels_total 1.0\n", writer.toString());
   }
 
   @Test

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
@@ -55,7 +55,11 @@ public class TextFormatTest {
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP nolabels_total help\n"
                  + "# TYPE nolabels_total counter\n"
-                 + "nolabels_total 1.0\n", writer.toString());
+                 + "nolabels_total 1.0\n"
+                 + "# HELP nolabels_created help\n"
+                 + "# TYPE nolabels_created gauge\n"
+                 + "nolabels_created 1234.0\n",
+                 writer.toString().replaceAll("_created [0-9E.]+", "_created 1234.0"));
   }
 
   @Test
@@ -65,7 +69,11 @@ public class TextFormatTest {
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP nolabels_total help\n"
                  + "# TYPE nolabels_total counter\n"
-                 + "nolabels_total 1.0\n", writer.toString());
+                 + "nolabels_total 1.0\n"
+                 + "# HELP nolabels_created help\n"
+                 + "# TYPE nolabels_created gauge\n"
+                 + "nolabels_created 1234.0\n",
+                 writer.toString().replaceAll("_created [0-9E.]+", "_created 1234.0"));
   }
 
 
@@ -107,7 +115,7 @@ public class TextFormatTest {
         return mfs;
       }
     }
-    
+
     new CustomCollector().register(registry);
     TextFormat.write004(writer, registry.metricFamilySamples());
     assertEquals("# HELP nolabels help\n"
@@ -123,7 +131,11 @@ public class TextFormatTest {
     assertEquals("# HELP nolabels help\n"
                  + "# TYPE nolabels summary\n"
                  + "nolabels_count 1.0\n"
-                 + "nolabels_sum 2.0\n", writer.toString());
+                 + "nolabels_sum 2.0\n"
+                 + "# HELP nolabels_created help\n"
+                 + "# TYPE nolabels_created gauge\n"
+                 + "nolabels_created 1234.0\n",
+                 writer.toString().replaceAll("_created [0-9E.]+", "_created 1234.0"));
   }
 
   @Test
@@ -140,7 +152,11 @@ public class TextFormatTest {
             + "labelsAndQuantiles{l=\"a\",quantile=\"0.9\",} 2.0\n"
             + "labelsAndQuantiles{l=\"a\",quantile=\"0.99\",} 2.0\n"
             + "labelsAndQuantiles_count{l=\"a\",} 1.0\n"
-            + "labelsAndQuantiles_sum{l=\"a\",} 2.0\n", writer.toString());
+            + "labelsAndQuantiles_sum{l=\"a\",} 2.0\n"
+            + "# HELP labelsAndQuantiles_created help\n"
+            + "# TYPE labelsAndQuantiles_created gauge\n"
+            + "labelsAndQuantiles_created{l=\"a\",} 1234.0\n",
+            writer.toString().replaceAll("(_created\\{.*\\}) [0-9E.]+", "$1 1234.0"));
   }
 
   @Test

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
@@ -15,6 +15,7 @@ import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+import io.prometheus.client.Info;
 import io.prometheus.client.Summary;
 
 
@@ -76,6 +77,15 @@ public class TextFormatTest {
                  writer.toString().replaceAll("_created [0-9E.]+", "_created 1234.0"));
   }
 
+  @Test
+  public void testInfoOutput() throws IOException {
+    Info noLabels = Info.build().name("nolabels").help("help").register(registry);
+    noLabels.info("foo", "bar");
+    TextFormat.write004(writer, registry.metricFamilySamples());
+    assertEquals("# HELP nolabels_info help\n"
+                 + "# TYPE nolabels_info gauge\n"
+                 + "nolabels_info{foo=\"bar\",} 1.0\n", writer.toString());
+  }
 
   @Test
   public void testCounterSamplesMissingTotal() throws IOException {

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/DropwizardExportsTest.java
@@ -224,7 +224,7 @@ public class DropwizardExportsTest {
 
         assertTrue(elements.keySet().contains("my_application_namedTimer1"));
         assertTrue(elements.keySet().contains("my_application_namedCounter1"));
-        assertTrue(elements.keySet().contains("my_application_namedMeter1_total"));
+        assertTrue(elements.keySet().contains("my_application_namedMeter1"));
         assertTrue(elements.keySet().contains("my_application_namedHistogram1"));
         assertTrue(elements.keySet().contains("my_application_namedGauge1"));
 
@@ -234,7 +234,7 @@ public class DropwizardExportsTest {
         assertThat(elements.get("my_application_namedCounter1").help,
                 is("Generated from Dropwizard metric import (metric=my.application.namedCounter1, type=com.codahale.metrics.Counter)"));
 
-        assertThat(elements.get("my_application_namedMeter1_total").help,
+        assertThat(elements.get("my_application_namedMeter1").help,
                 is("Generated from Dropwizard metric import (metric=my.application.namedMeter1, type=com.codahale.metrics.Meter)"));
 
         assertThat(elements.get("my_application_namedHistogram1").help,
@@ -321,7 +321,7 @@ public class DropwizardExportsTest {
         assertTrue(namedCounter.samples.contains(namedCounter1));
         assertTrue(namedCounter.samples.contains(namedCounter2));
 
-        final Collector.MetricFamilySamples namedMeter = elements.get("my_application_namedMeter_total");
+        final Collector.MetricFamilySamples namedMeter = elements.get("my_application_namedMeter");
         assertNotNull(namedMeter);
         assertEquals(Collector.Type.COUNTER, namedMeter.type);
         assertEquals(2, namedMeter.samples.size());

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/VersionInfoExports.java
@@ -1,7 +1,7 @@
 package io.prometheus.client.hotspot;
 
 import io.prometheus.client.Collector;
-import io.prometheus.client.GaugeMetricFamily;
+import io.prometheus.client.Info;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,20 +26,12 @@ public class VersionInfoExports extends Collector {
 
 
     public List<MetricFamilySamples> collect() {
-        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
-
-        GaugeMetricFamily jvmInfo = new GaugeMetricFamily(
-                "jvm_info",
-                "JVM version info",
-                Arrays.asList("version", "vendor", "runtime"));
-        jvmInfo.addMetric(
-                Arrays.asList(
-                    System.getProperty("java.runtime.version", "unknown"),
-                    System.getProperty("java.vm.vendor", "unknown"),
-                    System.getProperty("java.runtime.name", "unknown")),
-                    1L);
-        mfs.add(jvmInfo);
-
-        return mfs;
+        Info i = Info.build().name("jvm").help("VM version info").create();
+        i.info(
+            "version", System.getProperty("java.runtime.version", "unknown"),
+            "vendor", System.getProperty("java.vm.vendor", "unknown"),
+            "runtime", System.getProperty("java.runtime.name", "unknown")
+        );
+        return i.collect();
     }
 }

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/VersionInfoExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/VersionInfoExportsTest.java
@@ -21,7 +21,11 @@ public class VersionInfoExportsTest {
         assertEquals(
                 1L,
                 registry.getSampleValue(
-                        "jvm_info", new String[]{"version", "vendor", "runtime"}, new String[]{System.getProperty("java.runtime.version", "unknown"), System.getProperty("java.vm.vendor", "unknown"), System.getProperty("java.runtime.name", "unknown")}),
+                        "jvm_info", new String[]{"runtime", "vendor", "version"},
+                        new String[]{
+                          System.getProperty("java.runtime.name", "unknown"),
+                          System.getProperty("java.vm.vendor", "unknown"),
+                          System.getProperty("java.runtime.version", "unknown")}),
                 .0000001);
     }
 }

--- a/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
+++ b/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
@@ -67,13 +67,14 @@ public class HTTPServer {
             if ("/-/healthy".equals(contextPath)) {
                 osw.write(HEALTHY_RESPONSE);
             } else {
-                TextFormat.write004(osw,
+                String contentType = TextFormat.chooseContentType(t.getRequestHeaders().getFirst("Accept"));
+                t.getResponseHeaders().set("Content-Type", contentType);
+                TextFormat.writeFormat(contentType, osw,
                         registry.filteredMetricFamilySamples(parseQuery(query)));
             }
 
             osw.close();
-            t.getResponseHeaders().set("Content-Type",
-                    TextFormat.CONTENT_TYPE_004);
+
             if (shouldUseCompression(t)) {
                 t.getResponseHeaders().set("Content-Encoding", "gzip");
                 t.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);

--- a/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestHTTPServer.java
+++ b/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestHTTPServer.java
@@ -65,6 +65,17 @@ public class TestHTTPServer {
     return s.hasNext() ? s.next() : "";
   }
 
+  String requestWithAccept(String accept) throws IOException {
+    String url = "http://localhost:" + s.server.getAddress().getPort();
+    URLConnection connection = new URL(url).openConnection();
+    connection.setDoOutput(true);
+    connection.setDoInput(true);
+    connection.setRequestProperty("Accept", accept);
+    Scanner s = new Scanner(connection.getInputStream(), "UTF-8").useDelimiter("\\A");
+    return s.hasNext() ? s.next() : "";
+  }
+
+  @Test
   @Test(expected = IllegalArgumentException.class)
   public void testRefuseUsingUnbound() throws IOException {
     CollectorRegistry registry = new CollectorRegistry();
@@ -118,6 +129,12 @@ public class TestHTTPServer {
     assertThat(response).contains("a 0.0");
     assertThat(response).contains("b 0.0");
     assertThat(response).contains("c 0.0");
+  }
+
+  @Test
+  public void testOpenMetrics() throws IOException {
+    String response = requestWithAccept("application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1");
+    assertThat(response).contains("# EOF");
   }
 
   @Test

--- a/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestHTTPServer.java
+++ b/simpleclient_httpserver/src/test/java/io/prometheus/client/exporter/TestHTTPServer.java
@@ -75,7 +75,6 @@ public class TestHTTPServer {
     return s.hasNext() ? s.next() : "";
   }
 
-  @Test
   @Test(expected = IllegalArgumentException.class)
   public void testRefuseUsingUnbound() throws IOException {
     CollectorRegistry registry = new CollectorRegistry();

--- a/simpleclient_servlet/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
@@ -42,11 +42,12 @@ public class MetricsServlet extends HttpServlet {
   protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
           throws ServletException, IOException {
     resp.setStatus(HttpServletResponse.SC_OK);
-    resp.setContentType(TextFormat.CONTENT_TYPE_004);
+    String contentType = TextFormat.chooseContentType(req.getHeader("Accept"));
+    resp.setContentType(contentType);
 
     Writer writer = new BufferedWriter(resp.getWriter());
     try {
-      TextFormat.write004(writer, registry.filteredMetricFamilySamples(parse(req)));
+      TextFormat.writeFormat(contentType, writer, registry.filteredMetricFamilySamples(parse(req)));
       writer.flush();
     } finally {
       writer.close();

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
@@ -74,4 +74,23 @@ public class MetricsServletTest {
 
     verify(writer).close();
   }
+
+  @Test
+  public void testOpenMetricsNegotiated() throws IOException, ServletException {
+    CollectorRegistry registry = new CollectorRegistry();
+    Gauge.build("a", "a help").register(registry);
+
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader("Accept")).thenReturn("application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1");
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(resp.getWriter()).thenReturn(writer);
+
+    new MetricsServlet(registry).doGet(req, resp);
+
+    assertThat(stringWriter.toString()).contains("a 0.0");
+    assertThat(stringWriter.toString()).contains("# EOF");
+  }
+
 }

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusEndpoint.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusEndpoint.java
@@ -23,13 +23,13 @@ class PrometheusEndpoint extends AbstractEndpoint<String> {
 
   @Override
   public String invoke() {
-    return writeRegistry(Collections.<String>emptySet());
+    return writeRegistry(Collections.<String>emptySet(), "");
   }
 
-  public String writeRegistry(Set<String> metricsToInclude) {
+  public String writeRegistry(Set<String> metricsToInclude, String contentType) {
     try {
       Writer writer = new StringWriter();
-      TextFormat.write004(writer, collectorRegistry.filteredMetricFamilySamples(metricsToInclude));
+      TextFormat.writeFormat(contentType, writer, collectorRegistry.filteredMetricFamilySamples(metricsToInclude));
       return writer.toString();
     } catch (IOException e) {
       // This actually never happens since StringWriter::write() doesn't throw any IOException

--- a/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMvcEndpoint.java
+++ b/simpleclient_spring_boot/src/main/java/io/prometheus/client/spring/boot/PrometheusMvcEndpoint.java
@@ -4,6 +4,7 @@ import io.prometheus.client.exporter.common.TextFormat;
 import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,16 +30,18 @@ public class PrometheusMvcEndpoint extends EndpointMvcAdapter {
   )
   @ResponseBody
   public ResponseEntity value(
-          @RequestParam(value = "name[]", required = false, defaultValue = "") Set<String> name) {
+          @RequestParam(value = "name[]", required = false, defaultValue = "") Set<String> name,
+          @RequestHeader(value = "Accept", required = false, defaultValue = "") String accept) {
     if (!getDelegate().isEnabled()) {
       // Shouldn't happen - MVC endpoint shouldn't be registered when delegate's
       // disabled
       return getDisabledResponse();
     }
 
-    String result = delgate.writeRegistry(name);
+    String contentType = TextFormat.chooseContentType(accept);
+    String result = delgate.writeRegistry(name, contentType);
     return ResponseEntity.ok()
-            .header(CONTENT_TYPE, TextFormat.CONTENT_TYPE_004)
+            .header(CONTENT_TYPE, contentType)
             .body(result);
   }
 }

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusEndpointTest.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusEndpointTest.java
@@ -55,7 +55,7 @@ public class PrometheusEndpointTest {
     HttpHeaders headers = new HttpHeaders();
     headers.set("Accept", "text/plain");
 
-    ResponseEntity<String> metricsResponse = template.exchange(getBaseUrl() + "/prometheus?name[]=foo_bar", HttpMethod.GET, new HttpEntity(headers), String.class);
+    ResponseEntity<String> metricsResponse = template.exchange(getBaseUrl() + "/prometheus?name[]=foo_bar_total", HttpMethod.GET, new HttpEntity(headers), String.class);
 
     // then:
     assertEquals(HttpStatus.OK, metricsResponse.getStatusCode());
@@ -63,7 +63,7 @@ public class PrometheusEndpointTest {
 
     List<String> responseLines = Arrays.asList(metricsResponse.getBody().split("\n"));
     assertThat(responseLines, CustomMatchers.<String>exactlyNItems(1,
-            matchesPattern("foo_bar\\{label1=\"val1\",label2=\"val2\",?\\} 3.0")));
+            matchesPattern("foo_bar_total\\{label1=\"val1\",label2=\"val2\",?\\} 3.0")));
   }
 
   private String getBaseUrl() {

--- a/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusMvcEndpointTest.java
+++ b/simpleclient_spring_boot/src/test/java/io/prometheus/client/spring/boot/PrometheusMvcEndpointTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @RunWith(SpringRunner.class)
@@ -48,6 +49,19 @@ public class PrometheusMvcEndpointTest {
         ResponseEntity<String> metricsResponse = template.exchange(getBaseUrl() + "/prometheus", HttpMethod.GET, new HttpEntity(headers), String.class);
 
         assertEquals(HttpStatus.OK, metricsResponse.getStatusCode());
+    }
+
+    @Test
+    public void testAcceptOpenMetrics() throws Exception {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", "application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1");
+
+        ResponseEntity<String> metricsResponse = template.exchange(getBaseUrl() + "/prometheus", HttpMethod.GET, new HttpEntity(headers), String.class);
+
+        assertEquals(HttpStatus.OK, metricsResponse.getStatusCode());
+        assertEquals(StringUtils.deleteWhitespace(TextFormat.CONTENT_TYPE_OPENMETRICS_100), metricsResponse.getHeaders().getContentType().toString().toLowerCase());
+        assertTrue(metricsResponse.getBody().contains("# EOF"));
     }
 
     @Test

--- a/simpleclient_vertx/src/main/java/io/prometheus/client/vertx/MetricsHandler.java
+++ b/simpleclient_vertx/src/main/java/io/prometheus/client/vertx/MetricsHandler.java
@@ -73,10 +73,12 @@ public class MetricsHandler implements Handler<RoutingContext> {
   public void handle(RoutingContext ctx) {
     try {
       final BufferWriter writer = new BufferWriter();
-      TextFormat.write004(writer, registry.filteredMetricFamilySamples(parse(ctx.request())));
+      String contentType = TextFormat.chooseContentType(ctx.request().headers().get("Accept"));
+
+      TextFormat.writeFormat(contentType, writer, registry.filteredMetricFamilySamples(parse(ctx.request())));
       ctx.response()
               .setStatusCode(200)
-              .putHeader("Content-Type", TextFormat.CONTENT_TYPE_004)
+              .putHeader("Content-Type", contentType)
               .end(writer.getBuffer());
     } catch (IOException e) {
       ctx.fail(e);


### PR DESCRIPTION
This switches the core data model to OM, adds support for negotiating and exposing OpenMetrics format, adds units, created time, and adds new direct instrumentation for Info and Enum.

This is done as gracefully as practical, but this will break users - in particular if a) they have counters lacking a `_total` suffix in which case the sample names will change or b) if they happen to be using `UNTYPED` which is now called `UNKNOWN` in which case they'll need up update their code.