### PR TITLE
Clarify Info javadoc

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Enumeration.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Enumeration.java
@@ -1,8 +1,5 @@
 package io.prometheus.client;
 
-import io.prometheus.client.CKMSQuantiles.Quantile;
-
-import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,8 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.LinkedHashSet;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Enumeration metric, to track which of a set of states something is in.
@@ -19,7 +14,7 @@ import java.util.concurrent.TimeUnit;
  * The first provided state will be the default.
  *
  * <p>
- * Example enumeration:
+ * Example Enumeration:
  * <pre>
  * {@code
  *   class YourClass {

--- a/simpleclient/src/main/java/io/prometheus/client/Info.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Info.java
@@ -1,30 +1,24 @@
 package io.prometheus.client;
 
-import io.prometheus.client.CKMSQuantiles.Quantile;
-
-import java.io.Closeable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Info metric, key-value pairs.
  *
- * Examples of Info include, build information, version information, and potential target metadata,
- * The first provided state will be the default.
+ * Examples of Info include build information, version information, and potential target metadata.
+ * The first provided state will be the default. The string "_info" will be appended to the name.
  *
  * <p>
- * Example enumeration:
+ * Example Info:
  * <pre>
  * {@code
  *   class YourClass {
  *     static final Info buildInfo = Info.build()
- *         .name("your_build_info").help("Build information.")
+ *         .name("your_build").help("Build information.")
  *         .register();
  *
  *     void func() {

--- a/simpleclient/src/main/java/io/prometheus/client/Info.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Info.java
@@ -10,7 +10,7 @@ import java.util.TreeMap;
  * Info metric, key-value pairs.
  *
  * Examples of Info include build information, version information, and potential target metadata.
- * The first provided state will be the default. The string "_info" will be appended to the name.
+ * The string "_info" will be appended to the sample name.
  *
  * <p>
  * Example Info:


### PR DESCRIPTION
If you follow the example in the javadoc you get a metric named `your_build_info_info`.

Also remove unused imports.