### PR TITLE
Add an InstrumentedAppender constructor that allows passing a CollectorRegistry

### DIFF
--- a/simpleclient_logback/src/main/java/io/prometheus/client/logback/InstrumentedAppender.java
+++ b/simpleclient_logback/src/main/java/io/prometheus/client/logback/InstrumentedAppender.java
@@ -3,38 +3,46 @@ package io.prometheus.client.logback;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 
 public class InstrumentedAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
-
   public static final String COUNTER_NAME = "logback_appender_total";
   
-  private static final Counter COUNTER;
-  private static final Counter.Child TRACE_LABEL;
-  private static final Counter.Child DEBUG_LABEL;
-  private static final Counter.Child INFO_LABEL;
-  private static final Counter.Child WARN_LABEL;
-  private static final Counter.Child ERROR_LABEL;
-  
-  static {
-    COUNTER = Counter.build().name(COUNTER_NAME)
-            .help("Logback log statements at various log levels")
-            .labelNames("level")
-            .register();
-
-    TRACE_LABEL = COUNTER.labels("trace");
-    DEBUG_LABEL = COUNTER.labels("debug");
-    INFO_LABEL = COUNTER.labels("info");
-    WARN_LABEL = COUNTER.labels("warn");
-    ERROR_LABEL = COUNTER.labels("error");
-  }
+  private static final Counter defaultCounter = Counter.build().name(COUNTER_NAME)
+          .help("Logback log statements at various log levels")
+          .labelNames("level")
+          .register();
+  private final Counter.Child traceCounter;
+  private final Counter.Child debugCounter;
+  private final Counter.Child infoCounter;
+  private final Counter.Child warnCounter;
+  private final Counter.Child errorCounter;
 
   /**
    * Create a new instrumented appender using the default registry.
    */
   public InstrumentedAppender() {
+    this(defaultCounter);
   }
 
+  /**
+   * Create a new instrumented appender using the supplied registry.
+   */
+  public InstrumentedAppender(CollectorRegistry registry) {
+    this(Counter.build().name(COUNTER_NAME)
+            .help("Logback log statements at various log levels")
+            .labelNames("level")
+            .register(registry));
+  }
+
+  private InstrumentedAppender(Counter counter) {
+    this.traceCounter = counter.labels("trace");
+    this.debugCounter = counter.labels("debug");
+    this.infoCounter = counter.labels("info");
+    this.warnCounter = counter.labels("warn");
+    this.errorCounter = counter.labels("error");
+  }
 
   @Override
   public void start() {
@@ -45,19 +53,19 @@ public class InstrumentedAppender extends UnsynchronizedAppenderBase<ILoggingEve
   protected void append(ILoggingEvent event) {
     switch (event.getLevel().toInt()) {
       case Level.TRACE_INT:
-        TRACE_LABEL.inc();
+        this.traceCounter.inc();
         break;
       case Level.DEBUG_INT:
-        DEBUG_LABEL.inc();
+        this.debugCounter.inc();
         break;
       case Level.INFO_INT:
-        INFO_LABEL.inc();
+        this.infoCounter.inc();
         break;
       case Level.WARN_INT:
-        WARN_LABEL.inc();
+        this.warnCounter.inc();
         break;
       case Level.ERROR_INT:
-        ERROR_LABEL.inc();
+        this.errorCounter.inc();
         break;
       default:
         break;

--- a/simpleclient_logback/src/test/java/io/prometheus/client/logback/InstrumentedAppenderTest.java
+++ b/simpleclient_logback/src/test/java/io/prometheus/client/logback/InstrumentedAppenderTest.java
@@ -12,88 +12,86 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class InstrumentedAppenderTest {
-  public abstract static class Base {
-    CollectorRegistry registry;
-    InstrumentedAppender appender;
-    private ILoggingEvent event;
+  private CollectorRegistry registry;
+  private InstrumentedAppender appender;
+  private InstrumentedAppender defaultAppender;
+  private ILoggingEvent event;
 
-    @Before
-    public void setUp() throws Exception {
-      this.appender.start();
+  @Before
+  public void setUp() throws Exception {
+    registry = new CollectorRegistry();
 
-      this.event = mock(ILoggingEvent.class);
-    }
+    appender = new InstrumentedAppender(registry);
+    appender.start();
 
-    @Test
-    public void metersTraceEvents() throws Exception {
-      when(this.event.getLevel()).thenReturn(Level.TRACE);
+    defaultAppender = new InstrumentedAppender();
+    defaultAppender.start();
 
-      this.appender.doAppend(event);
-
-      assertEquals(1, this.getLogLevelCount("trace"));
-    }
-
-    @Test
-    public void metersDebugEvents() throws Exception {
-      when(this.event.getLevel()).thenReturn(Level.DEBUG);
-
-      this.appender.doAppend(event);
-
-      assertEquals(1, this.getLogLevelCount("debug"));
-    }
-
-    @Test
-    public void metersInfoEvents() throws Exception {
-      when(this.event.getLevel()).thenReturn(Level.INFO);
-
-      this.appender.doAppend(event);
-
-      assertEquals(1, this.getLogLevelCount("info"));
-    }
-
-    @Test
-    public void metersWarnEvents() throws Exception {
-      when(this.event.getLevel()).thenReturn(Level.WARN);
-
-      this.appender.doAppend(event);
-
-      assertEquals(1, this.getLogLevelCount("warn"));
-    }
-
-    @Test
-    public void metersErrorEvents() throws Exception {
-      when(this.event.getLevel()).thenReturn(Level.ERROR);
-
-      this.appender.doAppend(event);
-
-      assertEquals(1, this.getLogLevelCount("error"));
-    }
-
-    private int getLogLevelCount(String level) {
-      return this.registry.getSampleValue(COUNTER_NAME,
-              new String[]{"level"}, new String[]{level}).intValue();
-    }
+    event = mock(ILoggingEvent.class);
   }
 
-  public static class DefaultTest extends Base {
-    @Before
-    public void setUp() throws Exception {
-      this.registry = CollectorRegistry.defaultRegistry;
+  @Test
+  public void metersTraceEvents() throws Exception {
+    when(event.getLevel()).thenReturn(Level.TRACE);
 
-      this.appender = new InstrumentedAppender();
+    appender.doAppend(event);
+    assertEquals(1, getLogLevelCount("trace"));
 
-      super.setUp();
-    }
+    defaultAppender.doAppend(event);
+    assertEquals(1, getDefaultLogLevelCount("trace"));
   }
 
-  public static class InstanceTest extends Base {
-    @Before
-    public void setUp() throws Exception {
-      this.registry = new CollectorRegistry();
+  @Test
+  public void metersDebugEvents() throws Exception {
+    when(event.getLevel()).thenReturn(Level.DEBUG);
 
-      this.appender = new InstrumentedAppender(this.registry);
+    appender.doAppend(event);
+    assertEquals(1, getLogLevelCount("debug"));
 
-      super.setUp();
-    }
+    defaultAppender.doAppend(event);
+    assertEquals(1, getDefaultLogLevelCount("debug"));
+  }
+
+  @Test
+  public void metersInfoEvents() throws Exception {
+    when(event.getLevel()).thenReturn(Level.INFO);
+
+    appender.doAppend(event);
+    assertEquals(1, getLogLevelCount("info"));
+
+    defaultAppender.doAppend(event);
+    assertEquals(1, getDefaultLogLevelCount("info"));
+  }
+
+  @Test
+  public void metersWarnEvents() throws Exception {
+    when(event.getLevel()).thenReturn(Level.WARN);
+
+    appender.doAppend(event);
+    assertEquals(1, getLogLevelCount("warn"));
+
+    defaultAppender.doAppend(event);
+    assertEquals(1, getDefaultLogLevelCount("warn"));
+  }
+
+  @Test
+  public void metersErrorEvents() throws Exception {
+    when(event.getLevel()).thenReturn(Level.ERROR);
+
+    appender.doAppend(event);
+    assertEquals(1, getLogLevelCount("error"));
+
+    defaultAppender.doAppend(event);
+    assertEquals(1, getDefaultLogLevelCount("error"));
+  }
+
+  private int getLogLevelCount(String level) {
+    return registry.getSampleValue(COUNTER_NAME, new String[]{"level"}, new String[]{level}).intValue();
+  }
+
+  private int getDefaultLogLevelCount(String level) {
+    return CollectorRegistry.defaultRegistry
+            .getSampleValue(COUNTER_NAME, new String[]{"level"}, new String[]{level})
+            .intValue();
   }
 }

--- a/simpleclient_logback/src/test/java/io/prometheus/client/logback/InstrumentedAppenderTest.java
+++ b/simpleclient_logback/src/test/java/io/prometheus/client/logback/InstrumentedAppenderTest.java
@@ -12,65 +12,88 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class InstrumentedAppenderTest {
+  public abstract static class Base {
+    CollectorRegistry registry;
+    InstrumentedAppender appender;
+    private ILoggingEvent event;
 
-  private InstrumentedAppender appender;
-  private ILoggingEvent event;
+    @Before
+    public void setUp() throws Exception {
+      this.appender.start();
 
-  @Before
-  public void setUp() throws Exception {
-    appender = new InstrumentedAppender();
-    appender.start();
-    
-    event = mock(ILoggingEvent.class);
+      this.event = mock(ILoggingEvent.class);
+    }
+
+    @Test
+    public void metersTraceEvents() throws Exception {
+      when(this.event.getLevel()).thenReturn(Level.TRACE);
+
+      this.appender.doAppend(event);
+
+      assertEquals(1, this.getLogLevelCount("trace"));
+    }
+
+    @Test
+    public void metersDebugEvents() throws Exception {
+      when(this.event.getLevel()).thenReturn(Level.DEBUG);
+
+      this.appender.doAppend(event);
+
+      assertEquals(1, this.getLogLevelCount("debug"));
+    }
+
+    @Test
+    public void metersInfoEvents() throws Exception {
+      when(this.event.getLevel()).thenReturn(Level.INFO);
+
+      this.appender.doAppend(event);
+
+      assertEquals(1, this.getLogLevelCount("info"));
+    }
+
+    @Test
+    public void metersWarnEvents() throws Exception {
+      when(this.event.getLevel()).thenReturn(Level.WARN);
+
+      this.appender.doAppend(event);
+
+      assertEquals(1, this.getLogLevelCount("warn"));
+    }
+
+    @Test
+    public void metersErrorEvents() throws Exception {
+      when(this.event.getLevel()).thenReturn(Level.ERROR);
+
+      this.appender.doAppend(event);
+
+      assertEquals(1, this.getLogLevelCount("error"));
+    }
+
+    private int getLogLevelCount(String level) {
+      return this.registry.getSampleValue(COUNTER_NAME,
+              new String[]{"level"}, new String[]{level}).intValue();
+    }
   }
 
-  @Test
-  public void metersTraceEvents() throws Exception {
-    when(event.getLevel()).thenReturn(Level.TRACE);
+  public static class DefaultTest extends Base {
+    @Before
+    public void setUp() throws Exception {
+      this.registry = CollectorRegistry.defaultRegistry;
 
-    appender.doAppend(event);
+      this.appender = new InstrumentedAppender();
 
-    assertEquals(1, getLogLevelCount("trace"));
+      super.setUp();
+    }
   }
 
-  @Test
-  public void metersDebugEvents() throws Exception {
-    when(event.getLevel()).thenReturn(Level.DEBUG);
+  public static class InstanceTest extends Base {
+    @Before
+    public void setUp() throws Exception {
+      this.registry = new CollectorRegistry();
 
-    appender.doAppend(event);
+      this.appender = new InstrumentedAppender(this.registry);
 
-    assertEquals(1, getLogLevelCount("debug"));
-  }
-
-  @Test
-  public void metersInfoEvents() throws Exception {
-    when(event.getLevel()).thenReturn(Level.INFO);
-
-    appender.doAppend(event);
-
-    assertEquals(1, getLogLevelCount("info"));
-  }
-
-  @Test
-  public void metersWarnEvents() throws Exception {
-    when(event.getLevel()).thenReturn(Level.WARN);
-
-    appender.doAppend(event);
-
-    assertEquals(1, getLogLevelCount("warn"));
-  }
-
-  @Test
-  public void metersErrorEvents() throws Exception {
-    when(event.getLevel()).thenReturn(Level.ERROR);
-
-    appender.doAppend(event);
-
-    assertEquals(1, getLogLevelCount("error"));
-  }
-
-  private int getLogLevelCount(String level) {
-    return CollectorRegistry.defaultRegistry.getSampleValue(COUNTER_NAME, 
-            new String[]{"level"}, new String[]{level}).intValue();
+      super.setUp();
+    }
   }
 }


### PR DESCRIPTION
I needed the functionality to create an `InstrumentedAppender` for logback which registers the metrics with a custom registry (other than the default registry). The code only supported the assumed default registry. This pull request adds a second public constructor for supplying a registry.

This pull request also abstracts the tests and runs them twice. Once for the default registry and once for a supplied registry.