### PR TITLE
Improve shortcomings in the first iteration of CKMS

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
@@ -317,6 +317,8 @@ final class CKMSQuantiles {
             it.add(newItem);
             count++;
             item = newItem;
+            // Note that if the new value v is inserted before vi then ri increases by 1.
+            currentRank += item.g;
         }
 
         // reset buffered items to 0.
@@ -414,7 +416,14 @@ final class CKMSQuantiles {
     }
 
     /**
+     * Data class for Targeted quantile: T = {(φ_j , ε_j )}
      *
+     * Rather than requesting the same ε for all quantiles (the uniform case)
+     * or ε scaled by φ (the biased case), one might specify an arbitrary set
+     * of quantiles and the desired errors of ε for each in the form (φj , εj ).
+     * For example, input to the targeted quantiles problem might be {(0.5, 0.1), (0.2, 0.05), (0.9, 0.01)},
+     * meaning that the median should be returned with 10% error, the 20th percentile with 5% error,
+     * and the 90th percentile with 1%.
      */
     static class Quantile {
         /**
@@ -435,13 +444,6 @@ final class CKMSQuantiles {
         final double v;
 
         /**
-         * Targeted quantile: T = {(φ_j , ε_j )}
-         * Rather than requesting the same ε for all quantiles (the uniform case)
-         * or ε scaled by φ (the biased case), one might specify an arbitrary set
-         * of quantiles and the desired errors of ε for each in the form (φj , εj ).
-         * For example, input to the targeted quantiles problem might be {(0.5, 0.1), (0.2, 0.05), (0.9, 0.01)},
-         * meaning that the median should be returned with 10% error, the 20th percentile with 5% error,
-         * and the 90th percentile with 1%.
          *
          * @param quantile the quantile between 0 and 1
          * @param epsilon  the desired error for this quantile, between 0 and 1.

--- a/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
@@ -129,14 +129,10 @@ final class CKMSQuantiles {
      * @param quantiles The targeted quantiles, can be empty.
      */
     CKMSQuantiles(Quantile[] quantiles) {
-        // hard-coded epsilon of 0.1% to determine the batch size, and default epsilon in case of empty quantiles
-        double pointOnePercent = 0.001;
         if (quantiles.length == 0) { // we need at least one for this algorithm to work
-            this.quantiles = new Quantile[1];
-            this.quantiles[0] = new Quantile(0.5, pointOnePercent / 2);
-        } else {
-            this.quantiles = quantiles;
+            throw new IllegalArgumentException("quantiles cannot be empty");
         }
+        this.quantiles = quantiles;
 
         // section 5.1 Methods - Batch.
         // This is hardcoded to 500, which corresponds to an epsilon of 0.1%.
@@ -431,8 +427,8 @@ final class CKMSQuantiles {
          * @param epsilon  the desired error for this quantile, between 0 and 1.
          */
         Quantile(double quantile, double epsilon) {
-            if (quantile < 0 || quantile > 1.0) throw new IllegalArgumentException("Quantile must be between 0 and 1");
-            if (epsilon < 0 || epsilon > 1.0) throw new IllegalArgumentException("Epsilon must be between 0 and 1");
+            if (quantile <= 0 || quantile >= 1.0) throw new IllegalArgumentException("Quantile must be between 0 and 1");
+            if (epsilon <= 0 || epsilon >= 1.0) throw new IllegalArgumentException("Epsilon must be between 0 and 1");
 
             this.quantile = quantile;
             this.epsilon = epsilon;

--- a/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
@@ -180,6 +180,13 @@ final class CKMSQuantiles {
             return Double.NaN;
         }
 
+        // short-circuit min (p0) and max (p100) queries
+        if (q == 0.0) {
+            return samples.getFirst().value;
+        } else if (q == 1.0) {
+            return samples.getLast().value;
+        }
+
         // Straightforward implementation of Output(q).
         // Paper Section 3.1 on true rank: let r_i = Sum_{j=1}^{i−1} g_j
         int currentRank = 0;
@@ -200,8 +207,8 @@ final class CKMSQuantiles {
             }
         }
 
-        // edge case of wanting max value
-        return samples.getLast().value;
+        // The iterator is exhausted, return the last value.
+        return cur.value;
     }
 
     /**
@@ -328,6 +335,9 @@ final class CKMSQuantiles {
 
         ListIterator<Item> it = samples.listIterator();
 
+        // Preserve the first element (min) so that q=0.0 can be looked up
+        it.next();
+
         Item prev;
         Item next = it.next();
 
@@ -427,7 +437,7 @@ final class CKMSQuantiles {
          * @param epsilon  the desired error for this quantile, between 0 and 1.
          */
         Quantile(double quantile, double epsilon) {
-            if (quantile <= 0 || quantile >= 1.0) throw new IllegalArgumentException("Quantile must be between 0 and 1");
+            if (quantile < 0 || quantile > 1.0) throw new IllegalArgumentException("Quantile must be between 0 and 1");
             if (epsilon <= 0 || epsilon >= 1.0) throw new IllegalArgumentException("Epsilon must be between 0 and 1");
 
             this.quantile = quantile;

--- a/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
@@ -134,12 +134,22 @@ final class CKMSQuantiles {
         }
         this.quantiles = quantiles;
 
+
         // section 5.1 Methods - Batch.
+
         // This is hardcoded to 500, which corresponds to an epsilon of 0.1%.
-        this.insertThreshold = 500;
+        // Benchmarks showed that this size has a good performance on the Arrays.sort method used in insertBatch()
+        // Larger values grow too much in time to sort.
+        int threshold = 500;
+        for (Quantile q : quantiles) {
+            // Find a smaller threshold to cater for scenarios where this is required, e.g., large epsilon.
+            threshold = Math.min(threshold, (int) (1 / (2 * q.epsilon)));
+        }
+
+        this.insertThreshold = threshold;
 
         // create a buffer with size equal to threshold
-        this.buffer = new double[insertThreshold];
+        this.buffer = new double[threshold];
 
         // Initialize empty items
         this.samples = new LinkedList<Item>();

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -99,10 +99,10 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
     private int ageBuckets = 5;
 
     public Builder quantile(double quantile, double error) {
-      if (quantile < 0.0 || quantile > 1.0) {
+      if (quantile <= 0.0 || quantile >= 1.0) {
         throw new IllegalArgumentException("Quantile " + quantile + " invalid: Expected number between 0.0 and 1.0.");
       }
-      if (error < 0.0 || error > 1.0) {
+      if (error <= 0.0 || error >= 1.0) {
         throw new IllegalArgumentException("Error " + error + " invalid: Expected number between 0.0 and 1.0.");
       }
       quantiles.add(new Quantile(quantile, error));

--- a/simpleclient/src/test/java/io/prometheus/client/CKMSQuantilesTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CKMSQuantilesTest.java
@@ -79,12 +79,13 @@ public class CKMSQuantilesTest {
         assertTrue("sample size should be way below 1_000_000", ckms.samples.size() < 1000);
     }
 
+
     @Test
     public void testGetWithASingleQuantile() {
         List<Quantile> quantiles = new ArrayList<Quantile>();
         quantiles.add(new Quantile(0.95, 0.02));
 
-        final int elemCount = 1000000;
+        final int elemCount = 100;
         List<Double> shuffle = setupInput(elemCount);
 
         CKMSQuantiles ckms = new CKMSQuantiles(
@@ -95,8 +96,6 @@ public class CKMSQuantilesTest {
         }
         // given the linear distribution, we set the delta equal to the εn value for this quantile
         assertRank(elemCount, ckms.get(0.95), 0.95, 0.02);
-
-        assertTrue("sample size should be way below 1_000_000", ckms.samples.size() < 1000);
     }
 
     @Test
@@ -104,7 +103,7 @@ public class CKMSQuantilesTest {
         List<Quantile> quantiles = new ArrayList<Quantile>();
         quantiles.add(new Quantile(0.95, 0.02));
 
-        final int elemCount = 1000000;
+        final int elemCount = 1000;
         List<Double> shuffle = setupInput(elemCount);
 
         CKMSQuantiles ckms = new CKMSQuantiles(
@@ -116,8 +115,6 @@ public class CKMSQuantilesTest {
         // given the linear distribution, we set the delta equal to the εn value for this quantile
         assertRank(elemCount, ckms.get(0), 0.0, 0.001);
         assertRank(elemCount, ckms.get(1), 1.0, 0.001);
-
-        assertTrue("sample size should be way below 1_000_000", ckms.samples.size() < 1000);
     }
 
     private List<Double> setupInput(int elemCount) {

--- a/simpleclient/src/test/java/io/prometheus/client/CKMSQuantilesTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CKMSQuantilesTest.java
@@ -49,11 +49,12 @@ public class CKMSQuantilesTest {
     @Test
     public void testGetWithAMillionElements() {
         List<Quantile> quantiles = new ArrayList<Quantile>();
-        quantiles.add(new Quantile(0.01, 0.001));
+        quantiles.add(new Quantile(0.0, 0.001));
         quantiles.add(new Quantile(0.10, 0.01));
         quantiles.add(new Quantile(0.90, 0.001));
         quantiles.add(new Quantile(0.95, 0.02));
         quantiles.add(new Quantile(0.99, 0.001));
+        quantiles.add(new Quantile(1.0, 0.001));
 
         final int elemCount = 1000000;
         List<Double> shuffle = new ArrayList<Double>(elemCount);
@@ -70,11 +71,12 @@ public class CKMSQuantilesTest {
             ckms.insert(v);
         }
         // given the linear distribution, we set the delta equal to the εn value for this quantile
-        assertRank(elemCount, ckms.get(0.01), 0.01, 0.001);
+        assertRank(elemCount, ckms.get(0.0), 0.0, 0.001);
         assertRank(elemCount, ckms.get(0.1), 0.1, 0.01);
         assertRank(elemCount, ckms.get(0.9), 0.9, 0.001);
         assertRank(elemCount, ckms.get(0.95), 0.95, 0.02);
         assertRank(elemCount, ckms.get(0.99), 0.99, 0.001);
+        assertRank(elemCount, ckms.get(1.0), 1.0, 0.001);
 
         assertTrue("sample size should be way below 1_000_000", ckms.samples.size() < 1000);
     }


### PR DESCRIPTION
After discussion in #755 a next iteration:
- Introduce a dynamic batch size with an upper limit of 500. It looks like smaller batch size gives better results (precision) for single quantiles. 
- Skip merging the first item of the samples, to always have the real value of p0. 
- Enable the quantile to be 0 or 1, and short-circuit the get method to directly get the values for p0 and p100. 
- Fixes a bug that the pXX value was not within error bounds
