### PR TITLE
Exemplar API sketch

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -143,10 +143,11 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
      * @param amt the amount to increment the counter by
      * @param exemplarLabels a set of key value pairs used to create the exemplar
      *
-     * @throws IllegalArgumentException if exemplarLabels is null
-     * @throws IllegalArgumentException if exemplarLabels does not contain an even number of values
-     * @throws IllegalArgumentException if exemplarLabels contains any invalid labels
-     * @throws IllegalArgumentException if the combined length of the exemplarLabels is greater than 64
+     * @throws IllegalArgumentException If amt is negative.
+     * @throws IllegalArgumentException if exemplarLabels is null.
+     * @throws IllegalArgumentException if exemplarLabels does not contain an even number of values.
+     * @throws IllegalArgumentException if exemplarLabels contains any invalid labels.
+     * @throws IllegalArgumentException if the combined length of the exemplarLabels is greater than 64.
      */
     public void incWithExemplar(double amt, String... exemplarLabels){
       //TODO exemplar label validation

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
 /**
  * Counter metric, to track counts of events or running totals.
  * <p>
@@ -136,6 +138,23 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
       value.add(amt);
     }
     /**
+     * Increment the counter by given amount and update the exemplar for the series.
+     *
+     * @param amt the amount to increment the counter by
+     * @param exemplarLabels a set of key value pairs used to create the exemplar
+     *
+     * @throws IllegalArgumentException if exemplarLabels is null
+     * @throws IllegalArgumentException if exemplarLabels does not contain an even number of values
+     * @throws IllegalArgumentException if exemplarLabels contains any invalid labels
+     * @throws IllegalArgumentException if the combined length of the exemplarLabels is greater than 64
+     */
+    public void incWithExemplar(double amt, String... exemplarLabels){
+      //TODO exemplar label validation
+      inc(amt);
+      //TODO update exemplar
+      throw new NotImplementedException();
+    }
+    /**
      * Get the value of the counter.
      */
     public double get() {
@@ -162,6 +181,12 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
    */
   public void inc(double amt) {
     noLabelsChild.inc(amt);
+  }
+  /**
+   *
+   */
+  public void incWithExemplar(double amt, String... exemplarLabels){
+    noLabelsChild.incWithExemplar(amt, exemplarLabels);
   }
   
   /**

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
 /**
  * Histogram metric, to track distributions of events.
  * <p>
@@ -267,6 +269,23 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
       sum.add(amt);
     }
     /**
+     * Observe the given amount and update the exemplar for the bucket.
+     *
+     * @param amt the amount to observe
+     * @param exemplarLabels a set of key value pairs used to create the exemplar
+     *
+     * @throws IllegalArgumentException if exemplarLabels is null
+     * @throws IllegalArgumentException if exemplarLabels does not contain an even number of values
+     * @throws IllegalArgumentException if exemplarLabels contains any invalid labels
+     * @throws IllegalArgumentException if the combined length of the exemplarLabels is greater than 64
+     */
+    public void observeWithExemplar(double amt, String... exemplarLabels) {
+      //TODO exemplar label validation
+      observe(amt);
+      //TODO update exemplar
+      throw new NotImplementedException();
+    }
+    /**
      * Start a timer to track a duration.
      * <p>
      * Call {@link Timer#observeDuration} at the end of what you want to measure the duration of.
@@ -296,6 +315,12 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
    */
   public void observe(double amt) {
     noLabelsChild.observe(amt);
+  }
+  /**
+   *
+   */
+  public void observeWithExemplar(double amt, String... exemplarLabels) {
+    noLabelsChild.observeWithExemplar(amt, exemplarLabels);
   }
   /**
    * Start a timer to track a duration on the histogram with no labels.

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -274,10 +274,10 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
      * @param amt the amount to observe
      * @param exemplarLabels a set of key value pairs used to create the exemplar
      *
-     * @throws IllegalArgumentException if exemplarLabels is null
-     * @throws IllegalArgumentException if exemplarLabels does not contain an even number of values
-     * @throws IllegalArgumentException if exemplarLabels contains any invalid labels
-     * @throws IllegalArgumentException if the combined length of the exemplarLabels is greater than 64
+     * @throws IllegalArgumentException if exemplarLabels is null.
+     * @throws IllegalArgumentException if exemplarLabels does not contain an even number of values.
+     * @throws IllegalArgumentException if exemplarLabels contains any invalid labels.
+     * @throws IllegalArgumentException if the combined length of the exemplarLabels is greater than 64.
      */
     public void observeWithExemplar(double amt, String... exemplarLabels) {
       //TODO exemplar label validation


### PR DESCRIPTION
Expending a [comment](https://github.com/prometheus/client_java/issues/622#issuecomment-800901953) from https://github.com/prometheus/client_java/issues/622 to a PR.

This PR proposes an API for recording exemplar values on counters and histograms.

Adds new `<inc|add>WithExemplar(double value, String... exemplarLabels)` methods which take string varargs containing exemplar values.

Inspired by initial golang implementation by @beorn7 : https://github.com/prometheus/client_golang/pull/706

### Not addressed
* persisting exemplars/exposing them to scrapes (wanted to start with the validating the API) 
* histogram timer methods (adding exemplars to those could be tricky, doesn't need to block initial implementation)


### Intentionally omitted
* `Counter#incWithExemplar(String... examplarLabels)` increment by 1 convenience method (less duplication in the API, forcing the user to include an amount felt reasonable if they're already using the more verbose method).

@fstab @tomwilkie 