### PR TITLE
Use JavaDoc since tag on new public API

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Enumeration.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Enumeration.java
@@ -56,6 +56,8 @@ import java.util.concurrent.TimeUnit;
  *   }
  * }
  * </pre>
+ *
+ * @since 0.10.0
  */
 public class Enumeration extends SimpleCollector<Enumeration.Child> implements Counter.Describable {
 

--- a/simpleclient/src/main/java/io/prometheus/client/Info.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Info.java
@@ -34,6 +34,8 @@ import java.util.concurrent.TimeUnit;
  *   }
  * }
  * </pre>
+ *
+ * @since 0.10.0
  */
 public class Info extends SimpleCollector<Info.Child> implements Counter.Describable {
 

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -217,6 +217,8 @@ public abstract class SimpleCollector<Child> extends Collector {
     }
     /**
      * Set the unit of the metric. Required.
+     *
+     * @since 0.10.0
      */
     public B unit(String unit) {
       this.unit = unit;

--- a/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
+++ b/simpleclient_common/src/main/java/io/prometheus/client/exporter/common/TextFormat.java
@@ -19,11 +19,15 @@ public class TextFormat {
 
   /**
    * Content-type for Openmetrics text version 1.0.0.
+   *
+   * @since 0.10.0
    */
   public final static String CONTENT_TYPE_OPENMETRICS_100 = "application/openmetrics-text; version=1.0.0; charset=utf-8";
 
   /**
    * Return the content type that should be used for a given Accept HTTP header.
+   *
+   * @since 0.10.0
    */
   public static String chooseContentType(String acceptHeader) {
     if (acceptHeader == null) {
@@ -41,6 +45,8 @@ public class TextFormat {
 
   /**
    * Write out the given MetricFamilySamples in a format per the contentType.
+   *
+   * @since 0.10.0
    */
   public static void writeFormat(String contentType, Writer writer, Enumeration<Collector.MetricFamilySamples> mfs) throws IOException {
     if (CONTENT_TYPE_004.equals(contentType)) {
@@ -188,6 +194,8 @@ public class TextFormat {
 
   /**
    * Write out the OpenMetrics text version 1.0.0 of the given MetricFamilySamples.
+   *
+   * @since 0.10.0
    */
   public static void writeOpenMetrics100(Writer writer, Enumeration<Collector.MetricFamilySamples> mfs) throws IOException {
     while(mfs.hasMoreElements()) {


### PR DESCRIPTION
This will help other libraries that depend on this library to identify when they are using new API that will raise the minimum version of this library required by end users.