### PR TITLE
log4j version upgrade for CVE-2021-44228

### DIFF
--- a/simpleclient_log4j2/pom.xml
+++ b/simpleclient_log4j2/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.1</version>
+            <version>2.15.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes #725
Upgrade log4j-core from 2.1 to 2.15.0