### PR TITLE
Add MetricsFormatter to allow develops could collect metrics by their own way.

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -3,6 +3,7 @@ package io.prometheus.client;
 
 import io.prometheus.client.exemplars.Exemplar;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -27,14 +28,14 @@ public abstract class Collector {
   /**
    * Format metrics of this collector by given formatter.
    */
-  public void collect(MetricsFormatter formatter) {
+  public void collect(MetricsFormatter formatter) throws IOException {
     collect(formatter, null);
   }
 
   /**
    * Format metrics of this collector by given formatter.
    */
-  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) throws IOException {
     List<MetricFamilySamples> samples = collect(sampleNameFilter);
     formatter.format(samples);
   }

--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -167,43 +167,7 @@ public abstract class Collector {
      * we include the name without suffix here as well.
      */
     public String[] getNames() {
-      switch (type) {
-        case COUNTER:
-          return new String[]{
-                  name + "_total",
-                  name + "_created",
-                  name
-          };
-        case SUMMARY:
-          return new String[]{
-                  name + "_count",
-                  name + "_sum",
-                  name + "_created",
-                  name
-          };
-        case HISTOGRAM:
-          return new String[]{
-                  name + "_count",
-                  name + "_sum",
-                  name + "_bucket",
-                  name + "_created",
-                  name
-          };
-        case GAUGE_HISTOGRAM:
-          return new String[]{
-                  name + "_gcount",
-                  name + "_gsum",
-                  name + "_bucket",
-                  name
-          };
-        case INFO:
-          return new String[]{
-                  name + "_info",
-                  name
-          };
-        default:
-          return new String[]{name};
-      }
+      return Collector.getNames(type, name);
     }
 
 
@@ -386,6 +350,53 @@ public abstract class Collector {
       }
     }
     return new String(sanitized);
+  }
+
+  /**
+   * List of names that are reserved from collector type and collector name.
+   *
+   * @param type collector type
+   * @param name collect fullname
+   * @return
+   */
+  public static String[] getNames(Type type, String name) {
+    switch (type) {
+      case COUNTER:
+        return new String[]{
+                name + "_total",
+                name + "_created",
+                name
+        };
+      case SUMMARY:
+        return new String[]{
+                name + "_count",
+                name + "_sum",
+                name + "_created",
+                name
+        };
+      case HISTOGRAM:
+        return new String[]{
+                name + "_count",
+                name + "_sum",
+                name + "_bucket",
+                name + "_created",
+                name
+        };
+      case GAUGE_HISTOGRAM:
+        return new String[]{
+                name + "_gcount",
+                name + "_gsum",
+                name + "_bucket",
+                name
+        };
+      case INFO:
+        return new String[]{
+                name + "_info",
+                name
+        };
+      default:
+        return new String[]{name};
+    }
   }
 
   /**

--- a/simpleclient/src/main/java/io/prometheus/client/Collector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Collector.java
@@ -23,6 +23,22 @@ public abstract class Collector {
    */
   public abstract List<MetricFamilySamples> collect();
 
+
+  /**
+   * Format metrics of this collector by given formatter.
+   */
+  public void collect(MetricsFormatter formatter) {
+    collect(formatter, null);
+  }
+
+  /**
+   * Format metrics of this collector by given formatter.
+   */
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+    List<MetricFamilySamples> samples = collect(sampleNameFilter);
+    formatter.format(samples);
+  }
+
   /**
    * Like {@link #collect()}, but the result should only contain {@code MetricFamilySamples} where
    * {@code sampleNameFilter.test(name)} is {@code true} for at least one Sample name.
@@ -197,7 +213,7 @@ public abstract class Collector {
         return false;
       }
       MetricFamilySamples other = (MetricFamilySamples) obj;
-      
+
       return other.name.equals(name)
         && other.unit.equals(unit)
         && other.type.equals(type)
@@ -390,7 +406,7 @@ public abstract class Collector {
   public static String doubleToGoString(double d) {
     if (d == Double.POSITIVE_INFINITY) {
       return "+Inf";
-    } 
+    }
     if (d == Double.NEGATIVE_INFINITY) {
       return "-Inf";
     }

--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -1,5 +1,6 @@
 package io.prometheus.client;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -125,7 +126,7 @@ public class CollectorRegistry {
   /**
    * Format all the collector's metrics of this register by given formatter.
    */
-  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) throws IOException {
     Set<Collector> collectors = collectors();
     for (Collector collector : collectors) {
       collector.collect(formatter, sampleNameFilter);
@@ -135,7 +136,7 @@ public class CollectorRegistry {
   /**
    * Format all the collector's metrics of this register by given formatter.
    */
-  public void collect(MetricsFormatter formatter) {
+  public void collect(MetricsFormatter formatter) throws IOException {
     Set<Collector> collectors = collectors();
     for (Collector collector : collectors) {
       collector.collect(formatter);

--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -123,6 +123,26 @@ public class CollectorRegistry {
   }
 
   /**
+   * Format all the collector's metrics of this register by given formatter.
+   */
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+    Set<Collector> collectors = collectors();
+    for (Collector collector : collectors) {
+      collector.collect(formatter, sampleNameFilter);
+    }
+  }
+
+  /**
+   * Format all the collector's metrics of this register by given formatter.
+   */
+  public void collect(MetricsFormatter formatter) {
+    Set<Collector> collectors = collectors();
+    for (Collector collector : collectors) {
+      collector.collect(formatter);
+    }
+  }
+
+  /**
    * Enumeration of metrics of all registered collectors.
    */
   public Enumeration<Collector.MetricFamilySamples> metricFamilySamples() {

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -353,14 +353,19 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
 
   @Override
   public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
-    if (null != sampleNameFilter && sampleNameFilter.test(fullname)) {
-      if (formatter.supported(Type.COUNTER)) {
-        formatter.format(
-                new MetricsFormatter.MetricSnapshotSamples(
-                        fullname, unit, help, labelNames, Type.COUNTER, children.entrySet()));
-      } else {
-        formatter.format(this.collect());
+    if (null != sampleNameFilter) {
+      String[] names = Collector.getNames(Type.COUNTER, fullname);
+      if (!SampleNameFilter.filter(sampleNameFilter, names)) {
+        return;
       }
+    }
+
+    if (formatter.supported(Type.COUNTER)) {
+      formatter.format(
+              new MetricsFormatter.MetricSnapshotSamples(
+                      fullname, unit, help, labelNames, Type.COUNTER, children.entrySet()));
+    } else {
+      formatter.format(this.collect());
     }
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -4,6 +4,7 @@ import io.prometheus.client.exemplars.CounterExemplarSampler;
 import io.prometheus.client.exemplars.Exemplar;
 import io.prometheus.client.exemplars.ExemplarConfig;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -352,7 +353,7 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
 
 
   @Override
-  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) throws IOException {
     if (null != sampleNameFilter) {
       String[] names = Collector.getNames(Type.COUNTER, fullname);
       if (!SampleNameFilter.filter(sampleNameFilter, names)) {

--- a/simpleclient/src/main/java/io/prometheus/client/Counter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Counter.java
@@ -350,6 +350,20 @@ public class Counter extends SimpleCollector<Counter.Child> implements Collector
     return noLabelsChild.get();
   }
 
+
+  @Override
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+    if (null != sampleNameFilter && sampleNameFilter.test(fullname)) {
+      if (formatter.supported(Type.COUNTER)) {
+        formatter.format(
+                new MetricsFormatter.MetricSnapshotSamples(
+                        fullname, unit, help, labelNames, Type.COUNTER, children.entrySet()));
+      } else {
+        formatter.format(this.collect());
+      }
+    }
+  }
+
   @Override
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -1,6 +1,7 @@
 package io.prometheus.client;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -312,7 +313,7 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
 
 
   @Override
-  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) throws IOException {
     if (null != sampleNameFilter) {
       String[] names = Collector.getNames(Type.GAUGE, fullname);
       if (!SampleNameFilter.filter(sampleNameFilter, names)) {

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -313,14 +313,19 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
 
   @Override
   public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
-    if (null != sampleNameFilter && sampleNameFilter.test(fullname)) {
-      if (formatter.supported(Type.GAUGE)) {
-        formatter.format(
-                new MetricsFormatter.MetricSnapshotSamples(
-                        fullname, unit, help, labelNames, Type.GAUGE, children.entrySet()));
-      } else {
-        formatter.format(this.collect());
+    if (null != sampleNameFilter) {
+      String[] names = Collector.getNames(Type.GAUGE, fullname);
+      if (!SampleNameFilter.filter(sampleNameFilter, names)) {
+        return;
       }
+    }
+
+    if (formatter.supported(Type.GAUGE)) {
+      formatter.format(
+              new MetricsFormatter.MetricSnapshotSamples(
+                      fullname, unit, help, labelNames, Type.GAUGE, children.entrySet()));
+    } else {
+      formatter.format(this.collect());
     }
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Gauge.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Gauge.java
@@ -310,6 +310,20 @@ public class Gauge extends SimpleCollector<Gauge.Child> implements Collector.Des
     return noLabelsChild.get();
   }
 
+
+  @Override
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+    if (null != sampleNameFilter && sampleNameFilter.test(fullname)) {
+      if (formatter.supported(Type.GAUGE)) {
+        formatter.format(
+                new MetricsFormatter.MetricSnapshotSamples(
+                        fullname, unit, help, labelNames, Type.GAUGE, children.entrySet()));
+      } else {
+        formatter.format(this.collect());
+      }
+    }
+  }
+
   @Override
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>(children.size());

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -561,6 +561,19 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
   }
 
   @Override
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+    if (null != sampleNameFilter && sampleNameFilter.test(fullname)) {
+      if (formatter.supported(Type.HISTOGRAM)) {
+        formatter.format(
+                new MetricsFormatter.HistogramSnapshotSamples(
+                        fullname, unit, help, labelNames, Type.HISTOGRAM, children.entrySet(), buckets));
+      } else {
+        formatter.format(this.collect());
+      }
+    }
+  }
+
+  @Override
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
     for (Map.Entry<List<String>, Child> c : children.entrySet()) {

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -5,6 +5,7 @@ import io.prometheus.client.exemplars.ExemplarConfig;
 import io.prometheus.client.exemplars.HistogramExemplarSampler;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -561,7 +562,7 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
   }
 
   @Override
-  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) throws IOException {
     if (null != sampleNameFilter) {
       String[] names = Collector.getNames(Type.HISTOGRAM, fullname);
       if (!SampleNameFilter.filter(sampleNameFilter, names)) {

--- a/simpleclient/src/main/java/io/prometheus/client/Histogram.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Histogram.java
@@ -562,14 +562,19 @@ public class Histogram extends SimpleCollector<Histogram.Child> implements Colle
 
   @Override
   public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
-    if (null != sampleNameFilter && sampleNameFilter.test(fullname)) {
-      if (formatter.supported(Type.HISTOGRAM)) {
-        formatter.format(
-                new MetricsFormatter.HistogramSnapshotSamples(
-                        fullname, unit, help, labelNames, Type.HISTOGRAM, children.entrySet(), buckets));
-      } else {
-        formatter.format(this.collect());
+    if (null != sampleNameFilter) {
+      String[] names = Collector.getNames(Type.HISTOGRAM, fullname);
+      if (!SampleNameFilter.filter(sampleNameFilter, names)) {
+        return;
       }
+    }
+
+    if (formatter.supported(Type.HISTOGRAM)) {
+      formatter.format(
+              new MetricsFormatter.HistogramSnapshotSamples(
+                      fullname, unit, help, labelNames, Type.HISTOGRAM, children.entrySet(), buckets));
+    } else {
+      formatter.format(this.collect());
     }
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Info.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Info.java
@@ -149,14 +149,19 @@ public class Info extends SimpleCollector<Info.Child> implements Counter.Describ
 
   @Override
   public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
-    if (null != sampleNameFilter && sampleNameFilter.test(fullname)) {
-      if (formatter.supported(Type.INFO)) {
-        formatter.format(
-                new MetricsFormatter.MetricSnapshotSamples(
-                        fullname, unit, help, labelNames, Type.INFO, children.entrySet()));
-      } else {
-        formatter.format(this.collect());
+    if (null != sampleNameFilter) {
+      String[] names = Collector.getNames(Type.INFO, fullname);
+      if (!SampleNameFilter.filter(sampleNameFilter, names)) {
+        return;
       }
+    }
+
+    if (formatter.supported(Type.INFO)) {
+      formatter.format(
+              new MetricsFormatter.MetricSnapshotSamples(
+                      fullname, unit, help, labelNames, Type.INFO, children.entrySet()));
+    } else {
+      formatter.format(this.collect());
     }
   }
 

--- a/simpleclient/src/main/java/io/prometheus/client/Info.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Info.java
@@ -148,6 +148,19 @@ public class Info extends SimpleCollector<Info.Child> implements Counter.Describ
   }
 
   @Override
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+    if (null != sampleNameFilter && sampleNameFilter.test(fullname)) {
+      if (formatter.supported(Type.INFO)) {
+        formatter.format(
+                new MetricsFormatter.MetricSnapshotSamples(
+                        fullname, unit, help, labelNames, Type.INFO, children.entrySet()));
+      } else {
+        formatter.format(this.collect());
+      }
+    }
+  }
+
+  @Override
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
     for(Map.Entry<List<String>, Child> c: children.entrySet()) {

--- a/simpleclient/src/main/java/io/prometheus/client/Info.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Info.java
@@ -1,5 +1,6 @@
 package io.prometheus.client;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -148,7 +149,7 @@ public class Info extends SimpleCollector<Info.Child> implements Counter.Describ
   }
 
   @Override
-  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) throws IOException {
     if (null != sampleNameFilter) {
       String[] names = Collector.getNames(Type.INFO, fullname);
       if (!SampleNameFilter.filter(sampleNameFilter, names)) {

--- a/simpleclient/src/main/java/io/prometheus/client/MetricsFormatter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/MetricsFormatter.java
@@ -1,24 +1,38 @@
 package io.prometheus.client;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public abstract class MetricsFormatter {
 
+  private final MetricsWriter metricsWriter;
+
+  public MetricsFormatter(MetricsWriter metricsWriter) {
+    if (metricsWriter == null) {
+      throw new IllegalArgumentException();
+    }
+
+    this.metricsWriter = metricsWriter;
+  }
+
   /**
    * Format given samples.
    *
    * @param samples
+   * @throws IOException thrown by MetricsWriter
    */
-  public abstract void format(MetricSnapshotSamples samples);
+  public abstract void format(MetricSnapshotSamples samples) throws IOException;
 
   /**
    * Format given samples.
    *
    * @param mfs
+   * @throws IOException thrown by MetricsWriter
    */
-  public abstract void format(List<Collector.MetricFamilySamples> mfs);
+  public abstract void format(List<Collector.MetricFamilySamples> mfs) throws IOException;
 
   /**
    * Whether target type collect supported by MetricsFormatter#format(MetricSnapshotSamples samples)
@@ -66,6 +80,38 @@ public abstract class MetricsFormatter {
         double[] buckets) {
       super(name, unit, help, labelNames, type, children);
       this.buckets = buckets;
+    }
+  }
+
+  /**
+   * MetricsWriter for MetricsFormatter.
+   */
+  public static abstract class MetricsWriter extends Writer {
+    public void write(byte[] bytes) throws IOException {
+      this.write(bytes, 0, bytes.length);
+    }
+
+    public abstract void write(byte[] bytes, int offset, int length) throws IOException;
+
+    /**
+     * Get buffer.
+     *
+     * @param <T>
+     * @return
+     */
+    public <T> T getBuffer() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Append other writer to current.
+     *
+     * @param other
+     * @return
+     * @throws IOException
+     */
+    public MetricsWriter append(MetricsWriter other) throws IOException {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/simpleclient/src/main/java/io/prometheus/client/MetricsFormatter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/MetricsFormatter.java
@@ -1,0 +1,71 @@
+package io.prometheus.client;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class MetricsFormatter {
+
+  /**
+   * Format given samples.
+   *
+   * @param samples
+   */
+  public abstract void format(MetricSnapshotSamples samples);
+
+  /**
+   * Format given samples.
+   *
+   * @param mfs
+   */
+  public abstract void format(List<Collector.MetricFamilySamples> mfs);
+
+  /**
+   * Whether target type collect supported by MetricsFormatter#format(MetricSnapshotSamples samples)
+   * or not.
+   *
+   * @param type Collect type
+   * @return
+   */
+  public abstract boolean supported(Collector.Type type);
+
+  public static class MetricSnapshotSamples {
+    public final String name;
+    public final String unit;
+    public final String help;
+    public final List<String> labelNames;
+    public final Collector.Type type;
+    public final Set<? extends Map.Entry<List<String>, ?>> children;
+
+    public MetricSnapshotSamples(
+        String name,
+        String unit,
+        String help,
+        List<String> labelNames,
+        Collector.Type type,
+        Set<? extends Map.Entry<List<String>, ?>> children) {
+      this.name = name;
+      this.unit = unit;
+      this.type = type;
+      this.help = help;
+      this.labelNames = labelNames;
+      this.children = children;
+    }
+  }
+
+  public static class HistogramSnapshotSamples extends MetricSnapshotSamples {
+    public final double[] buckets;
+
+    public HistogramSnapshotSamples(
+        String name,
+        String unit,
+        String help,
+        List<String> labelNames,
+        Collector.Type type,
+        Set<? extends Map.Entry<List<String>, ?>> children,
+        double[] buckets) {
+      super(name, unit, help, labelNames, type, children);
+      this.buckets = buckets;
+    }
+  }
+}

--- a/simpleclient/src/main/java/io/prometheus/client/SampleNameFilter.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SampleNameFilter.java
@@ -239,4 +239,26 @@ public class SampleNameFilter implements Predicate<String> {
         }
         return filter;
     }
+
+
+    /**
+     * Helper method to determine if names passed the filter.
+     *
+     * @param filter
+     * @param names
+     * @return
+     */
+    public static boolean filter(Predicate<String> filter, String[] names) {
+        if (filter == null || names == null) {
+            return true;
+        }
+
+        for (String name : names) {
+            if (filter.test(name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -135,7 +135,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
     }
 
     /**
-     * The class JavaDoc for {@link Summary} has more information on {@link #maxAgeSeconds(long)} 
+     * The class JavaDoc for {@link Summary} has more information on {@link #maxAgeSeconds(long)}
      * @see Summary
      */
     public Builder maxAgeSeconds(long maxAgeSeconds) {
@@ -147,7 +147,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
     }
 
     /**
-     * The class JavaDoc for {@link Summary} has more information on {@link #ageBuckets(int)} 
+     * The class JavaDoc for {@link Summary} has more information on {@link #ageBuckets(int)}
      * @see Summary
      */
     public Builder ageBuckets(int ageBuckets) {
@@ -388,6 +388,19 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
    */
   public Child.Value get() {
     return noLabelsChild.get();
+  }
+
+  @Override
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+    if (null != sampleNameFilter && sampleNameFilter.test(fullname)) {
+      if (formatter.supported(Type.SUMMARY)) {
+        formatter.format(
+                new MetricsFormatter.MetricSnapshotSamples(
+                        fullname, unit, help, labelNames, Type.SUMMARY, children.entrySet()));
+      } else {
+        formatter.format(this.collect());
+      }
+    }
   }
 
   @Override

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -3,6 +3,7 @@ package io.prometheus.client;
 import io.prometheus.client.CKMSQuantiles.Quantile;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -391,7 +392,7 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
   }
 
   @Override
-  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
+  public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) throws IOException {
     if (null != sampleNameFilter) {
       String[] names = Collector.getNames(Type.SUMMARY, fullname);
       if (!SampleNameFilter.filter(sampleNameFilter, names)) {

--- a/simpleclient/src/main/java/io/prometheus/client/Summary.java
+++ b/simpleclient/src/main/java/io/prometheus/client/Summary.java
@@ -392,14 +392,19 @@ public class Summary extends SimpleCollector<Summary.Child> implements Counter.D
 
   @Override
   public void collect(MetricsFormatter formatter, Predicate<String> sampleNameFilter) {
-    if (null != sampleNameFilter && sampleNameFilter.test(fullname)) {
-      if (formatter.supported(Type.SUMMARY)) {
-        formatter.format(
-                new MetricsFormatter.MetricSnapshotSamples(
-                        fullname, unit, help, labelNames, Type.SUMMARY, children.entrySet()));
-      } else {
-        formatter.format(this.collect());
+    if (null != sampleNameFilter) {
+      String[] names = Collector.getNames(Type.SUMMARY, fullname);
+      if (!SampleNameFilter.filter(sampleNameFilter, names)) {
+        return;
       }
+    }
+
+    if (formatter.supported(Type.SUMMARY)) {
+      formatter.format(
+              new MetricsFormatter.MetricSnapshotSamples(
+                      fullname, unit, help, labelNames, Type.SUMMARY, children.entrySet()));
+    } else {
+      formatter.format(this.collect());
     }
   }
 

--- a/simpleclient/src/test/java/io/prometheus/client/MetricsFormatterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/MetricsFormatterTest.java
@@ -5,6 +5,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -23,7 +24,7 @@ public class MetricsFormatterTest {
     }
 
     @Test
-    public void testGauge() {
+    public void testGauge() throws IOException {
         Gauge gauge = Gauge.build()
                 .name("test_gauge")
                 .help("-")
@@ -32,7 +33,7 @@ public class MetricsFormatterTest {
 
         gauge.labels("value1", "value2").inc();
 
-        MetricsFormatter formatter = new MetricsFormatter() {
+        MetricsFormatter formatter = new MetricsFormatter(NOOP) {
             @Override
             public void format(MetricSnapshotSamples samples) {
                 Assert.assertNotNull(samples);
@@ -70,7 +71,7 @@ public class MetricsFormatterTest {
 
 
     @Test
-    public void testCounter() {
+    public void testCounter() throws IOException {
         Counter counter = Counter.build()
                 .name("test_counter")
                 .help("test_counter")
@@ -80,7 +81,7 @@ public class MetricsFormatterTest {
         counter.labels("value1", "value2").inc();
         counter.labels("value1", "value2").inc();
 
-        MetricsFormatter formatter = new MetricsFormatter() {
+        MetricsFormatter formatter = new MetricsFormatter(NOOP) {
             @Override
             public void format(MetricSnapshotSamples samples) {
                 Assert.assertNotNull(samples);
@@ -117,7 +118,7 @@ public class MetricsFormatterTest {
     }
 
     @Test
-    public void testInfo() {
+    public void testInfo() throws IOException {
         Info info = Info.build()
                 .name("test_info")
                 .help("test_info")
@@ -126,7 +127,7 @@ public class MetricsFormatterTest {
 
         info.labels("value1", "value2").info("name", "prometheus", "version", "0.0.1");
 
-        MetricsFormatter formatter = new MetricsFormatter() {
+        MetricsFormatter formatter = new MetricsFormatter(NOOP) {
             @Override
             public void format(MetricSnapshotSamples samples) {
                 Assert.assertNotNull(samples);
@@ -168,7 +169,7 @@ public class MetricsFormatterTest {
 
 
     @Test
-    public void testHistogram() {
+    public void testHistogram() throws IOException {
         final double[] buckets = new double[]{0.5, 0.9, 0.95, 0.99};
 
         Histogram histogram = Histogram
@@ -185,7 +186,7 @@ public class MetricsFormatterTest {
         histogram.labels("value1", "value2").observe(0.91);
 
 
-        MetricsFormatter formatter = new MetricsFormatter() {
+        MetricsFormatter formatter = new MetricsFormatter(NOOP) {
             @Override
             public void format(MetricSnapshotSamples samples) {
                 Assert.assertNotNull(samples);
@@ -229,7 +230,7 @@ public class MetricsFormatterTest {
 
 
     @Test
-    public void testSummary() {
+    public void testSummary() throws IOException {
         Summary summary = Summary
                 .build("test_summary", "test_summary")
                 .quantile(0.5, 0.05)
@@ -242,7 +243,7 @@ public class MetricsFormatterTest {
         summary.labels("value1", "value2").observe(4);
 
 
-        MetricsFormatter formatter = new MetricsFormatter() {
+        MetricsFormatter formatter = new MetricsFormatter(NOOP) {
             @Override
             public void format(MetricSnapshotSamples samples) {
                 Assert.assertNotNull(samples);
@@ -283,7 +284,7 @@ public class MetricsFormatterTest {
 
 
     @Test
-    public void testEnum() {
+    public void testEnum() throws IOException {
         Enumeration enumeration = Enumeration
                 .build("test_summary", "test_summary")
                 .labelNames("label1", "label2")
@@ -294,7 +295,7 @@ public class MetricsFormatterTest {
         enumeration.labels("value1", "value2").state("b");
 
 
-        MetricsFormatter formatter = new MetricsFormatter() {
+        MetricsFormatter formatter = new MetricsFormatter(NOOP) {
             @Override
             public void format(MetricSnapshotSamples samples) {
                 throw new UnsupportedOperationException();
@@ -316,7 +317,7 @@ public class MetricsFormatterTest {
 
 
     @Test
-    public void testGaugeWithFilter() {
+    public void testGaugeWithFilter() throws IOException {
         Gauge gauge = Gauge.build()
                 .name("test_gauge")
                 .help("-")
@@ -325,7 +326,7 @@ public class MetricsFormatterTest {
 
         gauge.labels("value1", "value2").inc();
 
-        MetricsFormatter formatter = new MetricsFormatter() {
+        MetricsFormatter formatter = new MetricsFormatter(NOOP) {
             @Override
             public void format(MetricSnapshotSamples samples) {
                 Assert.assertNotNull(samples);
@@ -350,7 +351,7 @@ public class MetricsFormatterTest {
         });
 
         final AtomicBoolean executed = new AtomicBoolean(false);
-        MetricsFormatter formatter1 = new MetricsFormatter() {
+        MetricsFormatter formatter1 = new MetricsFormatter(NOOP) {
             @Override
             public void format(MetricSnapshotSamples samples) {
                 executed.set(true);
@@ -378,7 +379,7 @@ public class MetricsFormatterTest {
     }
 
     @Test
-    public void testCounterWithFilter() {
+    public void testCounterWithFilter() throws IOException {
         Counter counter = Counter.build()
                 .name("test_counter")
                 .help("-")
@@ -387,7 +388,7 @@ public class MetricsFormatterTest {
 
         counter.labels("value1", "value2").inc();
 
-        MetricsFormatter formatter = new MetricsFormatter() {
+        MetricsFormatter formatter = new MetricsFormatter(NOOP) {
             @Override
             public void format(MetricSnapshotSamples samples) {
                 Assert.assertNotNull(samples);
@@ -412,7 +413,7 @@ public class MetricsFormatterTest {
         });
 
         final AtomicBoolean executed = new AtomicBoolean(false);
-        MetricsFormatter formatter1 = new MetricsFormatter() {
+        MetricsFormatter formatter1 = new MetricsFormatter(NOOP) {
             @Override
             public void format(MetricSnapshotSamples samples) {
                 executed.set(true);
@@ -437,5 +438,31 @@ public class MetricsFormatterTest {
         });
 
         Assert.assertFalse(executed.get());
+    }
+
+
+    private static final MetricsFormatter.MetricsWriter NOOP = new NoopMetricsWriter();
+
+    private static class NoopMetricsWriter extends MetricsFormatter.MetricsWriter {
+
+        @Override
+        public void write(byte[] bytes, int offset, int length) throws IOException {
+            //noop
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            //noop
+        }
+
+        @Override
+        public void flush() throws IOException {
+            //noop
+        }
+
+        @Override
+        public void close() throws IOException {
+            //noop
+        }
     }
 }

--- a/simpleclient/src/test/java/io/prometheus/client/MetricsFormatterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/MetricsFormatterTest.java
@@ -1,0 +1,441 @@
+package io.prometheus.client;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class MetricsFormatterTest {
+    CollectorRegistry registry;
+
+    @Before
+    public void setup() {
+        this.registry = new CollectorRegistry();
+    }
+
+    @After
+    public void cleanup() {
+        this.registry.clear();
+    }
+
+    @Test
+    public void testGauge() {
+        Gauge gauge = Gauge.build()
+                .name("test_gauge")
+                .help("-")
+                .labelNames("label1", "label2")
+                .register(registry);
+
+        gauge.labels("value1", "value2").inc();
+
+        MetricsFormatter formatter = new MetricsFormatter() {
+            @Override
+            public void format(MetricSnapshotSamples samples) {
+                Assert.assertNotNull(samples);
+                Assert.assertEquals(samples.name, "test_gauge");
+                Assert.assertEquals(samples.help, "-");
+                Assert.assertTrue(
+                        samples.labelNames.contains("label1") && samples.labelNames.contains("label2"));
+                Assert.assertEquals(samples.type, Collector.Type.GAUGE);
+                Assert.assertEquals(samples.children.size(), 1);
+
+                for (Map.Entry<List<String>, ?> entry : samples.children) {
+                    Object v = entry.getValue();
+                    List<String> key = entry.getKey();
+                    Assert.assertEquals(key.size(), 2);
+                    Assert.assertTrue(key.contains("value1") && key.contains("value2"));
+                    Assert.assertTrue(v instanceof Gauge.Child);
+                    Gauge.Child child = (Gauge.Child) v;
+                    Assert.assertEquals(child.get(), 1.0D, .001);
+                }
+            }
+
+            @Override
+            public void format(List<Collector.MetricFamilySamples> mfs) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean supported(Collector.Type type) {
+                return true;
+            }
+        };
+
+        registry.collect(formatter);
+    }
+
+
+    @Test
+    public void testCounter() {
+        Counter counter = Counter.build()
+                .name("test_counter")
+                .help("test_counter")
+                .labelNames("label1", "label2")
+                .register(registry);
+
+        counter.labels("value1", "value2").inc();
+        counter.labels("value1", "value2").inc();
+
+        MetricsFormatter formatter = new MetricsFormatter() {
+            @Override
+            public void format(MetricSnapshotSamples samples) {
+                Assert.assertNotNull(samples);
+                Assert.assertEquals(samples.name, "test_counter");
+                Assert.assertEquals(samples.help, "test_counter");
+                Assert.assertTrue(
+                        samples.labelNames.contains("label1") && samples.labelNames.contains("label2"));
+                Assert.assertEquals(samples.type, Collector.Type.COUNTER);
+                Assert.assertEquals(samples.children.size(), 1);
+
+                for (Map.Entry<List<String>, ?> entry : samples.children) {
+                    Object v = entry.getValue();
+                    List<String> key = entry.getKey();
+                    Assert.assertEquals(key.size(), 2);
+                    Assert.assertTrue(key.contains("value1") && key.contains("value2"));
+                    Assert.assertTrue(v instanceof Counter.Child);
+                    Counter.Child child = (Counter.Child) v;
+                    Assert.assertEquals(child.get(), 2, .001);
+                }
+            }
+
+            @Override
+            public void format(List<Collector.MetricFamilySamples> mfs) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean supported(Collector.Type type) {
+                return true;
+            }
+        };
+
+        registry.collect(formatter);
+    }
+
+    @Test
+    public void testInfo() {
+        Info info = Info.build()
+                .name("test_info")
+                .help("test_info")
+                .labelNames("label1", "label2")
+                .register(registry);
+
+        info.labels("value1", "value2").info("name", "prometheus", "version", "0.0.1");
+
+        MetricsFormatter formatter = new MetricsFormatter() {
+            @Override
+            public void format(MetricSnapshotSamples samples) {
+                Assert.assertNotNull(samples);
+                Assert.assertEquals(samples.name, "test_info");
+                Assert.assertEquals(samples.help, "test_info");
+                Assert.assertTrue(
+                        samples.labelNames.contains("label1") && samples.labelNames.contains("label2"));
+                Assert.assertEquals(samples.type, Collector.Type.INFO);
+                Assert.assertEquals(samples.children.size(), 1);
+
+                for (Map.Entry<List<String>, ?> entry : samples.children) {
+                    Object v = entry.getValue();
+                    List<String> key = entry.getKey();
+
+                    Assert.assertTrue(key.contains("value1") && key.contains("value2"));
+                    Assert.assertTrue(v instanceof Info.Child);
+
+                    Info.Child child = (Info.Child) v;
+                    Map<String, String> infos = child.get();
+                    Assert.assertEquals(2, infos.size());
+                    Assert.assertEquals(infos.get("name"), "prometheus");
+                    Assert.assertEquals(infos.get("version"), "0.0.1");
+                }
+            }
+
+            @Override
+            public void format(List<Collector.MetricFamilySamples> mfs) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean supported(Collector.Type type) {
+                return true;
+            }
+        };
+
+        registry.collect(formatter);
+    }
+
+
+    @Test
+    public void testHistogram() {
+        final double[] buckets = new double[]{0.5, 0.9, 0.95, 0.99};
+
+        Histogram histogram = Histogram
+                .build("test_histogram", "test_histogram")
+                .buckets(buckets)
+                .labelNames("label1", "label2")
+                .register(registry);
+
+        histogram.labels("value1", "value2").observe(0.1);
+        histogram.labels("value1", "value2").observe(0.2);
+        histogram.labels("value1", "value2").observe(0.3);
+        histogram.labels("value1", "value2").observe(0.6);
+        histogram.labels("value1", "value2").observe(0.7);
+        histogram.labels("value1", "value2").observe(0.91);
+
+
+        MetricsFormatter formatter = new MetricsFormatter() {
+            @Override
+            public void format(MetricSnapshotSamples samples) {
+                Assert.assertNotNull(samples);
+                Assert.assertEquals(samples.name, "test_histogram");
+                Assert.assertEquals(samples.help, "test_histogram");
+                Assert.assertTrue(
+                        samples.labelNames.contains("label1") && samples.labelNames.contains("label2"));
+                Assert.assertEquals(samples.type, Collector.Type.HISTOGRAM);
+                Assert.assertEquals(samples.children.size(), 1);
+                Assert.assertTrue(samples instanceof HistogramSnapshotSamples);
+                HistogramSnapshotSamples hsamples = (HistogramSnapshotSamples) samples;
+                Assert.assertArrayEquals(hsamples.buckets, new double[]{0.5, 0.9, 0.95, 0.99, Double.POSITIVE_INFINITY}, 0.0);
+
+                for (Map.Entry<List<String>, ?> entry : hsamples.children) {
+                    Object v = entry.getValue();
+                    List<String> key = entry.getKey();
+
+                    Assert.assertTrue(key.contains("value1") && key.contains("value2"));
+                    Assert.assertTrue(v instanceof Histogram.Child);
+                    Histogram.Child child = (Histogram.Child) v;
+                    Histogram.Child.Value value = child.get();
+                    double[] valueBuckets = value.buckets;
+                    Assert.assertEquals(value.sum, 0.1 + 0.2 + 0.3 + 0.6 + 0.7 + 0.91, .001);
+                    Assert.assertEquals(valueBuckets[0], 3, .001);
+                }
+            }
+
+            @Override
+            public void format(List<Collector.MetricFamilySamples> mfs) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean supported(Collector.Type type) {
+                return true;
+            }
+        };
+
+        registry.collect(formatter);
+    }
+
+
+    @Test
+    public void testSummary() {
+        Summary summary = Summary
+                .build("test_summary", "test_summary")
+                .quantile(0.5, 0.05)
+                .quantile(0.9, 0.01)
+                .quantile(0.99, 0.001)
+                .labelNames("label1", "label2")
+                .register(registry);
+
+        summary.labels("value1", "value2").observe(2);
+        summary.labels("value1", "value2").observe(4);
+
+
+        MetricsFormatter formatter = new MetricsFormatter() {
+            @Override
+            public void format(MetricSnapshotSamples samples) {
+                Assert.assertNotNull(samples);
+                Assert.assertEquals(samples.name, "test_summary");
+                Assert.assertEquals(samples.help, "test_summary");
+                Assert.assertTrue(
+                        samples.labelNames.contains("label1") && samples.labelNames.contains("label2"));
+                Assert.assertEquals(samples.type, Collector.Type.SUMMARY);
+                Assert.assertEquals(samples.children.size(), 1);
+
+                for (Map.Entry<List<String>, ?> entry : samples.children) {
+                    Object v = entry.getValue();
+                    List<String> key = entry.getKey();
+
+                    Assert.assertTrue(key.contains("value1") && key.contains("value2"));
+                    Assert.assertTrue(v instanceof Summary.Child);
+                    Summary.Child child = (Summary.Child) v;
+                    Summary.Child.Value value = child.get();
+
+                    Assert.assertEquals(value.sum, 6, .001);
+                    Assert.assertEquals(value.count, 2, .001);
+                }
+            }
+
+            @Override
+            public void format(List<Collector.MetricFamilySamples> mfs) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean supported(Collector.Type type) {
+                return true;
+            }
+        };
+
+        registry.collect(formatter);
+    }
+
+
+    @Test
+    public void testEnum() {
+        Enumeration enumeration = Enumeration
+                .build("test_summary", "test_summary")
+                .labelNames("label1", "label2")
+                .states("a", "b", "c", "d")
+                .register(registry);
+
+        enumeration.labels("value1", "value2").state("a");
+        enumeration.labels("value1", "value2").state("b");
+
+
+        MetricsFormatter formatter = new MetricsFormatter() {
+            @Override
+            public void format(MetricSnapshotSamples samples) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void format(List<Collector.MetricFamilySamples> mfs) {
+                Assert.assertNotNull(mfs);
+            }
+
+            @Override
+            public boolean supported(Collector.Type type) {
+                return false;
+            }
+        };
+
+        registry.collect(formatter);
+    }
+
+
+    @Test
+    public void testGaugeWithFilter() {
+        Gauge gauge = Gauge.build()
+                .name("test_gauge")
+                .help("-")
+                .labelNames("label1", "label2")
+                .register(registry);
+
+        gauge.labels("value1", "value2").inc();
+
+        MetricsFormatter formatter = new MetricsFormatter() {
+            @Override
+            public void format(MetricSnapshotSamples samples) {
+                Assert.assertNotNull(samples);
+            }
+
+            @Override
+            public void format(List<Collector.MetricFamilySamples> mfs) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean supported(Collector.Type type) {
+                return true;
+            }
+        };
+
+        registry.collect(formatter, new Predicate<String>() {
+            @Override
+            public boolean test(String s) {
+                return s.equals("test_gauge");
+            }
+        });
+
+        final AtomicBoolean executed = new AtomicBoolean(false);
+        MetricsFormatter formatter1 = new MetricsFormatter() {
+            @Override
+            public void format(MetricSnapshotSamples samples) {
+                executed.set(true);
+            }
+
+            @Override
+            public void format(List<Collector.MetricFamilySamples> mfs) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean supported(Collector.Type type) {
+                return true;
+            }
+        };
+
+        registry.collect(formatter1, new Predicate<String>() {
+            @Override
+            public boolean test(String s) {
+                return s.equals("test_gauge_11111");
+            }
+        });
+
+        Assert.assertFalse(executed.get());
+    }
+
+    @Test
+    public void testCounterWithFilter() {
+        Counter counter = Counter.build()
+                .name("test_counter")
+                .help("-")
+                .labelNames("label1", "label2")
+                .register(registry);
+
+        counter.labels("value1", "value2").inc();
+
+        MetricsFormatter formatter = new MetricsFormatter() {
+            @Override
+            public void format(MetricSnapshotSamples samples) {
+                Assert.assertNotNull(samples);
+            }
+
+            @Override
+            public void format(List<Collector.MetricFamilySamples> mfs) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean supported(Collector.Type type) {
+                return true;
+            }
+        };
+
+        registry.collect(formatter, new Predicate<String>() {
+            @Override
+            public boolean test(String s) {
+                return s.equals("test_counter");
+            }
+        });
+
+        final AtomicBoolean executed = new AtomicBoolean(false);
+        MetricsFormatter formatter1 = new MetricsFormatter() {
+            @Override
+            public void format(MetricSnapshotSamples samples) {
+                executed.set(true);
+            }
+
+            @Override
+            public void format(List<Collector.MetricFamilySamples> mfs) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean supported(Collector.Type type) {
+                return true;
+            }
+        };
+
+        registry.collect(formatter1, new Predicate<String>() {
+            @Override
+            public boolean test(String s) {
+                return s.equals("test_counter_1111");
+            }
+        });
+
+        Assert.assertFalse(executed.get());
+    }
+}

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/BufferPoolsExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/BufferPoolsExports.java
@@ -72,7 +72,7 @@ public class BufferPoolsExports extends Collector {
 
     @Override
     public List<MetricFamilySamples> collect() {
-        return collect(null);
+        return collect((Predicate<String>) null);
     }
 
     @Override

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ClassLoadingExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ClassLoadingExports.java
@@ -67,7 +67,7 @@ public class ClassLoadingExports extends Collector {
 
   @Override
   public List<MetricFamilySamples> collect() {
-    return collect(null);
+    return collect((Predicate<String>) null);
   }
 
   @Override

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/GarbageCollectorExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/GarbageCollectorExports.java
@@ -41,7 +41,7 @@ public class GarbageCollectorExports extends Collector {
 
   @Override
   public List<MetricFamilySamples> collect() {
-    return collect(null);
+    return collect((Predicate<String>) null);
   }
 
   @Override

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/MemoryPoolsExports.java
@@ -227,7 +227,7 @@ public class MemoryPoolsExports extends Collector {
 
   @Override
   public List<MetricFamilySamples> collect() {
-    return collect(null);
+    return collect((Predicate<String>) null);
   }
 
   @Override

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -166,7 +166,7 @@ public class ThreadExports extends Collector {
 
   @Override
   public List<MetricFamilySamples> collect() {
-    return collect(null);
+    return collect((Predicate<String>) null);
   }
 
   @Override


### PR DESCRIPTION
Add MetricsFormatter to allow develops collect metrics by their own way.
For more context, you can see https://github.com/prometheus/client_java/pull/782