### PR TITLE
Add support to jakarta servlet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@
 .idea
 *.iml
 
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+
 target/
 simpleclient_pushgateway/mockserver.log
 simpleclient_pushgateway/mockserver_request.log

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <module>simpleclient_logback</module>
         <module>simpleclient_pushgateway</module>
         <module>simpleclient_servlet</module>
+        <module>simpleclient_servlet_jakarta</module>
         <module>simpleclient_spring_web</module>
         <module>simpleclient_spring_boot</module>
         <module>simpleclient_jetty</module>

--- a/simpleclient_servlet/pom.xml
+++ b/simpleclient_servlet/pom.xml
@@ -80,4 +80,59 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>updateSource</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <executions>
+                            <execution>
+                                <id>copy-resources</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/../simpleclient_servlet_jakarta/src</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>src</directory>
+                                        </resource>
+                                    </resources>
+                                    <overwrite>true</overwrite>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.7</version>
+                        <executions>
+                            <execution>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <tasks>
+                                        <replace dir="${basedir}/../simpleclient_servlet_jakarta/src" token="javax.servlet" value="jakarta.servlet"/>
+                                        <replace file="${basedir}/../simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java" 
+                                                    token="Connector connector =  (Connector)"
+                                                    value="ServerConnector connector =  (ServerConnector)"/>
+                                        <replace file="${basedir}/../simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java" 
+                                                    token="server.Connector"
+                                                    value="server.ServerConnector"/>
+                                    </tasks>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
@@ -1,6 +1,8 @@
 package io.prometheus.client.exporter;
 
 import io.prometheus.client.Gauge;
+
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
@@ -28,8 +30,9 @@ public class ExampleBenchmark {
         server.start();
         Thread.sleep(1000);
 
+        Connector connector =  (Connector) server.getConnectors()[0];
         byte[] bytes = new byte[8192];
-        URL url = new URL("http", "localhost", server.getConnectors()[0].getLocalPort(), "/metrics");
+        URL url = new URL("http", "localhost", connector.getLocalPort(), "/metrics");
 
         long start = System.nanoTime();
         for (int i = 0; i < 100; i++) {

--- a/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
+++ b/simpleclient_servlet/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
@@ -2,7 +2,6 @@ package io.prometheus.client.filter;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
-import org.eclipse.jetty.http.HttpMethods;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -25,6 +24,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class MetricsFilterTest {
+	
+	public static final String GET = "GET";
+	public static final String POST = "POST";
+	
     MetricsFilter f = new MetricsFilter();
 
     @After
@@ -49,7 +52,7 @@ public class MetricsFilterTest {
         HttpServletRequest req = mock(HttpServletRequest.class);
 
         when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang/zilch/zip/nada");
-        when(req.getMethod()).thenReturn(HttpMethods.GET);
+        when(req.getMethod()).thenReturn(GET);
 
         HttpServletResponse res = mock(HttpServletResponse.class);
         FilterChain c = mock(FilterChain.class);
@@ -58,7 +61,7 @@ public class MetricsFilterTest {
 
         verify(c).doFilter(req, res);
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(metricName + "_count", new String[]{"path", "method"}, new String[]{"/foo/bar/baz/bang", HttpMethods.GET});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(metricName + "_count", new String[]{"path", "method"}, new String[]{"/foo/bar/baz/bang", GET});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -69,7 +72,7 @@ public class MetricsFilterTest {
         final String path = "/foo/bar/baz/bang/zilch/zip/nada";
 
         when(req.getRequestURI()).thenReturn(path);
-        when(req.getMethod()).thenReturn(HttpMethods.GET);
+        when(req.getMethod()).thenReturn(GET);
 
         HttpServletResponse res = mock(HttpServletResponse.class);
         FilterChain c = mock(FilterChain.class);
@@ -85,7 +88,7 @@ public class MetricsFilterTest {
         verify(c).doFilter(req, res);
 
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(name + "_count", new String[]{"path", "method"}, new String[]{path, HttpMethods.GET});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(name + "_count", new String[]{"path", "method"}, new String[]{path, GET});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -95,7 +98,7 @@ public class MetricsFilterTest {
         HttpServletRequest req = mock(HttpServletRequest.class);
         final String path = "/foo/bar/baz/bang";
         when(req.getRequestURI()).thenReturn(path);
-        when(req.getMethod()).thenReturn(HttpMethods.POST);
+        when(req.getMethod()).thenReturn(POST);
 
         FilterChain c = mock(FilterChain.class);
         doAnswer(new Answer<Void>() {
@@ -117,7 +120,7 @@ public class MetricsFilterTest {
         HttpServletResponse res = mock(HttpServletResponse.class);
         constructed.doFilter(req, res, c);
 
-        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foobar_baz_filter_duration_seconds_sum", new String[]{"path", "method"}, new String[]{path, HttpMethods.POST});
+        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foobar_baz_filter_duration_seconds_sum", new String[]{"path", "method"}, new String[]{path, POST});
         assertNotNull(sum);
         assertEquals(0.1, sum, 0.01);
     }
@@ -127,7 +130,7 @@ public class MetricsFilterTest {
         HttpServletRequest req = mock(HttpServletRequest.class);
         final String path = "/foo/bar/baz/bang";
         when(req.getRequestURI()).thenReturn(path);
-        when(req.getMethod()).thenReturn(HttpMethods.POST);
+        when(req.getMethod()).thenReturn(POST);
 
         FilterChain c = mock(FilterChain.class);
         doAnswer(new Answer<Void>() {
@@ -149,13 +152,13 @@ public class MetricsFilterTest {
 
         f.doFilter(req, res, c);
 
-        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foo_sum", new String[]{"path", "method"}, new String[]{"/foo", HttpMethods.POST});
+        final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foo_sum", new String[]{"path", "method"}, new String[]{"/foo", POST});
         assertEquals(0.1, sum, 0.01);
 
-        final Double le05 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "le"}, new String[]{"/foo", HttpMethods.POST, "0.05"});
+        final Double le05 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "le"}, new String[]{"/foo", POST, "0.05"});
         assertNotNull(le05);
         assertEquals(0, le05, 0.01);
-        final Double le15 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "le"}, new String[]{"/foo", HttpMethods.POST, "0.15"});
+        final Double le15 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket", new String[]{"path", "method", "le"}, new String[]{"/foo", POST, "0.15"});
         assertNotNull(le15);
         assertEquals(1, le15, 0.01);
 
@@ -185,7 +188,7 @@ public class MetricsFilterTest {
     public void testStatusCode() throws Exception {
         HttpServletRequest req = mock(HttpServletRequest.class);
         when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang");
-        when(req.getMethod()).thenReturn(HttpMethods.GET);
+        when(req.getMethod()).thenReturn(GET);
 
         HttpServletResponse res = mock(HttpServletResponse.class);
         when(res.getStatus()).thenReturn(200);
@@ -202,7 +205,7 @@ public class MetricsFilterTest {
 
         constructed.doFilter(req, res, c);
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_status_total", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, "200"});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_status_total", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", GET, "200"});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }
@@ -211,7 +214,7 @@ public class MetricsFilterTest {
     public void testStatusCodeWithNonHttpServletResponse() throws Exception {
         HttpServletRequest req = mock(HttpServletRequest.class);
         when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang");
-        when(req.getMethod()).thenReturn(HttpMethods.GET);
+        when(req.getMethod()).thenReturn(GET);
 
         ServletResponse res = mock(ServletResponse.class);
 
@@ -227,7 +230,7 @@ public class MetricsFilterTest {
 
         constructed.doFilter(req, res, c);
 
-        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_status_total", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", HttpMethods.GET, MetricsFilter.UNKNOWN_HTTP_STATUS_CODE});
+        final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue("foobar_filter_status_total", new String[]{"path", "method", "status"}, new String[]{"/foo/bar", GET, MetricsFilter.UNKNOWN_HTTP_STATUS_CODE});
         assertNotNull(sampleValue);
         assertEquals(1, sampleValue, 0.0001);
     }

--- a/simpleclient_servlet_jakarta/pom.xml
+++ b/simpleclient_servlet_jakarta/pom.xml
@@ -9,12 +9,12 @@
     </parent>
 
     <groupId>io.prometheus</groupId>
-    <artifactId>simpleclient_servlet</artifactId>
+    <artifactId>simpleclient_servlet_jakarta</artifactId>
     <packaging>bundle</packaging>
 
-    <name>Prometheus Java Simpleclient Servlet</name>
+    <name>Prometheus Java Simpleclient jakarta Servlet</name>
     <description>
-        HTTP servlet exporter for the simpleclient.
+        HTTP jakarta servlet exporter for the simpleclient.
     </description>
 
     <licenses>
@@ -49,9 +49,9 @@
             <version>0.10.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- Test Dependencies Follow -->
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>8.1.7.v20120910</version>
+            <version>11.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/simpleclient_servlet_jakarta/pom.xml
+++ b/simpleclient_servlet_jakarta/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.10.1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.prometheus</groupId>
+    <artifactId>simpleclient_servlet</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Prometheus Java Simpleclient Servlet</name>
+    <description>
+        HTTP servlet exporter for the simpleclient.
+    </description>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>brian-brazil</id>
+            <name>Brian Brazil</name>
+            <email>brian.brazil@boxever.com</email>
+        </developer>
+    </developers>
+
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.10.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+            <version>0.10.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Test Dependencies Follow -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>2.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>8.1.7.v20120910</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.28.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/simpleclient_servlet_jakarta/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
+++ b/simpleclient_servlet_jakarta/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
@@ -3,10 +3,10 @@ package io.prometheus.client.exporter;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;

--- a/simpleclient_servlet_jakarta/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
+++ b/simpleclient_servlet_jakarta/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
@@ -1,0 +1,72 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The MetricsServlet class exists to provide a simple way of exposing the metrics values.
+ *
+ */
+public class MetricsServlet extends HttpServlet {
+
+  private CollectorRegistry registry;
+
+  /**
+   * Construct a MetricsServlet for the default registry.
+   */
+  public MetricsServlet() {
+    this(CollectorRegistry.defaultRegistry);
+  }
+
+  /**
+   * Construct a MetricsServlet for the given registry.
+   * @param registry collector registry
+   */
+  public MetricsServlet(CollectorRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+          throws ServletException, IOException {
+    resp.setStatus(HttpServletResponse.SC_OK);
+    String contentType = TextFormat.chooseContentType(req.getHeader("Accept"));
+    resp.setContentType(contentType);
+
+    Writer writer = new BufferedWriter(resp.getWriter());
+    try {
+      TextFormat.writeFormat(contentType, writer, registry.filteredMetricFamilySamples(parse(req)));
+      writer.flush();
+    } finally {
+      writer.close();
+    }
+  }
+
+  private Set<String> parse(HttpServletRequest req) {
+    String[] includedParam = req.getParameterValues("name[]");
+    if (includedParam == null) {
+      return Collections.emptySet();
+    } else {
+      return new HashSet<String>(Arrays.asList(includedParam));
+    }
+  }
+
+  @Override
+  protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
+          throws ServletException, IOException {
+    doGet(req, resp);
+  }
+
+}

--- a/simpleclient_servlet_jakarta/src/main/java/io/prometheus/client/filter/MetricsFilter.java
+++ b/simpleclient_servlet_jakarta/src/main/java/io/prometheus/client/filter/MetricsFilter.java
@@ -1,0 +1,206 @@
+package io.prometheus.client.filter;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Histogram;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * The MetricsFilter class exists to provide a high-level filter that enables tunable collection of
+ * metrics for Servlet performance.
+ *
+ * <p>
+ * The metric name itself is required, and configured with a {@code metric-name} init parameter.
+ *
+ * <p>
+ * The help parameter, configured with the {@code help} init parameter, is not required but strongly
+ * recommended.
+ *
+ * <p>
+ * By default, this filter will provide metrics that distinguish only 1 level deep for the request
+ * path (including servlet context path), but can be configured with the {@code path-components}
+ * init parameter. Any number provided that is less than 1 will provide the full path granularity
+ * (warning, this may affect performance).
+ *
+ * <p>
+ * The Histogram buckets can be configured with a {@code buckets} init parameter whose value is a
+ * comma-separated list of valid {@code double} values.
+ *
+ * <p>
+ * HTTP statuses will be aggregated via Counter. The name for this counter will be derived from the
+ * {@code metric-name} init parameter.
+ *
+ * <pre>
+ * {@code
+ * <filter>
+ *   <filter-name>prometheusFilter</filter-name>
+ *   <filter-class>io.prometheus.client.filter.MetricsFilter</filter-class>
+ *   <init-param>
+ *      <param-name>metric-name</param-name>
+ *      <param-value>webapp_metrics_filter</param-value>
+ *   </init-param>
+ *   <init-param>
+ *      <param-name>help</param-name>
+ *      <param-value>The time taken fulfilling servlet requests</param-value>
+ *   </init-param>
+ *   <init-param>
+ *      <param-name>buckets</param-name>
+ *      <param-value>0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10</param-value>
+ *   </init-param>
+ *   <init-param>
+ *      <param-name>path-components</param-name>
+ *      <param-value>0</param-value>
+ *   </init-param>
+ * </filter>
+ * }
+ * </pre>
+ *
+ * @author Andrew Stuart &lt;andrew.stuart2@gmail.com&gt;
+ */
+public class MetricsFilter implements Filter {
+	static final String PATH_COMPONENT_PARAM = "path-components";
+	static final String HELP_PARAM = "help";
+	static final String METRIC_NAME_PARAM = "metric-name";
+	static final String BUCKET_CONFIG_PARAM = "buckets";
+	static final String UNKNOWN_HTTP_STATUS_CODE = "";
+
+	private Histogram histogram = null;
+	private Counter statusCounter = null;
+
+	// Package-level for testing purposes.
+	int pathComponents = 1;
+	private String metricName = null;
+	private String help = "The time taken fulfilling servlet requests";
+	private double[] buckets = null;
+
+	public MetricsFilter() {
+	}
+
+	public MetricsFilter(String metricName, String help, Integer pathComponents, double[] buckets) {
+		this.metricName = metricName;
+		this.buckets = buckets;
+		if (help != null) {
+			this.help = help;
+		}
+		if (pathComponents != null) {
+			this.pathComponents = pathComponents;
+		}
+	}
+
+	private boolean isEmpty(String s) {
+		return s == null || s.length() == 0;
+	}
+
+	private String getComponents(String str) {
+		if (str == null || pathComponents < 1) {
+			return str;
+		}
+		int count = 0;
+		int i = -1;
+		do {
+			i = str.indexOf("/", i + 1);
+			if (i < 0) {
+				// Path is longer than specified pathComponents.
+				return str;
+			}
+			count++;
+		} while (count <= pathComponents);
+
+		return str.substring(0, i);
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		Histogram.Builder builder = Histogram.build().labelNames("path", "method");
+
+		if (filterConfig == null && isEmpty(metricName)) {
+			throw new ServletException(
+					"No configuration object provided, and no metricName passed via constructor");
+		}
+
+		if (filterConfig != null) {
+			if (isEmpty(metricName)) {
+				metricName = filterConfig.getInitParameter(METRIC_NAME_PARAM);
+				if (isEmpty(metricName)) {
+					throw new ServletException("Init parameter \"" + METRIC_NAME_PARAM
+							+ "\" is required; please supply a value");
+				}
+			}
+
+			if (!isEmpty(filterConfig.getInitParameter(HELP_PARAM))) {
+				help = filterConfig.getInitParameter(HELP_PARAM);
+			}
+
+			// Allow overriding of the path "depth" to track
+			if (!isEmpty(filterConfig.getInitParameter(PATH_COMPONENT_PARAM))) {
+				pathComponents = Integer
+						.valueOf(filterConfig.getInitParameter(PATH_COMPONENT_PARAM));
+			}
+
+			// Allow users to override the default bucket configuration
+			if (!isEmpty(filterConfig.getInitParameter(BUCKET_CONFIG_PARAM))) {
+				String[] bucketParams = filterConfig.getInitParameter(BUCKET_CONFIG_PARAM)
+						.split(",");
+				buckets = new double[bucketParams.length];
+
+				for (int i = 0; i < bucketParams.length; i++) {
+					buckets[i] = Double.parseDouble(bucketParams[i]);
+				}
+			}
+		}
+
+		if (buckets != null) {
+			builder = builder.buckets(buckets);
+		}
+
+		histogram = builder.help(help).name(metricName).register();
+
+		statusCounter = Counter.build(metricName + "_status_total", "HTTP status codes of " + help)
+				.labelNames("path", "method", "status")
+				.register();
+	}
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+			FilterChain filterChain) throws IOException, ServletException {
+		if (!(servletRequest instanceof HttpServletRequest)) {
+			filterChain.doFilter(servletRequest, servletResponse);
+			return;
+		}
+
+		HttpServletRequest request = (HttpServletRequest) servletRequest;
+
+		String path = request.getRequestURI();
+
+		String components = getComponents(path);
+		String method = request.getMethod();
+		Histogram.Timer timer = histogram.labels(components, method).startTimer();
+
+		try {
+			filterChain.doFilter(servletRequest, servletResponse);
+		} finally {
+			timer.observeDuration();
+			statusCounter.labels(components, method, getStatusCode(servletResponse)).inc();
+		}
+	}
+
+	private String getStatusCode(ServletResponse servletResponse) {
+		if (!(servletResponse instanceof HttpServletResponse)) {
+			return UNKNOWN_HTTP_STATUS_CODE;
+		}
+
+		return Integer.toString(((HttpServletResponse) servletResponse).getStatus());
+	}
+
+	@Override
+	public void destroy() {
+	}
+}

--- a/simpleclient_servlet_jakarta/src/main/java/io/prometheus/client/filter/MetricsFilter.java
+++ b/simpleclient_servlet_jakarta/src/main/java/io/prometheus/client/filter/MetricsFilter.java
@@ -14,32 +14,23 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
- * The MetricsFilter class exists to provide a high-level filter that enables tunable collection of
- * metrics for Servlet performance.
+ * The MetricsFilter class exists to provide a high-level filter that enables tunable collection of metrics for Servlet
+ * performance.
  *
- * <p>
- * The metric name itself is required, and configured with a {@code metric-name} init parameter.
+ * <p>The metric name itself is required, and configured with a {@code metric-name} init parameter.
  *
- * <p>
- * The help parameter, configured with the {@code help} init parameter, is not required but strongly
- * recommended.
+ * <p>The help parameter, configured with the {@code help} init parameter, is not required but strongly recommended.
  *
- * <p>
- * By default, this filter will provide metrics that distinguish only 1 level deep for the request
- * path (including servlet context path), but can be configured with the {@code path-components}
- * init parameter. Any number provided that is less than 1 will provide the full path granularity
- * (warning, this may affect performance).
+ * <p>By default, this filter will provide metrics that distinguish only 1 level deep for the request path
+ * (including servlet context path), but can be configured with the {@code path-components} init parameter. Any number
+ * provided that is less than 1 will provide the full path granularity (warning, this may affect performance).
  *
- * <p>
- * The Histogram buckets can be configured with a {@code buckets} init parameter whose value is a
- * comma-separated list of valid {@code double} values.
+ * <p>The Histogram buckets can be configured with a {@code buckets} init parameter whose value is a comma-separated list
+ * of valid {@code double} values.
  *
- * <p>
- * HTTP statuses will be aggregated via Counter. The name for this counter will be derived from the
- * {@code metric-name} init parameter.
+ * <p>HTTP statuses will be aggregated via Counter. The name for this counter will be derived from the {@code metric-name} init parameter.
  *
- * <pre>
- * {@code
+ * <pre>{@code
  * <filter>
  *   <filter-name>prometheusFilter</filter-name>
  *   <filter-class>io.prometheus.client.filter.MetricsFilter</filter-class>
@@ -60,147 +51,150 @@ import java.io.IOException;
  *      <param-value>0</param-value>
  *   </init-param>
  * </filter>
- * }
- * </pre>
+ * }</pre>
  *
  * @author Andrew Stuart &lt;andrew.stuart2@gmail.com&gt;
  */
 public class MetricsFilter implements Filter {
-	static final String PATH_COMPONENT_PARAM = "path-components";
-	static final String HELP_PARAM = "help";
-	static final String METRIC_NAME_PARAM = "metric-name";
-	static final String BUCKET_CONFIG_PARAM = "buckets";
-	static final String UNKNOWN_HTTP_STATUS_CODE = "";
+    static final String PATH_COMPONENT_PARAM = "path-components";
+    static final String HELP_PARAM = "help";
+    static final String METRIC_NAME_PARAM = "metric-name";
+    static final String BUCKET_CONFIG_PARAM = "buckets";
+    static final String UNKNOWN_HTTP_STATUS_CODE = "";
 
-	private Histogram histogram = null;
-	private Counter statusCounter = null;
+    private Histogram histogram = null;
+    private Counter statusCounter = null;
 
-	// Package-level for testing purposes.
-	int pathComponents = 1;
-	private String metricName = null;
-	private String help = "The time taken fulfilling servlet requests";
-	private double[] buckets = null;
+    // Package-level for testing purposes.
+    int pathComponents = 1;
+    private String metricName = null;
+    private String help = "The time taken fulfilling servlet requests";
+    private double[] buckets = null;
 
-	public MetricsFilter() {
-	}
+    public MetricsFilter() {}
 
-	public MetricsFilter(String metricName, String help, Integer pathComponents, double[] buckets) {
-		this.metricName = metricName;
-		this.buckets = buckets;
-		if (help != null) {
-			this.help = help;
-		}
-		if (pathComponents != null) {
-			this.pathComponents = pathComponents;
-		}
-	}
+    public MetricsFilter(
+            String metricName,
+            String help,
+            Integer pathComponents,
+            double[] buckets) {
+        this.metricName = metricName;
+        this.buckets = buckets;
+        if (help != null) {
+            this.help = help;
+        }
+        if (pathComponents != null) {
+            this.pathComponents = pathComponents;
+        }
+    }
 
-	private boolean isEmpty(String s) {
-		return s == null || s.length() == 0;
-	}
+    private boolean isEmpty(String s) {
+        return s == null || s.length() == 0;
+    }
 
-	private String getComponents(String str) {
-		if (str == null || pathComponents < 1) {
-			return str;
-		}
-		int count = 0;
-		int i = -1;
-		do {
-			i = str.indexOf("/", i + 1);
-			if (i < 0) {
-				// Path is longer than specified pathComponents.
-				return str;
-			}
-			count++;
-		} while (count <= pathComponents);
+    private String getComponents(String str) {
+        if (str == null || pathComponents < 1) {
+            return str;
+        }
+        int count = 0;
+        int i =  -1;
+        do {
+            i = str.indexOf("/", i + 1);
+            if (i < 0) {
+                // Path is longer than specified pathComponents.
+                return str;
+            }
+            count++;
+        } while (count <= pathComponents);
 
-		return str.substring(0, i);
-	}
+        return str.substring(0, i);
+    }
 
-	@Override
-	public void init(FilterConfig filterConfig) throws ServletException {
-		Histogram.Builder builder = Histogram.build().labelNames("path", "method");
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        Histogram.Builder builder = Histogram.build()
+                .labelNames("path", "method");
 
-		if (filterConfig == null && isEmpty(metricName)) {
-			throw new ServletException(
-					"No configuration object provided, and no metricName passed via constructor");
-		}
+        if (filterConfig == null && isEmpty(metricName)) {
+            throw new ServletException("No configuration object provided, and no metricName passed via constructor");
+        }
 
-		if (filterConfig != null) {
-			if (isEmpty(metricName)) {
-				metricName = filterConfig.getInitParameter(METRIC_NAME_PARAM);
-				if (isEmpty(metricName)) {
-					throw new ServletException("Init parameter \"" + METRIC_NAME_PARAM
-							+ "\" is required; please supply a value");
-				}
-			}
+        if (filterConfig != null) {
+            if (isEmpty(metricName)) {
+                metricName = filterConfig.getInitParameter(METRIC_NAME_PARAM);
+                if (isEmpty(metricName)) {
+                    throw new ServletException("Init parameter \"" + METRIC_NAME_PARAM + "\" is required; please supply a value");
+                }
+            }
 
-			if (!isEmpty(filterConfig.getInitParameter(HELP_PARAM))) {
-				help = filterConfig.getInitParameter(HELP_PARAM);
-			}
+            if (!isEmpty(filterConfig.getInitParameter(HELP_PARAM))) {
+                help = filterConfig.getInitParameter(HELP_PARAM);
+            }
 
-			// Allow overriding of the path "depth" to track
-			if (!isEmpty(filterConfig.getInitParameter(PATH_COMPONENT_PARAM))) {
-				pathComponents = Integer
-						.valueOf(filterConfig.getInitParameter(PATH_COMPONENT_PARAM));
-			}
+            // Allow overriding of the path "depth" to track
+            if (!isEmpty(filterConfig.getInitParameter(PATH_COMPONENT_PARAM))) {
+                pathComponents = Integer.valueOf(filterConfig.getInitParameter(PATH_COMPONENT_PARAM));
+            }
 
-			// Allow users to override the default bucket configuration
-			if (!isEmpty(filterConfig.getInitParameter(BUCKET_CONFIG_PARAM))) {
-				String[] bucketParams = filterConfig.getInitParameter(BUCKET_CONFIG_PARAM)
-						.split(",");
-				buckets = new double[bucketParams.length];
+            // Allow users to override the default bucket configuration
+            if (!isEmpty(filterConfig.getInitParameter(BUCKET_CONFIG_PARAM))) {
+                String[] bucketParams = filterConfig.getInitParameter(BUCKET_CONFIG_PARAM).split(",");
+                buckets = new double[bucketParams.length];
 
-				for (int i = 0; i < bucketParams.length; i++) {
-					buckets[i] = Double.parseDouble(bucketParams[i]);
-				}
-			}
-		}
+                for (int i = 0; i < bucketParams.length; i++) {
+                    buckets[i] = Double.parseDouble(bucketParams[i]);
+                }
+            }
+        }
 
-		if (buckets != null) {
-			builder = builder.buckets(buckets);
-		}
+        if (buckets != null) {
+            builder = builder.buckets(buckets);
+        }
 
-		histogram = builder.help(help).name(metricName).register();
+        histogram = builder
+                .help(help)
+                .name(metricName)
+                .register();
 
-		statusCounter = Counter.build(metricName + "_status_total", "HTTP status codes of " + help)
-				.labelNames("path", "method", "status")
-				.register();
-	}
+        statusCounter = Counter.build(metricName + "_status_total", "HTTP status codes of " + help)
+                .labelNames("path", "method", "status")
+                .register();
+    }
 
-	@Override
-	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
-			FilterChain filterChain) throws IOException, ServletException {
-		if (!(servletRequest instanceof HttpServletRequest)) {
-			filterChain.doFilter(servletRequest, servletResponse);
-			return;
-		}
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        if (!(servletRequest instanceof HttpServletRequest)) {
+            filterChain.doFilter(servletRequest, servletResponse);
+            return;
+        }
 
-		HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
 
-		String path = request.getRequestURI();
+        String path = request.getRequestURI();
 
-		String components = getComponents(path);
-		String method = request.getMethod();
-		Histogram.Timer timer = histogram.labels(components, method).startTimer();
+        String components = getComponents(path);
+        String method = request.getMethod();
+        Histogram.Timer timer = histogram
+            .labels(components, method)
+            .startTimer();
 
-		try {
-			filterChain.doFilter(servletRequest, servletResponse);
-		} finally {
-			timer.observeDuration();
-			statusCounter.labels(components, method, getStatusCode(servletResponse)).inc();
-		}
-	}
+        try {
+            filterChain.doFilter(servletRequest, servletResponse);
+        } finally {
+            timer.observeDuration();
+            statusCounter.labels(components, method, getStatusCode(servletResponse)).inc();
+        }
+    }
 
-	private String getStatusCode(ServletResponse servletResponse) {
-		if (!(servletResponse instanceof HttpServletResponse)) {
-			return UNKNOWN_HTTP_STATUS_CODE;
-		}
+    private String getStatusCode(ServletResponse servletResponse) {
+        if (!(servletResponse instanceof HttpServletResponse)) {
+            return UNKNOWN_HTTP_STATUS_CODE;
+        }
 
-		return Integer.toString(((HttpServletResponse) servletResponse).getStatus());
-	}
+        return Integer.toString(((HttpServletResponse) servletResponse).getStatus());
+    }
 
-	@Override
-	public void destroy() {
-	}
+    @Override
+    public void destroy() {
+    }
 }

--- a/simpleclient_servlet_jakarta/src/main/java/io/prometheus/client/filter/MetricsFilter.java
+++ b/simpleclient_servlet_jakarta/src/main/java/io/prometheus/client/filter/MetricsFilter.java
@@ -3,14 +3,14 @@ package io.prometheus.client.filter;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
+++ b/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
@@ -1,0 +1,52 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.Gauge;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.UUID;
+
+public class ExampleBenchmark {
+
+    public static void main(String[] args) throws Exception {
+
+        Gauge gauge = Gauge.build().name("labels").help("foo").labelNames("bar").register();
+        for (int i = 0; i < 10000; i++) {
+            gauge.labels(UUID.randomUUID().toString()).set(Math.random());
+        }
+
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+
+        Server server = new Server(0);
+        server.setHandler(context);
+        server.start();
+        Thread.sleep(1000);
+
+        byte[] bytes = new byte[8192];
+        URL url = new URL("http", "localhost", server.getConnectors()[0].getLocalPort(), "/metrics");
+
+        long start = System.nanoTime();
+        for (int i = 0; i < 100; i++) {
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            InputStream in = connection.getInputStream();
+            try {
+                while (in.read(bytes) != -1) in.available();
+            } finally {
+                in.close();
+            }
+            connection.disconnect();
+        }
+        System.out.println(String.format("%,3d ns", System.nanoTime() - start));
+
+        server.stop();
+        server.join();
+
+    }
+
+}

--- a/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
+++ b/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
@@ -2,6 +2,7 @@ package io.prometheus.client.exporter;
 
 import io.prometheus.client.Gauge;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
@@ -27,9 +28,9 @@ public class ExampleBenchmark {
         server.setHandler(context);
         server.start();
         Thread.sleep(1000);
-
+        ServerConnector connector =  (ServerConnector) server.getConnectors()[0];
         byte[] bytes = new byte[8192];
-        URL url = new URL("http", "localhost", server.getConnectors()[0].getLocalPort(), "/metrics");
+        URL url = new URL("http", "localhost", connector.getLocalPort(), "/metrics");
 
         long start = System.nanoTime();
         for (int i = 0; i < 100; i++) {

--- a/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
+++ b/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/ExampleBenchmark.java
@@ -1,8 +1,9 @@
 package io.prometheus.client.exporter;
 
 import io.prometheus.client.Gauge;
-import org.eclipse.jetty.server.Server;
+
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
@@ -28,6 +29,7 @@ public class ExampleBenchmark {
         server.setHandler(context);
         server.start();
         Thread.sleep(1000);
+
         ServerConnector connector =  (ServerConnector) server.getConnectors()[0];
         byte[] bytes = new byte[8192];
         URL url = new URL("http", "localhost", connector.getLocalPort(), "/metrics");

--- a/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/ExampleExporter.java
+++ b/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/ExampleExporter.java
@@ -1,0 +1,34 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+import io.prometheus.client.Summary;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
+public class ExampleExporter {
+
+  static final Gauge g = Gauge.build().name("gauge").help("blah").register();
+  static final Counter c = Counter.build().name("counter").help("meh").register();
+  static final Summary s = Summary.build().name("summary").help("meh").register();
+  static final Histogram h = Histogram.build().name("histogram").help("meh").register();
+  static final Gauge l = Gauge.build().name("labels").help("blah").labelNames("l").register();
+
+  public static void main(String[] args) throws Exception {
+    Server server = new Server(1234);
+    ServletContextHandler context = new ServletContextHandler();
+    context.setContextPath("/");
+    server.setHandler(context);
+    context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+    g.set(1);
+    c.inc(2);
+    s.observe(3);
+    h.observe(4);
+    l.labels("foo").inc(5);
+    server.start();
+    server.join();
+  }
+
+}

--- a/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
+++ b/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
@@ -1,0 +1,96 @@
+package io.prometheus.client.exporter;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Gauge;
+import org.junit.Test;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MetricsServletTest {
+
+  @Test
+  public void testWriterFiltersBasedOnParameter() throws IOException, ServletException {
+    CollectorRegistry registry = new CollectorRegistry();
+    Gauge.build("a", "a help").register(registry);
+    Gauge.build("b", "a help").register(registry);
+    Gauge.build("c", "a help").register(registry);
+
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getParameterValues("name[]")).thenReturn(new String[]{"a", "b", "oneTheDoesntExist", ""});
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(resp.getWriter()).thenReturn(writer);
+
+    new MetricsServlet(registry).doGet(req, resp);
+
+    assertThat(stringWriter.toString()).contains("a 0.0");
+    assertThat(stringWriter.toString()).contains("b 0.0");
+    assertThat(stringWriter.toString()).doesNotContain("c 0.0");
+  }
+
+  @Test
+  public void testWriterIsClosedNormally() throws IOException, ServletException {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    PrintWriter writer = mock(PrintWriter.class);
+    when(resp.getWriter()).thenReturn(writer);
+    CollectorRegistry registry = new CollectorRegistry();
+    Gauge a = Gauge.build("a", "a help").register(registry);
+
+    new MetricsServlet(registry).doGet(req, resp);
+    verify(writer).close();
+  }
+
+  @Test
+  public void testWriterIsClosedOnException() throws IOException, ServletException {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    PrintWriter writer = mock(PrintWriter.class);
+    when(resp.getWriter()).thenReturn(writer);
+    doThrow(new RuntimeException()).when(writer).write(any(char[].class), anyInt(), anyInt());
+    CollectorRegistry registry = new CollectorRegistry();
+    Gauge a = Gauge.build("a", "a help").register(registry);
+
+    try {
+      new MetricsServlet(registry).doGet(req, resp);
+      fail("Exception expected");
+    } catch (Exception e) {
+    }
+
+    verify(writer).close();
+  }
+
+  @Test
+  public void testOpenMetricsNegotiated() throws IOException, ServletException {
+    CollectorRegistry registry = new CollectorRegistry();
+    Gauge.build("a", "a help").register(registry);
+
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getHeader("Accept")).thenReturn("application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1");
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(resp.getWriter()).thenReturn(writer);
+
+    new MetricsServlet(registry).doGet(req, resp);
+
+    assertThat(stringWriter.toString()).contains("a 0.0");
+    assertThat(stringWriter.toString()).contains("# EOF");
+  }
+
+}

--- a/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
+++ b/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/exporter/MetricsServletTest.java
@@ -4,9 +4,9 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
 import org.junit.Test;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
+++ b/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
@@ -1,0 +1,243 @@
+package io.prometheus.client.filter;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Enumeration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MetricsFilterTest {
+	MetricsFilter f = new MetricsFilter();
+
+	@After
+	public void clear() {
+		CollectorRegistry.defaultRegistry.clear();
+	}
+
+	@Test
+	public void init() throws Exception {
+		FilterConfig cfg = mock(FilterConfig.class);
+		when(cfg.getInitParameter(anyString())).thenReturn(null);
+
+		String metricName = "foo";
+
+		when(cfg.getInitParameter(MetricsFilter.METRIC_NAME_PARAM)).thenReturn(metricName);
+		when(cfg.getInitParameter(MetricsFilter.PATH_COMPONENT_PARAM)).thenReturn("4");
+
+		f.init(cfg);
+
+		assertEquals(f.pathComponents, 4);
+
+		HttpServletRequest req = mock(HttpServletRequest.class);
+
+		when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang/zilch/zip/nada");
+		when(req.getMethod()).thenReturn(HttpMethods.GET);
+
+		HttpServletResponse res = mock(HttpServletResponse.class);
+		FilterChain c = mock(FilterChain.class);
+
+		f.doFilter(req, res, c);
+
+		verify(c).doFilter(req, res);
+
+		final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(
+				metricName + "_count",
+				new String[] { "path", "method" },
+				new String[] { "/foo/bar/baz/bang", HttpMethods.GET });
+		assertNotNull(sampleValue);
+		assertEquals(1, sampleValue, 0.0001);
+	}
+
+	@Test
+	public void doFilter() throws Exception {
+		HttpServletRequest req = mock(HttpServletRequest.class);
+		final String path = "/foo/bar/baz/bang/zilch/zip/nada";
+
+		when(req.getRequestURI()).thenReturn(path);
+		when(req.getMethod()).thenReturn(HttpMethods.GET);
+
+		HttpServletResponse res = mock(HttpServletResponse.class);
+		FilterChain c = mock(FilterChain.class);
+
+		String name = "foo";
+		FilterConfig cfg = mock(FilterConfig.class);
+		when(cfg.getInitParameter(MetricsFilter.METRIC_NAME_PARAM)).thenReturn(name);
+		when(cfg.getInitParameter(MetricsFilter.PATH_COMPONENT_PARAM)).thenReturn("0");
+
+		f.init(cfg);
+		f.doFilter(req, res, c);
+
+		verify(c).doFilter(req, res);
+
+		final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(name + "_count",
+				new String[] { "path", "method" },
+				new String[] { path, HttpMethods.GET });
+		assertNotNull(sampleValue);
+		assertEquals(1, sampleValue, 0.0001);
+	}
+
+	@Test
+	public void testConstructor() throws Exception {
+		HttpServletRequest req = mock(HttpServletRequest.class);
+		final String path = "/foo/bar/baz/bang";
+		when(req.getRequestURI()).thenReturn(path);
+		when(req.getMethod()).thenReturn(HttpMethods.POST);
+
+		FilterChain c = mock(FilterChain.class);
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+				Thread.sleep(100);
+				return null;
+			}
+		}).when(c).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+		MetricsFilter constructed = new MetricsFilter("foobar_baz_filter_duration_seconds",
+				"Help for my filter", 0, null);
+		constructed.init(mock(FilterConfig.class));
+
+		HttpServletResponse res = mock(HttpServletResponse.class);
+		constructed.doFilter(req, res, c);
+
+		final Double sum = CollectorRegistry.defaultRegistry.getSampleValue(
+				"foobar_baz_filter_duration_seconds_sum",
+				new String[] { "path", "method" },
+				new String[] { path, HttpMethods.POST });
+		assertNotNull(sum);
+		assertEquals(0.1, sum, 0.01);
+	}
+
+	@Test
+	public void testBucketsAndName() throws Exception {
+		HttpServletRequest req = mock(HttpServletRequest.class);
+		final String path = "/foo/bar/baz/bang";
+		when(req.getRequestURI()).thenReturn(path);
+		when(req.getMethod()).thenReturn(HttpMethods.POST);
+
+		FilterChain c = mock(FilterChain.class);
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+				Thread.sleep(100);
+				return null;
+			}
+		}).when(c).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+		final String buckets = "0.01,0.05,0.1,0.15,0.25";
+		FilterConfig cfg = mock(FilterConfig.class);
+		when(cfg.getInitParameter(MetricsFilter.BUCKET_CONFIG_PARAM)).thenReturn(buckets);
+		when(cfg.getInitParameter(MetricsFilter.METRIC_NAME_PARAM)).thenReturn("foo");
+
+		HttpServletResponse res = mock(HttpServletResponse.class);
+
+		f.init(cfg);
+
+		f.doFilter(req, res, c);
+
+		final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foo_sum",
+				new String[] { "path", "method" },
+				new String[] { "/foo", HttpMethods.POST });
+		assertEquals(0.1, sum, 0.01);
+
+		final Double le05 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket",
+				new String[] { "path", "method", "le" },
+				new String[] { "/foo", HttpMethods.POST, "0.05" });
+		assertNotNull(le05);
+		assertEquals(0, le05, 0.01);
+		final Double le15 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket",
+				new String[] { "path", "method", "le" },
+				new String[] { "/foo", HttpMethods.POST, "0.15" });
+		assertNotNull(le15);
+		assertEquals(1, le15, 0.01);
+
+		final Enumeration<Collector.MetricFamilySamples> samples = CollectorRegistry.defaultRegistry
+				.metricFamilySamples();
+		Collector.MetricFamilySamples sample = null;
+		while (samples.hasMoreElements()) {
+			sample = samples.nextElement();
+			if (sample.name.equals("foo")) {
+				break;
+			}
+		}
+
+		assertNotNull(sample);
+
+		int count = 0;
+		for (Collector.MetricFamilySamples.Sample s : sample.samples) {
+			if (s.name.equals("foo_bucket")) {
+				count++;
+			}
+		}
+		// +1 because of the final le=+infinity bucket
+		assertEquals(buckets.split(",").length + 1, count);
+	}
+
+	@Test
+	public void testStatusCode() throws Exception {
+		HttpServletRequest req = mock(HttpServletRequest.class);
+		when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang");
+		when(req.getMethod()).thenReturn(HttpMethods.GET);
+
+		HttpServletResponse res = mock(HttpServletResponse.class);
+		when(res.getStatus()).thenReturn(200);
+
+		FilterChain c = mock(FilterChain.class);
+
+		MetricsFilter constructed = new MetricsFilter("foobar_filter", "Help for my filter", 2,
+				null);
+		constructed.init(mock(FilterConfig.class));
+
+		constructed.doFilter(req, res, c);
+
+		final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(
+				"foobar_filter_status_total",
+				new String[] { "path", "method", "status" },
+				new String[] { "/foo/bar", HttpMethods.GET, "200" });
+		assertNotNull(sampleValue);
+		assertEquals(1, sampleValue, 0.0001);
+	}
+
+	@Test
+	public void testStatusCodeWithNonHttpServletResponse() throws Exception {
+		HttpServletRequest req = mock(HttpServletRequest.class);
+		when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang");
+		when(req.getMethod()).thenReturn(HttpMethods.GET);
+
+		ServletResponse res = mock(ServletResponse.class);
+
+		FilterChain c = mock(FilterChain.class);
+
+		MetricsFilter constructed = new MetricsFilter("foobar_filter", "Help for my filter", 2,
+				null);
+		constructed.init(mock(FilterConfig.class));
+
+		constructed.doFilter(req, res, c);
+
+		final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(
+				"foobar_filter_status_total",
+				new String[] { "path", "method", "status" },
+				new String[] {
+						"/foo/bar",
+						HttpMethods.GET,
+						MetricsFilter.UNKNOWN_HTTP_STATUS_CODE });
+		assertNotNull(sampleValue);
+		assertEquals(1, sampleValue, 0.0001);
+	}
+}

--- a/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
+++ b/simpleclient_servlet_jakarta/src/test/java/io/prometheus/client/filter/MetricsFilterTest.java
@@ -2,16 +2,18 @@ package io.prometheus.client.filter;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
+
+import org.eclipse.jetty.http.HttpMethod;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Enumeration;
 
 import static org.junit.Assert.assertEquals;
@@ -48,7 +50,7 @@ public class MetricsFilterTest {
 		HttpServletRequest req = mock(HttpServletRequest.class);
 
 		when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang/zilch/zip/nada");
-		when(req.getMethod()).thenReturn(HttpMethods.GET);
+		when(req.getMethod()).thenReturn(HttpMethod.GET.asString());
 
 		HttpServletResponse res = mock(HttpServletResponse.class);
 		FilterChain c = mock(FilterChain.class);
@@ -60,7 +62,7 @@ public class MetricsFilterTest {
 		final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(
 				metricName + "_count",
 				new String[] { "path", "method" },
-				new String[] { "/foo/bar/baz/bang", HttpMethods.GET });
+				new String[] { "/foo/bar/baz/bang", HttpMethod.GET.asString() });
 		assertNotNull(sampleValue);
 		assertEquals(1, sampleValue, 0.0001);
 	}
@@ -71,7 +73,7 @@ public class MetricsFilterTest {
 		final String path = "/foo/bar/baz/bang/zilch/zip/nada";
 
 		when(req.getRequestURI()).thenReturn(path);
-		when(req.getMethod()).thenReturn(HttpMethods.GET);
+		when(req.getMethod()).thenReturn(HttpMethod.GET.asString());
 
 		HttpServletResponse res = mock(HttpServletResponse.class);
 		FilterChain c = mock(FilterChain.class);
@@ -88,7 +90,7 @@ public class MetricsFilterTest {
 
 		final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(name + "_count",
 				new String[] { "path", "method" },
-				new String[] { path, HttpMethods.GET });
+				new String[] { path, HttpMethod.GET.asString() });
 		assertNotNull(sampleValue);
 		assertEquals(1, sampleValue, 0.0001);
 	}
@@ -98,7 +100,7 @@ public class MetricsFilterTest {
 		HttpServletRequest req = mock(HttpServletRequest.class);
 		final String path = "/foo/bar/baz/bang";
 		when(req.getRequestURI()).thenReturn(path);
-		when(req.getMethod()).thenReturn(HttpMethods.POST);
+		when(req.getMethod()).thenReturn(HttpMethod.POST.asString());
 
 		FilterChain c = mock(FilterChain.class);
 		doAnswer(new Answer<Void>() {
@@ -119,7 +121,7 @@ public class MetricsFilterTest {
 		final Double sum = CollectorRegistry.defaultRegistry.getSampleValue(
 				"foobar_baz_filter_duration_seconds_sum",
 				new String[] { "path", "method" },
-				new String[] { path, HttpMethods.POST });
+				new String[] { path, HttpMethod.POST.asString() });
 		assertNotNull(sum);
 		assertEquals(0.1, sum, 0.01);
 	}
@@ -129,7 +131,7 @@ public class MetricsFilterTest {
 		HttpServletRequest req = mock(HttpServletRequest.class);
 		final String path = "/foo/bar/baz/bang";
 		when(req.getRequestURI()).thenReturn(path);
-		when(req.getMethod()).thenReturn(HttpMethods.POST);
+		when(req.getMethod()).thenReturn(HttpMethod.POST.asString());
 
 		FilterChain c = mock(FilterChain.class);
 		doAnswer(new Answer<Void>() {
@@ -153,17 +155,17 @@ public class MetricsFilterTest {
 
 		final Double sum = CollectorRegistry.defaultRegistry.getSampleValue("foo_sum",
 				new String[] { "path", "method" },
-				new String[] { "/foo", HttpMethods.POST });
+				new String[] { "/foo", HttpMethod.POST.asString() });
 		assertEquals(0.1, sum, 0.01);
 
 		final Double le05 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket",
 				new String[] { "path", "method", "le" },
-				new String[] { "/foo", HttpMethods.POST, "0.05" });
+				new String[] { "/foo", HttpMethod.POST.asString(), "0.05" });
 		assertNotNull(le05);
 		assertEquals(0, le05, 0.01);
 		final Double le15 = CollectorRegistry.defaultRegistry.getSampleValue("foo_bucket",
 				new String[] { "path", "method", "le" },
-				new String[] { "/foo", HttpMethods.POST, "0.15" });
+				new String[] { "/foo", HttpMethod.POST.asString(), "0.15" });
 		assertNotNull(le15);
 		assertEquals(1, le15, 0.01);
 
@@ -193,7 +195,7 @@ public class MetricsFilterTest {
 	public void testStatusCode() throws Exception {
 		HttpServletRequest req = mock(HttpServletRequest.class);
 		when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang");
-		when(req.getMethod()).thenReturn(HttpMethods.GET);
+		when(req.getMethod()).thenReturn(HttpMethod.GET.asString());
 
 		HttpServletResponse res = mock(HttpServletResponse.class);
 		when(res.getStatus()).thenReturn(200);
@@ -209,7 +211,7 @@ public class MetricsFilterTest {
 		final Double sampleValue = CollectorRegistry.defaultRegistry.getSampleValue(
 				"foobar_filter_status_total",
 				new String[] { "path", "method", "status" },
-				new String[] { "/foo/bar", HttpMethods.GET, "200" });
+				new String[] { "/foo/bar", HttpMethod.GET.asString(), "200" });
 		assertNotNull(sampleValue);
 		assertEquals(1, sampleValue, 0.0001);
 	}
@@ -218,7 +220,7 @@ public class MetricsFilterTest {
 	public void testStatusCodeWithNonHttpServletResponse() throws Exception {
 		HttpServletRequest req = mock(HttpServletRequest.class);
 		when(req.getRequestURI()).thenReturn("/foo/bar/baz/bang");
-		when(req.getMethod()).thenReturn(HttpMethods.GET);
+		when(req.getMethod()).thenReturn(HttpMethod.GET.asString());
 
 		ServletResponse res = mock(ServletResponse.class);
 
@@ -235,7 +237,7 @@ public class MetricsFilterTest {
 				new String[] { "path", "method", "status" },
 				new String[] {
 						"/foo/bar",
-						HttpMethods.GET,
+						HttpMethod.GET.asString(),
 						MetricsFilter.UNKNOWN_HTTP_STATUS_CODE });
 		assertNotNull(sampleValue);
 		assertEquals(1, sampleValue, 0.0001);


### PR DESCRIPTION
The module simpleclient_servlet_jakarta is a copy of simpleclient_servlet where javax.servlet is replaced by jakarta.servlet (real changes can be seen in the second commit)