### PR TITLE
Could io.prometheus:simpleclient_hibernate:0.10.1-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/simpleclient_hibernate/pom.xml
+++ b/simpleclient_hibernate/pom.xml
@@ -47,6 +47,20 @@
             <artifactId>hibernate-core</artifactId>
             <version>5.2.0.Final</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jta_1.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Testing -->


### PR DESCRIPTION
@fstab Hi, I am a user of project **_io.prometheus:simpleclient_hibernate:0.10.1-SNAPSHOT_**. I found that its pom file introduced **_24_** dependencies. However, among them, **_7_** libraries (**_29%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_io.prometheus:simpleclient_hibernate:0.10.1-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.apache.geronimo.specs:geronimo-jta_1.1_spec:jar:1.1.1:provided
javax.enterprise:cdi-api:jar:1.1-PFD:provided
javax.inject:javax.inject:jar:1:provided
javax.annotation:jsr250-api:jar:1.0:provided
javax.el:el-api:jar:2.2:provided
org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec:jar:1.0.0.Beta1:provided
xml-apis:xml-apis:jar:1.0.b2:provided
</code></pre>