### PR TITLE
Filter metrics by suffix

### DIFF
--- a/simpleclient_servlet_common/src/main/java/io/prometheus/client/servlet/common/exporter/Exporter.java
+++ b/simpleclient_servlet_common/src/main/java/io/prometheus/client/servlet/common/exporter/Exporter.java
@@ -26,6 +26,8 @@ public class Exporter {
   public static final String NAME_MUST_NOT_BE_EQUAL_TO = "name-must-not-be-equal-to";
   public static final String NAME_MUST_START_WITH = "name-must-start-with";
   public static final String NAME_MUST_NOT_START_WITH = "name-must-not-start-with";
+  public static final String NAME_MUST_END_WITH = "name-must-end-with";
+  public static final String NAME_MUST_NOT_END_WITH = "name-must-not-end-with";
 
   private CollectorRegistry registry;
   private Predicate<String> sampleNameFilter;
@@ -48,12 +50,16 @@ public class Exporter {
     List<String> excludedNames = SampleNameFilter.stringToList(servletConfig.getInitParameter(NAME_MUST_NOT_BE_EQUAL_TO));
     List<String> allowedPrefixes = SampleNameFilter.stringToList(servletConfig.getInitParameter(NAME_MUST_START_WITH));
     List<String> excludedPrefixes = SampleNameFilter.stringToList(servletConfig.getInitParameter(NAME_MUST_NOT_START_WITH));
+    List<String> allowedSuffixes = SampleNameFilter.stringToList(servletConfig.getInitParameter(NAME_MUST_END_WITH));
+    List<String> excludedSuffixes = SampleNameFilter.stringToList(servletConfig.getInitParameter(NAME_MUST_NOT_END_WITH));
     if (!allowedPrefixes.isEmpty() || !excludedPrefixes.isEmpty() || !allowedNames.isEmpty() || !excludedNames.isEmpty()) {
       SampleNameFilter filter = new SampleNameFilter.Builder()
               .nameMustBeEqualTo(allowedNames)
               .nameMustNotBeEqualTo(excludedNames)
               .nameMustStartWith(allowedPrefixes)
               .nameMustNotStartWith(excludedPrefixes)
+              .nameMustEndWith(allowedSuffixes)
+              .nameMustNotEndWith(excludedSuffixes)
               .build();
       if (this.sampleNameFilter != null) {
         this.sampleNameFilter = filter.and(this.sampleNameFilter);


### PR DESCRIPTION
Allow filtering metrics by suffix. For example, this can be used to filter out `_created` metrics.

There are different ways to configure this, depending on how you expose metrics:

## Manual creation of the HTTPServer

```java
    HTTPServer httpServer = new HTTPServer.Builder()
        .withRegistry(registry)
        .withSampleNameFilter(new SampleNameFilter.Builder()
            .nameMustNotEndWith("_created")
            .build())
        .build();
```

See `TestHTTPServer.testCreatedMetricRemoved()`.

## Exporter Servlet

```xml
    <servlet>
        <servlet-name>prometheus-exporter</servlet-name>
        <servlet-class>io.prometheus.client.servlet.jakarta.exporter.MetricsServlet</servlet-class>
        <init-param>
            <param-name>name-must-not-end-with</param-name>
            <param-value>_created</param-value>
        </init-param>
    </servlet>
```

## jmx_exporter

We are working on a new configuration file format for `jmx_exporter`, see the `new-config` branch. The new config will have a section like this:

```yaml
metricFilter:
  nameMustNotEndWith:
    - _created
```