### PR TITLE
Refactor HTTPMetricsHandler to have public constructors

### DIFF
--- a/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
+++ b/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java
@@ -71,11 +71,11 @@ public class HTTPServer implements Closeable {
         private final Supplier<Predicate<String>> sampleNameFilterSupplier;
         private final static String HEALTHY_RESPONSE = "Exporter is Healthy.";
 
-        HTTPMetricHandler(CollectorRegistry registry) {
+        public HTTPMetricHandler(CollectorRegistry registry) {
             this(registry, null);
         }
 
-        HTTPMetricHandler(CollectorRegistry registry, Supplier<Predicate<String>> sampleNameFilterSupplier) {
+        public HTTPMetricHandler(CollectorRegistry registry, Supplier<Predicate<String>> sampleNameFilterSupplier) {
             this.registry = registry;
             this.sampleNameFilterSupplier = sampleNameFilterSupplier;
         }


### PR DESCRIPTION
Refactored HTTPMetricsHandler to an external class to resolve https://github.com/prometheus/client_java/issues/720

Signed-off-by: Doug Hoard <doug.hoard@gmail.com>