### PR TITLE
Prevent name conflicts and rename jvm_classes_loaded

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -48,16 +48,29 @@ public class CollectorRegistry {
    */
   public void register(Collector m) {
     List<String> names = collectorNames(m);
+    assertNoDuplicateNames(m, names);
     synchronized (namesCollectorsLock) {
       for (String name : names) {
         if (namesToCollectors.containsKey(name)) {
-          throw new IllegalArgumentException("Collector already registered that provides name: " + name);
+          throw new IllegalArgumentException("Failed to register Collector of type " + m.getClass().getSimpleName()
+                  + ": " + name + " is already in use by another Collector of type "
+                  + namesToCollectors.get(name).getClass().getSimpleName());
         }
       }
       for (String name : names) {
         namesToCollectors.put(name, m);
       }
       collectorsToNames.put(m, names);
+    }
+  }
+
+  private void assertNoDuplicateNames(Collector m, List<String> names) {
+    Set<String> uniqueNames = new HashSet<String>();
+    for (String name : names) {
+      if (!uniqueNames.add(name)) {
+        throw new IllegalArgumentException("Failed to register Collector of type " + m.getClass().getSimpleName()
+                + ": The Collector exposes the same name multiple times: " + name);
+      }
     }
   }
 

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ClassLoadingExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ClassLoadingExports.java
@@ -20,7 +20,7 @@ import java.util.List;
  * </pre>
  * Example metrics being exported:
  * <pre>
- *   jvm_classes_loaded{} 1000
+ *   jvm_classes_currently_loaded{} 1000
  *   jvm_classes_loaded_total{} 2000
  *   jvm_classes_unloaded_total{} 500
  * </pre>
@@ -38,7 +38,7 @@ public class ClassLoadingExports extends Collector {
 
   void addClassLoadingMetrics(List<MetricFamilySamples> sampleFamilies) {
     sampleFamilies.add(new GaugeMetricFamily(
-          "jvm_classes_loaded",
+          "jvm_classes_currently_loaded",
           "The number of classes that are currently loaded in the JVM",
           clBean.getLoadedClassCount()));
     sampleFamilies.add(new CounterMetricFamily(

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/ClassLoadingExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/ClassLoadingExportsTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 public class ClassLoadingExportsTest {
 
   private ClassLoadingMXBean mockClassLoadingsBean = Mockito.mock(ClassLoadingMXBean.class);
-  private CollectorRegistry registry = new CollectorRegistry();
+  private CollectorRegistry registry = new CollectorRegistry(true);
   private ClassLoadingExports collectorUnderTest;
 
   private static final String[] EMPTY_LABEL = new String[0];
@@ -31,7 +31,7 @@ public class ClassLoadingExportsTest {
     assertEquals(
             1000,
             registry.getSampleValue(
-                    "jvm_classes_loaded", EMPTY_LABEL, EMPTY_LABEL),
+                    "jvm_classes_currently_loaded", EMPTY_LABEL, EMPTY_LABEL),
             .0000001);
     assertEquals(
             2000L,


### PR DESCRIPTION
The `ClassLoadingExports` collector provides a `Gauge` named `jvm_classes_loaded` and a `Counter` named `jvm_classes_loaded_total`. This is an illegal name conflict in OpenMetrics, and this is also the root cause for https://github.com/prometheus/jmx_exporter/issues/621.

This PR renames `jvm_classes_loaded` to `jvm_classes_currently_loaded`.

**This is a breaking change. Prometheus queries referencing `jvm_classes_loaded` need to be adapted to the new name `jvm_classes_currently_loaded`.**

Moreover, the PR adds a check in `CollectorRegistry.register(Collector)` to prevent collectors with such name conflicts from being registered.

The check will be performed if the `Collector` implements `Collector.Describable`, or if `CollectorRegistry.autoDescribe` is `true` (it's `true` by default for the `CollectorRegistry.defaultRegistry` and `false` by default for custom registries).