### PR TITLE
Fix Describable returning an empty list

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -169,10 +169,15 @@ public class CollectorRegistry {
         HashSet<Collector> collectors = new HashSet<Collector>();
         synchronized (namesCollectorsLock) {
           for (Map.Entry<Collector, List<String>> entry : collectorsToNames.entrySet()) {
-            for (String name : entry.getValue()) {
-              if (sampleNameFilter.test(name)) {
-                collectors.add(entry.getKey());
-                break;
+            List<String> names = entry.getValue();
+            if (names.isEmpty()) {
+              collectors.add(entry.getKey());
+            } else {
+              for (String name : names) {
+                if (sampleNameFilter.test(name)) {
+                  collectors.add(entry.getKey());
+                  break;
+                }
               }
             }
           }

--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -168,10 +168,12 @@ public class CollectorRegistry {
       } else {
         HashSet<Collector> collectors = new HashSet<Collector>();
         synchronized (namesCollectorsLock) {
-          for (Map.Entry<String, Collector> entry : namesToCollectors.entrySet()) {
-            // Note that namesToCollectors contains keys for all combinations of suffixes (_total, _info, etc.).
-            if (sampleNameFilter.test(entry.getKey())) {
-              collectors.add(entry.getValue());
+          for (Map.Entry<Collector, List<String>> entry : collectorsToNames.entrySet()) {
+            for (String name : entry.getValue()) {
+              if (sampleNameFilter.test(name)) {
+                collectors.add(entry.getKey());
+                break;
+              }
             }
           }
         }

--- a/simpleclient/src/test/java/io/prometheus/client/EmptyDescribableTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/EmptyDescribableTest.java
@@ -1,0 +1,47 @@
+package io.prometheus.client;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class EmptyDescribableTest {
+
+    static class TestCollector extends Collector implements Collector.Describable {
+
+        private final List<MetricFamilySamples> describeResult;
+
+        TestCollector(List<MetricFamilySamples> describeResult) {
+            this.describeResult = describeResult;
+        }
+
+        @Override
+        public List<MetricFamilySamples> collect() {
+            List<String> labelNames = Arrays.asList("label1", "label2");
+            List<String> labelValues1 = Arrays.asList("a", "b");
+            List<String> labelValues2 = Arrays.asList("c", "d");
+            List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(2);
+            samples.add(new MetricFamilySamples.Sample("my_metric", labelNames, labelValues1, 1.0));
+            samples.add(new MetricFamilySamples.Sample("my_metric", labelNames, labelValues2, 2.0));
+            MetricFamilySamples mfs = new MetricFamilySamples("my_metric", "", Type.UNKNOWN, "help text", samples);
+            return Collections.singletonList(mfs);
+        }
+
+        @Override
+        public List<MetricFamilySamples> describe() {
+            return describeResult;
+        }
+    }
+
+    @Test
+    public void testEmptyDescribe() {
+        CollectorRegistry registry = new CollectorRegistry();
+        TestCollector collector = new TestCollector(new ArrayList<Collector.MetricFamilySamples>());
+        collector.register(registry);
+        Set<String> includedNames = new HashSet<String>(Collections.singletonList("my_metric"));
+        List<Collector.MetricFamilySamples> mfs = Collections.list(registry.filteredMetricFamilySamples(includedNames));
+        assertEquals(1, mfs.size());
+        assertEquals(2, mfs.get(0).samples.size());
+    }
+}


### PR DESCRIPTION
As described in #780, if a `Collector` implements `Describable`, but the `describe()` method returns an empty list, the metrics from this `Collector` will never be collected.

This PR should fix this.