### PR TITLE
Bump log4j version to 2.17.1 to solve CVE-2021-44832

### DIFF
--- a/integration_tests/it_log4j2/pom.xml
+++ b/integration_tests/it_log4j2/pom.xml
@@ -12,7 +12,7 @@
     <name>Integration Tests - log4j2</name>
 
     <properties>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <!-- I manually tested this with log4j2.version 2.3 and Java 6, and it worked fine. -->
         <!-- <log4j2.version>2.3</log4j2.version> -->
     </properties>


### PR DESCRIPTION
Bumps log4j-core from 2.17.0 to 2.17.1