### PR TITLE
Patch for a number of CVEs Affecting Vert.x Web

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <module>simpleclient_jetty_jdk8</module>
         <module>simpleclient_tracer</module>
         <module>simpleclient_vertx</module>
+        <module>simpleclient_vertx4</module>
         <module>simpleclient_bom</module>
         <module>benchmarks</module>
         <module>integration_tests</module>

--- a/simpleclient_vertx4/pom.xml
+++ b/simpleclient_vertx4/pom.xml
@@ -20,12 +20,12 @@
         <version>0.14.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>simpleclient_vertx</artifactId>
+    <artifactId>simpleclient_vertx4</artifactId>
     <packaging>bundle</packaging>
 
-    <name>Prometheus Java Simpleclient Vert.x 3</name>
+    <name>Prometheus Java Simpleclient Vert.x 4</name>
     <description>
-        Vert.x 3 Web Handler exporter for the simpleclient.
+        Vert.x 4 Web Handler exporter for the simpleclient.
     </description>
 
     <licenses>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
-            <version>3.9.12</version>
+            <version>4.2.3</version>
             <scope>provided</scope>
         </dependency>
         <!-- Test Dependencies Follow -->

--- a/simpleclient_vertx4/src/main/java/io/prometheus/client/vertx/MetricsHandler.java
+++ b/simpleclient_vertx4/src/main/java/io/prometheus/client/vertx/MetricsHandler.java
@@ -1,0 +1,91 @@
+package io.prometheus.client.vertx;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Metrics Handler for Vert.x Web.
+ * <p>
+ * This handler will allow the usage of Prometheus Client Java API with
+ * Vert.x applications and expose a API compatible handler for the collector.
+ * <p>
+ * Usage:
+ * <p>
+ * router.route("/metrics").handler(new MetricsHandler());
+ */
+public class MetricsHandler implements Handler<RoutingContext> {
+
+  /**
+   * Wrap a Vert.x Buffer as a Writer so it can be used with
+   * TextFormat writer
+   */
+  private static class BufferWriter extends Writer {
+
+    private final Buffer buffer = Buffer.buffer();
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+      buffer.appendString(new String(cbuf, off, len));
+    }
+
+    @Override
+    public void flush() throws IOException {
+      // NO-OP
+    }
+
+    @Override
+    public void close() throws IOException {
+      // NO-OP
+    }
+
+    Buffer getBuffer() {
+      return buffer;
+    }
+  }
+
+  private CollectorRegistry registry;
+
+  /**
+   * Construct a MetricsHandler for the default registry.
+   */
+  public MetricsHandler() {
+    this(CollectorRegistry.defaultRegistry);
+  }
+
+  /**
+   * Construct a MetricsHandler for the given registry.
+   */
+  public MetricsHandler(CollectorRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public void handle(RoutingContext ctx) {
+    try {
+      final BufferWriter writer = new BufferWriter();
+      String contentType = TextFormat.chooseContentType(ctx.request().headers().get("Accept"));
+
+      TextFormat.writeFormat(contentType, writer, registry.filteredMetricFamilySamples(parse(ctx.request())));
+      ctx.response()
+              .setStatusCode(200)
+              .putHeader("Content-Type", contentType)
+              .end(writer.getBuffer());
+    } catch (IOException e) {
+      ctx.fail(e);
+    }
+  }
+
+  private Set<String> parse(HttpServerRequest request) {
+    return new HashSet(request.params().getAll("name[]"));
+  }
+}

--- a/simpleclient_vertx4/src/test/java/io/prometheus/client/vertx/ExampleExporter.java
+++ b/simpleclient_vertx4/src/test/java/io/prometheus/client/vertx/ExampleExporter.java
@@ -1,0 +1,33 @@
+package io.prometheus.client.vertx;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+import io.prometheus.client.Summary;
+import io.prometheus.client.vertx.MetricsHandler;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+
+public class ExampleExporter {
+
+  static final Gauge g = Gauge.build().name("gauge").help("blah").register();
+  static final Counter c = Counter.build().name("counter").help("meh").register();
+  static final Summary s = Summary.build().name("summary").help("meh").register();
+  static final Histogram h = Histogram.build().name("histogram").help("meh").register();
+  static final Gauge l = Gauge.build().name("labels").help("blah").labelNames("l").register();
+
+  public static void main(String[] args) throws Exception {
+    final Vertx vertx = Vertx.vertx();
+    final Router router = Router.router(vertx);
+
+    router.route("/metrics").handler(new MetricsHandler());
+
+    vertx.createHttpServer().requestHandler(router).listen(1234);
+
+    g.set(1);
+    c.inc(2);
+    s.observe(3);
+    h.observe(4);
+    l.labels("foo").inc(5);
+  }
+}

--- a/simpleclient_vertx4/src/test/java/io/prometheus/client/vertx/MetricsHandlerTest.java
+++ b/simpleclient_vertx4/src/test/java/io/prometheus/client/vertx/MetricsHandlerTest.java
@@ -1,0 +1,89 @@
+package io.prometheus.client.vertx;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Gauge;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.util.Scanner;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricsHandlerTest {
+
+  private static Vertx vertx;
+  private static Integer port;
+  private static CollectorRegistry registry;
+
+  @BeforeClass
+  public static void setUp() throws Throwable {
+    Semaphore s = new Semaphore(1);
+
+
+    vertx = Vertx.vertx();
+    final Vertx vertx = Vertx.vertx();
+    final Router router = Router.router(vertx);
+
+    registry = new CollectorRegistry();
+    router.route("/metrics").handler(new MetricsHandler(registry));
+
+    router.route("/test").handler(routingContext -> {
+      routingContext.response().putHeader("content-type", "text").end("Hello World!");
+    });
+
+    ServerSocket socket = new ServerSocket(0);
+    port = socket.getLocalPort();
+    socket.close();
+
+    s.acquire();
+    vertx.createHttpServer().requestHandler(router).listen(port,
+            event -> s.release()
+    );
+
+    s.tryAcquire(10, TimeUnit.SECONDS);
+
+    Gauge.build("a", "a help").register(registry);
+    Gauge.build("b", "b help").register(registry);
+    Gauge.build("c", "c help").register(registry);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    vertx.close();
+  }
+
+  @Test
+  public void metricsRequest_shouldReturnMetrics() throws IOException {
+    String out = makeRequest("/metrics");
+
+    assertThat(out).contains("a 0.0");
+    assertThat(out).contains("b 0.0");
+    assertThat(out).contains("c 0.0");
+  }
+
+  @Test
+  public void metricsRequest_shouldAllowFilteringMetrics() throws IOException {
+    String out = makeRequest("/metrics?name[]=b&name[]=c");
+
+    assertThat(out).doesNotContain("a 0.0");
+    assertThat(out).contains("b 0.0");
+    assertThat(out).contains("c 0.0");
+  }
+
+
+  private String makeRequest(String url) throws IOException {
+    Scanner scanner = new Scanner(new URL("http://localhost:" + port + url).openStream(), "UTF-8")
+            .useDelimiter("\\A");
+    String out = scanner.next();
+    scanner.close();
+    return out;
+  }
+}


### PR DESCRIPTION
Patches for:
* https://www.cve.org/CVERecord?id=CVE-2018-12537
* https://www.cve.org/CVERecord?id=CVE-2018-12540
* https://www.cve.org/CVERecord?id=CVE-2018-12541
* https://www.cve.org/CVERecord?id=CVE-2018-12542

Skips over:
* https://www.cve.org/CVERecord?id=CVE-2018-12544
* https://www.cve.org/CVERecord?id=CVE-2019-17640
* https://www.cve.org/CVERecord?id=CVE-2020-35217

Fixes #705