### PR TITLE
Add value filter to TextFormat for easier supplying fake values.

### DIFF
--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatOpenMetricsTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatOpenMetricsTest.java
@@ -185,4 +185,22 @@ public class TextFormatOpenMetricsTest {
                  + "nolabels 1.0\n"
                  + "# EOF\n", writer.toString());
   }
+
+  @Test
+  public void testValueFilterMutating() throws IOException {
+    Gauge labels = Gauge.build().name("labels").help("help").labelNames("l").register(registry);
+    labels.labels("a").inc();
+
+    TextFormat.writeOpenMetrics100(writer, registry.metricFamilySamples(), new TextFormat.ValueFilter() {
+      @Override
+      public double getValue(Collector.MetricFamilySamples.Sample sample) {
+        return sample.value * 3.0;
+      }
+    });
+
+    assertEquals("Value was not replace with mutated value 1.0 x 3.0","# TYPE labels gauge\n"
+            + "# HELP labels help\n"
+            + "labels{l=\"a\"} 3.0\n"
+            + "# EOF\n", writer.toString());
+  }
 }

--- a/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
+++ b/simpleclient_common/src/test/java/io/prometheus/client/exporter/common/TextFormatTest.java
@@ -241,4 +241,21 @@ public class TextFormatTest {
     assertEquals(TextFormat.CONTENT_TYPE_OPENMETRICS_100, TextFormat.chooseContentType("application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1"));
     assertEquals(TextFormat.CONTENT_TYPE_OPENMETRICS_100, TextFormat.chooseContentType("application/openmetrics-text; version=1.0.0"));
   }
+
+  @Test
+  public void testValueFilterMutating() throws IOException {
+    Gauge labels = Gauge.build().name("labels").help("help").labelNames("l").register(registry);
+    labels.labels("a").inc();
+
+    TextFormat.write004(writer, registry.metricFamilySamples(), new TextFormat.ValueFilter() {
+      @Override
+      public double getValue(Collector.MetricFamilySamples.Sample sample) {
+        return 2.0;
+      }
+    });
+
+    assertEquals("Value was not replace with mutated fixed value 2.0","# HELP labels help\n"
+            + "# TYPE labels gauge\n"
+            + "labels{l=\"a\",} 2.0\n", writer.toString());
+  }
 }


### PR DESCRIPTION
Fake values are useful for easy simulation of (temporary) alert situations. By proving a mutating ValueFilter in software that uses the simpleclient, end-to-end tests of the whole alerting chain will be much easier.

See #627
