### PR TITLE
Add "jvm_memory_pool_collection_bytes_xxx" (MemoryPoolMXBean.getCollectionUsage()

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
@@ -102,6 +102,26 @@ public class MemoryPoolsExports extends Collector {
         "Initial bytes of a given JVM memory pool.",
         Collections.singletonList("pool"));
     sampleFamilies.add(init);
+    GaugeMetricFamily collectionUsed = new GaugeMetricFamily(
+        "jvm_memory_pool_collection_bytes_used",
+        "Used bytes after last collection of a given JVM memory pool.",
+        Collections.singletonList("pool"));
+    sampleFamilies.add(collectionUsed);
+    GaugeMetricFamily collectionCommitted = new GaugeMetricFamily(
+        "jvm_memory_pool_collection_bytes_committed",
+        "Committed after last collection bytes of a given JVM memory pool.",
+        Collections.singletonList("pool"));
+    sampleFamilies.add(collectionCommitted);
+    GaugeMetricFamily collectionMax = new GaugeMetricFamily(
+        "jvm_memory_pool_collection_bytes_max",
+        "Max bytes after last collection of a given JVM memory pool.",
+        Collections.singletonList("pool"));
+    sampleFamilies.add(collectionMax);
+    GaugeMetricFamily collectionInit = new GaugeMetricFamily(
+        "jvm_memory_pool_collection_bytes_init",
+        "Initial after last collection bytes of a given JVM memory pool.",
+        Collections.singletonList("pool"));
+    sampleFamilies.add(collectionInit);
     for (final MemoryPoolMXBean pool : poolBeans) {
       MemoryUsage poolUsage = pool.getUsage();
       used.addMetric(
@@ -116,6 +136,21 @@ public class MemoryPoolsExports extends Collector {
       init.addMetric(
           Collections.singletonList(pool.getName()),
           poolUsage.getInit());
+      MemoryUsage collectionPoolUsage = pool.getCollectionUsage();
+      if (collectionPoolUsage != null) {
+          collectionUsed.addMetric(
+              Collections.singletonList(pool.getName()),
+              collectionPoolUsage.getUsed());
+          collectionCommitted.addMetric(
+              Collections.singletonList(pool.getName()),
+              collectionPoolUsage.getCommitted());
+          collectionMax.addMetric(
+              Collections.singletonList(pool.getName()),
+              collectionPoolUsage.getMax());
+          collectionInit.addMetric(
+              Collections.singletonList(pool.getName()),
+              collectionPoolUsage.getInit());
+      }
     }
   }
 

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/MemoryPoolsExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/MemoryPoolsExportsTest.java
@@ -20,7 +20,9 @@ public class MemoryPoolsExportsTest {
   private MemoryPoolMXBean mockPoolsBean2 = Mockito.mock(MemoryPoolMXBean.class);
   private MemoryMXBean mockMemoryBean = Mockito.mock(MemoryMXBean.class);
   private MemoryUsage mockUsage1 = Mockito.mock(MemoryUsage.class);
+  private MemoryUsage mockCollectionUsage1 = Mockito.mock(MemoryUsage.class);
   private MemoryUsage mockUsage2 = Mockito.mock(MemoryUsage.class);
+  private MemoryUsage mockCollectionUsage2 = Mockito.mock(MemoryUsage.class);
   private List<MemoryPoolMXBean> mockList = Arrays.asList(mockPoolsBean1, mockPoolsBean2);
   private CollectorRegistry registry = new CollectorRegistry();
   private MemoryPoolsExports collectorUnderTest;
@@ -29,18 +31,28 @@ public class MemoryPoolsExportsTest {
   public void setUp() {
     when(mockPoolsBean1.getName()).thenReturn("PS Eden Space");
     when(mockPoolsBean1.getUsage()).thenReturn(mockUsage1);
+    when(mockPoolsBean1.getCollectionUsage()).thenReturn(mockCollectionUsage1);
     when(mockPoolsBean2.getName()).thenReturn("PS Old Gen");
     when(mockPoolsBean2.getUsage()).thenReturn(mockUsage2);
+    when(mockPoolsBean2.getCollectionUsage()).thenReturn(mockCollectionUsage2);
     when(mockMemoryBean.getHeapMemoryUsage()).thenReturn(mockUsage1);
     when(mockMemoryBean.getNonHeapMemoryUsage()).thenReturn(mockUsage2);
     when(mockUsage1.getUsed()).thenReturn(500000L);
     when(mockUsage1.getCommitted()).thenReturn(1000000L);
     when(mockUsage1.getMax()).thenReturn(2000000L);
     when(mockUsage1.getInit()).thenReturn(1000L);
+    when(mockCollectionUsage1.getUsed()).thenReturn(400000L);
+    when(mockCollectionUsage1.getCommitted()).thenReturn(800000L);
+    when(mockCollectionUsage1.getMax()).thenReturn(1600000L);
+    when(mockCollectionUsage1.getInit()).thenReturn(2000L);
     when(mockUsage2.getUsed()).thenReturn(10000L);
     when(mockUsage2.getCommitted()).thenReturn(20000L);
     when(mockUsage2.getMax()).thenReturn(3000000L);
     when(mockUsage2.getInit()).thenReturn(2000L);
+    when(mockCollectionUsage2.getUsed()).thenReturn(20000L);
+    when(mockCollectionUsage2.getCommitted()).thenReturn(40000L);
+    when(mockCollectionUsage2.getMax()).thenReturn(6000000L);
+    when(mockCollectionUsage2.getInit()).thenReturn(4000L);
     collectorUnderTest = new MemoryPoolsExports(mockMemoryBean, mockList).register(registry);
   }
 
@@ -75,6 +87,34 @@ public class MemoryPoolsExportsTest {
             new String[]{"PS Eden Space"}),
         .0000001);
     assertEquals(
+        400000L,
+        registry.getSampleValue(
+            "jvm_memory_pool_collection_bytes_used",
+            new String[]{"pool"},
+            new String[]{"PS Eden Space"}),
+        .0000001);
+    assertEquals(
+        800000L,
+        registry.getSampleValue(
+            "jvm_memory_pool_collection_bytes_committed",
+            new String[]{"pool"},
+            new String[]{"PS Eden Space"}),
+        .0000001);
+    assertEquals(
+        1600000L,
+        registry.getSampleValue(
+            "jvm_memory_pool_collection_bytes_max",
+            new String[]{"pool"},
+            new String[]{"PS Eden Space"}),
+        .0000001);
+    assertEquals(
+        2000L,
+        registry.getSampleValue(
+            "jvm_memory_pool_collection_bytes_init",
+            new String[]{"pool"},
+            new String[]{"PS Eden Space"}),
+        .0000001);
+    assertEquals(
         10000L,
         registry.getSampleValue(
             "jvm_memory_pool_bytes_used",
@@ -99,6 +139,34 @@ public class MemoryPoolsExportsTest {
         2000L,
         registry.getSampleValue(
             "jvm_memory_pool_bytes_init",
+            new String[]{"pool"},
+            new String[]{"PS Old Gen"}),
+        .0000001);
+    assertEquals(
+        20000L,
+        registry.getSampleValue(
+            "jvm_memory_pool_collection_bytes_used",
+            new String[]{"pool"},
+            new String[]{"PS Old Gen"}),
+        .0000001);
+    assertEquals(
+        40000L,
+        registry.getSampleValue(
+            "jvm_memory_pool_collection_bytes_committed",
+            new String[]{"pool"},
+            new String[]{"PS Old Gen"}),
+        .0000001);
+    assertEquals(
+        6000000L,
+        registry.getSampleValue(
+            "jvm_memory_pool_collection_bytes_max",
+            new String[]{"pool"},
+            new String[]{"PS Old Gen"}),
+        .0000001);
+    assertEquals(
+        4000L,
+        registry.getSampleValue(
+            "jvm_memory_pool_collection_bytes_init",
             new String[]{"pool"},
             new String[]{"PS Old Gen"}),
         .0000001);


### PR DESCRIPTION
CollectioUsage is important to efficiently track the footpoints of the memory sawtooth curve.

Signed-off-by: Rainer Jung <rainer.jung@kippdata.de>