### PR TITLE
CMKSQuantiles: Remove call to Math.floor in f()

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
@@ -185,9 +185,9 @@ final class CKMSQuantiles {
             // The expected result of (2*0.01*30)/(1-0.95) is 12. The actual result is 11.99999999999999.
             // To avoid running into these types of error we add 0.00000000001 before rounding down.
             if (r >= q.quantile * n) {
-                result = (int) Math.floor(q.v * r + 0.00000000001);
+                result = (int) (q.v * r + 0.00000000001);
             } else {
-                result = (int) Math.floor(q.u * (n - r) + 0.00000000001);
+                result = (int) (q.u * (n - r) + 0.00000000001);
             }
             if (result < minResult) {
                 minResult = result;


### PR DESCRIPTION
Since we can be sure that the result is always positive, rounding down with casting to int is faster than using Math.floor while getting the same result.

Added the Benchmark to validate the change. 
```
Benchmark                            Mode  Cnt   Score   Error  Units
CKMSQuantileBenchmark.ckmsQuantileF  avgt    4  37,188 ± 6,681  ns/op
CKMSQuantileBenchmark.ckmsQuantileF  avgt    4  20,500 ± 1,054  ns/op <= Without floor()
```

This might not seem much, but f is being called almost all the time (insert, compress, get) and this 17 ns difference can add up to a significant amount. 
