### PR TITLE
Document unit as optional

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -216,7 +216,7 @@ public abstract class SimpleCollector<Child> extends Collector {
       return (B)this;
     }
     /**
-     * Set the unit of the metric. Required.
+     * Set the unit of the metric. Optional.
      *
      * @since 0.10.0
      */


### PR DESCRIPTION
It was incorrectly documented as required when initially introduced.
See https://github.com/prometheus/client_java/pull/615#discussion_r565027894