### PR TITLE
Move servlet adapters to an internal package to avoid duplicating classes when building OSGi bundles

### DIFF
--- a/simpleclient_servlet/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/exporter/MetricsServlet.java
@@ -1,6 +1,6 @@
 package io.prometheus.client.exporter;
 
-import io.prometheus.client.Adapter;
+import io.prometheus.client.internal.Adapter;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Predicate;
 import io.prometheus.client.servlet.common.exporter.Exporter;
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-import static io.prometheus.client.Adapter.wrap;
+import static io.prometheus.client.internal.Adapter.wrap;
 
 /**
  * The MetricsServlet class provides a simple way of exposing the metrics values.

--- a/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/filter/MetricsFilter.java
@@ -1,6 +1,6 @@
 package io.prometheus.client.filter;
 
-import io.prometheus.client.Adapter;
+import io.prometheus.client.internal.Adapter;
 import io.prometheus.client.servlet.common.filter.Filter;
 import io.prometheus.client.servlet.common.filter.FilterConfigurationException;
 

--- a/simpleclient_servlet/src/main/java/io/prometheus/client/internal/Adapter.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/internal/Adapter.java
@@ -58,7 +58,7 @@ public class Adapter {
 
         @Override
         public void setStatus(int httpStatusCode) {
-            delegate.setBufferSize(httpStatusCode);
+            delegate.setStatus(httpStatusCode);
         }
 
         @Override

--- a/simpleclient_servlet/src/main/java/io/prometheus/client/internal/Adapter.java
+++ b/simpleclient_servlet/src/main/java/io/prometheus/client/internal/Adapter.java
@@ -1,4 +1,4 @@
-package io.prometheus.client;
+package io.prometheus.client.internal;
 
 import io.prometheus.client.servlet.common.adapter.FilterConfigAdapter;
 import io.prometheus.client.servlet.common.adapter.HttpServletRequestAdapter;


### PR DESCRIPTION
This fixes #771 

OSGi requires that any particular package is exposed by only one bundle (jar). With the `Adapter` class directly in the root `io.prometheus.simpleclient` it was copying all the other classes from this particular package and so copying the classes from `simpleclient`. I've chosen `io.prometheus.simpleclient.internal` as no package named internal is exported by default in OSGi. So, in OSGi environments, this class will only be visible by `MetricsServlet` and `MetricsFilter`

I've also included a fix of a typo that was preventing the adapter class to work as expected.