### PR TITLE
Added CompilationMXBean compilation time metric

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -254,4 +254,22 @@ public class CollectorRegistry {
     return null;
   }
 
+  /**
+   * Returns the given value, or null if it doesn't exist.
+   * <p>
+   * This is inefficient, and intended only for use in unittests.
+   */
+  public Double getSampleValue(String name, String[] labelNames, String[] labelValues, Predicate<String> sampleNameFilter) {
+    for (Collector.MetricFamilySamples metricFamilySamples : Collections.list(filteredMetricFamilySamples(sampleNameFilter))) {
+      for (Collector.MetricFamilySamples.Sample sample : metricFamilySamples.samples) {
+        if (sample.name.equals(name)
+                && Arrays.equals(sample.labelNames.toArray(), labelNames)
+                && Arrays.equals(sample.labelValues.toArray(), labelValues)) {
+          return sample.value;
+        }
+      }
+    }
+    return null;
+  }
+
 }

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/CompilationExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/CompilationExports.java
@@ -1,0 +1,66 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.GaugeMetricFamily;
+import io.prometheus.client.Predicate;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.CompilationMXBean;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.prometheus.client.SampleNameFilter.ALLOW_ALL;
+
+/**
+ * Exports metrics about JVM compilation.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new CompilationExports().register();
+ * }
+ * </pre>
+ * Example metrics being exported:
+ * <pre>
+ *   jvm_compilation_time_ms_total{} 123432
+ * </pre>
+ */
+public class CompilationExports extends Collector {
+
+    private static final String JVM_COMPILATION_TIME_SECONDS_TOTAL = "jvm_compilation_time_seconds_total";
+
+    private final CompilationMXBean compilationMXBean;
+
+    public CompilationExports() {
+        this(ManagementFactory.getCompilationMXBean());
+    }
+
+    public CompilationExports(CompilationMXBean compilationMXBean) {
+        this.compilationMXBean = compilationMXBean;
+    }
+
+    void addCompilationMetrics(List<MetricFamilySamples> sampleFamilies, Predicate<String> nameFilter) {
+        // Sanity check in the scenario that a JVM doesn't implement compilation time monitoring
+        if (compilationMXBean != null && compilationMXBean.isCompilationTimeMonitoringSupported()) {
+            if (nameFilter.test(JVM_COMPILATION_TIME_SECONDS_TOTAL)) {
+                sampleFamilies.add(new CounterMetricFamily(
+                        JVM_COMPILATION_TIME_SECONDS_TOTAL,
+                        "The total time in seconds taken for HotSpot class compilation",
+                        compilationMXBean.getTotalCompilationTime() / MILLISECONDS_PER_SECOND));
+            }
+        }
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        return collect(null);
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect(Predicate<String> nameFilter) {
+        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>(1);
+        addCompilationMetrics(mfs, nameFilter == null ? ALLOW_ALL : nameFilter);
+        return mfs;
+    }
+}

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java
@@ -16,6 +16,7 @@ import io.prometheus.client.CollectorRegistry;
  * </pre>
  */
 public class DefaultExports {
+
   private static boolean initialized = false;
 
   /**
@@ -34,14 +35,14 @@ public class DefaultExports {
    * Register the default Hotspot collectors with the given registry.
    */
   public static void register(CollectorRegistry registry) {
-    new StandardExports().register(registry);
-    new MemoryPoolsExports().register(registry);
-    new MemoryAllocationExports().register(registry);
     new BufferPoolsExports().register(registry);
-    new GarbageCollectorExports().register(registry);
-    new ThreadExports().register(registry);
     new ClassLoadingExports().register(registry);
+    new CompilationExports().register(registry);
+    new GarbageCollectorExports().register(registry);
+    new MemoryAllocationExports().register(registry);
+    new MemoryPoolsExports().register(registry);
+    new StandardExports().register(registry);
+    new ThreadExports().register(registry);
     new VersionInfoExports().register(registry);
   }
-
 }

--- a/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/CompilationExportsTest.java
+++ b/simpleclient_hotspot/src/test/java/io/prometheus/client/hotspot/CompilationExportsTest.java
@@ -1,0 +1,59 @@
+package io.prometheus.client.hotspot;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.SampleNameFilter;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.management.CompilationMXBean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+public class CompilationExportsTest {
+
+    private CompilationMXBean mockCompilationsBean = Mockito.mock(CompilationMXBean.class);
+    private CollectorRegistry registry = new CollectorRegistry();
+    private CompilationExports collectorUnderTest;
+
+    private static final String[] EMPTY_LABEL = new String[0];
+
+    @Before
+    public void setUp() {
+        when(mockCompilationsBean.getTotalCompilationTime()).thenReturn(10000l);
+        when(mockCompilationsBean.isCompilationTimeMonitoringSupported()).thenReturn(true);
+        collectorUnderTest = new CompilationExports(mockCompilationsBean).register(registry);
+    }
+
+    @Test
+    public void testCompilationExports() {
+        assertEquals(
+                10.0,
+                registry.getSampleValue(
+                        "jvm_compilation_time_seconds_total", EMPTY_LABEL, EMPTY_LABEL),
+                .0000001);
+    }
+
+    @Test
+    public void testCompilationExportsWithFilter() {
+        assertEquals(
+                10.0,
+                registry.getSampleValue(
+                        "jvm_compilation_time_seconds_total", EMPTY_LABEL, EMPTY_LABEL, SampleNameFilter.ALLOW_ALL),
+                .0000001);
+    }
+
+    @Test
+    public void testCompilationExportsFiltered() {
+        SampleNameFilter sampleNameFilter =
+                new SampleNameFilter.Builder()
+                        .nameMustNotBeEqualTo("jvm_compilation_time_seconds_total")
+                        .build();
+
+        assertNull(
+                registry.getSampleValue(
+                        "jvm_compilation_time_seconds_total", EMPTY_LABEL, EMPTY_LABEL, sampleNameFilter));
+    }
+}


### PR DESCRIPTION
Added CompilationMXBean compilation time metric in milliseconds.
Reorded collector registration in `DefaultExports`.

Signed-off-by: Doug Hoard <doug.hoard@gmail.com>

@fstab @rainerjung 