### PR TITLE
Added CompilationMXBean compilation time metric

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/CompilationExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/CompilationExports.java
@@ -1,0 +1,50 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CounterMetricFamily;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.CompilationMXBean;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Exports metrics about JVM compilation.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new CompilationExports().register();
+ * }
+ * </pre>
+ * Example metrics being exported:
+ * <pre>
+ *   jvm_compilation_time{} 123432
+ * </pre>
+ */
+public class CompilationExports extends Collector {
+
+    private final CompilationMXBean compilationMXBean;
+
+    public CompilationExports() {
+        this(ManagementFactory.getCompilationMXBean());
+    }
+
+    public CompilationExports(CompilationMXBean compilationMXBean) {
+        this.compilationMXBean = compilationMXBean;
+    }
+
+    public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>(1);
+
+        // Sanity check in the scenario that
+        if (compilationMXBean != null && compilationMXBean.isCompilationTimeMonitoringSupported()) {
+            mfs.add(new CounterMetricFamily(
+                    "jvm_compilation_time_ms_total",
+                    "The total time in ms taken for HotSpot class compilation",
+                    compilationMXBean.getTotalCompilationTime()));
+        }
+
+        return mfs;
+    }
+}

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java
@@ -16,6 +16,7 @@ import io.prometheus.client.CollectorRegistry;
  * </pre>
  */
 public class DefaultExports {
+
   private static boolean initialized = false;
 
   /**
@@ -34,14 +35,14 @@ public class DefaultExports {
    * Register the default Hotspot collectors with the given registry.
    */
   public static void register(CollectorRegistry registry) {
-    new StandardExports().register(registry);
-    new MemoryPoolsExports().register(registry);
-    new MemoryAllocationExports().register(registry);
     new BufferPoolsExports().register(registry);
-    new GarbageCollectorExports().register(registry);
-    new ThreadExports().register(registry);
     new ClassLoadingExports().register(registry);
+    new CompilationExports().register(registry);
+    new GarbageCollectorExports().register(registry);
+    new MemoryAllocationExports().register(registry);
+    new MemoryPoolsExports().register(registry);
+    new StandardExports().register(registry);
+    new ThreadExports().register(registry);
     new VersionInfoExports().register(registry);
   }
-
 }

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/CompilationExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/CompilationExportsTest.java
@@ -1,0 +1,36 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.management.CompilationMXBean;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class CompilationExportsTest {
+
+    private CompilationMXBean mockCompilationsBean = Mockito.mock(CompilationMXBean.class);
+    private CollectorRegistry registry = new CollectorRegistry();
+    private CompilationExports collectorUnderTest;
+
+    private static final String[] EMPTY_LABEL = new String[0];
+
+    @Before
+    public void setUp() {
+        when(mockCompilationsBean.getTotalCompilationTime()).thenReturn(10l);
+        when(mockCompilationsBean.isCompilationTimeMonitoringSupported()).thenReturn(true);
+        collectorUnderTest = new CompilationExports(mockCompilationsBean).register(registry);
+    }
+
+    @Test
+    public void testCompilation() {
+        assertEquals(
+                10.0,
+                registry.getSampleValue(
+                        "jvm_compilation_time_ms_total", EMPTY_LABEL, EMPTY_LABEL),
+                .0000001);
+    }
+}


### PR DESCRIPTION
Added CompilationMXBean compilation time metric in milliseconds.
Reordered registration in `DefaultExports`.

Signed-off-by: Doug Hoard <doug.hoard@gmail.com>

@fstab @rainerjung 