### PR TITLE
[issues/678] update pom.xml accordingly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,11 @@
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>1.4.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>2.4.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -193,8 +198,14 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.4.0</version>
                 <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/simpleclient_tracer/simpleclient_tracer_common/pom.xml
+++ b/simpleclient_tracer/simpleclient_tracer_common/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>simpleclient_tracer_common</artifactId>
   <name>Prometheus Java Span Context Supplier - Common</name>
+  <packaging>bundle</packaging>
 
   <dependencies>
   </dependencies>

--- a/simpleclient_tracer/simpleclient_tracer_otel/pom.xml
+++ b/simpleclient_tracer/simpleclient_tracer_otel/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>simpleclient_tracer_otel</artifactId>
   <name>Prometheus Java Span Context Supplier - OpenTelemetry</name>
+  <packaging>bundle</packaging>
 
   <dependencies>
     <dependency>

--- a/simpleclient_tracer/simpleclient_tracer_otel_agent/pom.xml
+++ b/simpleclient_tracer/simpleclient_tracer_otel_agent/pom.xml
@@ -10,6 +10,7 @@
 
   <artifactId>simpleclient_tracer_otel_agent</artifactId>
   <name>Prometheus Java Span Context Supplier - OpenTelemetry Agent</name>
+  <packaging>bundle</packaging>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
To address https://github.com/prometheus/client_java/issues/678 --

1. make the artifacts of name `simpleclient_tracer_*` packed as bundles
2. make the resolution of imported packages optional by default

@fstab and @tomwilkie, may I ask you maintainers to take a look?

If possible, I'm also requesting the delivery of this fix in 0.11.x asap, as the absence of must-import packages prevents the upgrade of `simpleclient` in OSGi runtime.