### PR TITLE
Add Counter.Child no-arg constructor

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -176,6 +176,10 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
     private final CounterExemplarSampler exemplarSampler;
     private final AtomicReference<Exemplar> exemplar = new AtomicReference<Exemplar>();
 
+    public Child() {
+      this(null, null);
+    }
+
     public Child(Boolean exemplarsEnabled, CounterExemplarSampler exemplarSampler) {
       this.exemplarsEnabled = exemplarsEnabled;
       this.exemplarSampler = exemplarSampler;


### PR DESCRIPTION
Fix backwards incompatible change introduced in the "exemplar commit", b76e1e95d1c8ce3141584e2a2d260519c3a6eb19

After upgrading to 0.11.0 the following no longer compiled:
```java
    private final Counter completedTaskCounter =
            Counter.build()
                   .name("foo_completed_tasks")
                   .help("The number of tasks completed.")
                   .create()
                   .setChild(new Counter.Child() {
                       @Override
                       public double get() {
                           return completedTasks.longValue();
                       }
                   });
```

The exemplars commit added a new constructor to `Counter.Child` which meant that the implicit no-arg constructor was removed.

As a work-around I've changed to `new Counter.Child(null, null)`, but this fix might save someone else from compilation errors after upgrading.

Signed-off-by: Robin Karlsson <snago86@gmail.com>