### PR TITLE
Mark opentelemtry-api as optional to make it an optional dependency in OSGi

### DIFF
--- a/simpleclient_tracer/simpleclient_tracer_otel/pom.xml
+++ b/simpleclient_tracer/simpleclient_tracer_otel/pom.xml
@@ -23,6 +23,7 @@
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/simpleclient_tracer/simpleclient_tracer_otel_agent/pom.xml
+++ b/simpleclient_tracer/simpleclient_tracer_otel_agent/pom.xml
@@ -23,6 +23,7 @@
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
As the `io.opentelemetry:opentelemetry-api` has the provided scope, a user has to include this dependency to make it work.
As it's not retrieved by default, I marked it as optional in Maven to make it optional in OSGi environments.

This fixes #678