### PR TITLE
Add "jvm_compilation_time_total" counter (CompilationMXBean.getTotalCompilationTime)

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/CompilationExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/CompilationExports.java
@@ -1,0 +1,49 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CounterMetricFamily;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.CompilationMXBean;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Exports metrics about JVM compilation.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new CompilationExports().register();
+ * }
+ * </pre>
+ * Example metrics being exported:
+ * <pre>
+ *   jvm_compilation_time{} 123432
+ * </pre>
+ */
+public class CompilationExports extends Collector {
+  private final CompilationMXBean compBean;
+
+  public CompilationExports() {
+    this(ManagementFactory.getCompilationMXBean());
+  }
+
+  public CompilationExports(CompilationMXBean compBean) {
+    this.compBean = compBean;
+  }
+
+  void addCompilationMetrics(List<MetricFamilySamples> sampleFamilies) {
+    sampleFamilies.add(new CounterMetricFamily(
+          "jvm_compilation_time_total",
+          "The total time taken for HotSpot class compilation",
+          compBean.getTotalCompilationTime() / MILLISECONDS_PER_SECOND));
+  }
+
+
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+    addCompilationMetrics(mfs);
+    return mfs;
+  }
+}

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/CompilationExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/CompilationExportsTest.java
@@ -1,0 +1,36 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.management.CompilationMXBean;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class CompilationExportsTest {
+
+  private CompilationMXBean mockCompilationsBean = Mockito.mock(CompilationMXBean.class);
+  private CollectorRegistry registry = new CollectorRegistry();
+  private CompilationExports collectorUnderTest;
+
+  private static final String[] EMPTY_LABEL = new String[0];
+
+  @Before
+  public void setUp() {
+    when(mockCompilationsBean.getTotalCompilationTime()).thenReturn(TimeUnit.SECONDS.toMillis(10));
+    collectorUnderTest = new CompilationExports(mockCompilationsBean).register(registry);
+  }
+
+  @Test
+  public void testCompilation() {
+    assertEquals(
+            10d,
+            registry.getSampleValue(
+                    "jvm_compilation_time_total", EMPTY_LABEL, EMPTY_LABEL),
+            .0000001);
+  }
+}


### PR DESCRIPTION
The subject says it all. It is one of the few missing metrics from the standard platform MBeans.