### PR TITLE
Make HTTPMetricHandler class public

### DIFF
--- a/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
+++ b/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
@@ -58,7 +58,7 @@ public class HTTPServer {
     /**
      * Handles Metrics collections from the given registry.
      */
-    static class HTTPMetricHandler implements HttpHandler {
+    public static class HTTPMetricHandler implements HttpHandler {
         private final CollectorRegistry registry;
         private final LocalByteArray response = new LocalByteArray();
         private final static String HEALTHY_RESPONSE = "Exporter is Healthy.";


### PR DESCRIPTION
This makes the HTTPMetricHandler reusable to allow custom HTTPServer implementations.

Fixes #529

@fstab @tomwilkie This is a replacement PR for the closed https://github.com/prometheus/client_java/pull/530. The #529 issue has been closed already but having this class exposed would help me with a custom `HTTPServer` implementation. :smile: Thank you!