### PR TITLE
CKMSQuantiles: Extract upperbound calculation to be done once per get

### DIFF
--- a/benchmarks/src/main/java/io/prometheus/client/CKMSQuantileBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/client/CKMSQuantileBenchmark.java
@@ -97,6 +97,10 @@ public class CKMSQuantileBenchmark {
             for (Double l : shuffle) {
                 ckmsQuantiles.insert(l);
             }
+            // make sure we inserted all 'hanging' samples (count % 128)
+            ckmsQuantiles.get(0);
+            // compress everything so we have a similar samples size regardless of n.
+            ckmsQuantiles.compress();
             System.out.println("Sample size is: " + ckmsQuantiles.samples.size());
         }
 

--- a/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CKMSQuantiles.java
@@ -152,11 +152,12 @@ final class CKMSQuantiles {
 
         int r = 0; // sum of g's left of the current sample
         int desiredRank = (int) Math.ceil(q * n);
+        int upperBound = desiredRank + f(desiredRank) / 2;
 
         ListIterator<Sample> iterator = samples.listIterator();
         while (iterator.hasNext()) {
             Sample sample = iterator.next();
-            if (r + sample.g + sample.delta > desiredRank + f(desiredRank) / 2) {
+            if (r + sample.g + sample.delta > upperBound) {
                 iterator.previous(); // roll back the item.next() above
                 if (iterator.hasPrevious()) {
                     Sample result = iterator.previous();


### PR DESCRIPTION
The upperbound is constant for a given quantile, and does only depend on the desired rank. 

By calculating this once we save on calculations of this "constant".

On an iterator size of 39, and 4 quantiles defined, the get is almost 5 times faster. 
```
Benchmark                                       (value)  Mode  Cnt    Score    Error  Units
CKMSQuantileBenchmark.ckmsQuantileGetBenchmark    10000  avgt    4  70,541 ±  5,932  ns/op *Inlined*
CKMSQuantileBenchmark.ckmsQuantileGetBenchmark    10000  avgt    4  340,909 ±  4,159  ns/op *current*
```
