### PR TITLE
Fixed code to handle the scenario where help is set to `null`

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -228,7 +228,11 @@ public abstract class SimpleCollector<Child> extends Collector {
      * Set the help string of the metric. Required.
      */
     public B help(String help) {
-      this.help = help;
+      if (help == null) {
+        this.help = "";
+      } else {
+        this.help = help;
+      }
       return (B)this;
     }
     /**

--- a/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/CounterTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.junit.rules.ExpectedException.none;
 
 import java.util.ArrayList;
@@ -32,7 +33,13 @@ public class CounterTest {
   private double getValue() {
     return registry.getSampleValue("nolabels_total").doubleValue();
   }
-  
+
+  @Test(expected=IllegalStateException.class)
+  public void testNullHelp() {
+    Counter.build().name("nolabels2").help(null).register(registry);
+    fail("Expected IllegalStateException");
+  }
+
   @Test
   public void testIncrement() {
     noLabels.inc();

--- a/simpleclient/src/test/java/io/prometheus/client/EnumerationTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/EnumerationTest.java
@@ -1,6 +1,5 @@
 package io.prometheus.client;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -9,7 +8,7 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public class EnumerationTest {
@@ -29,6 +28,12 @@ public class EnumerationTest {
   }
   private Double getLabeledState(String labelValue, String s) {
     return registry.getSampleValue("labels", new String[]{"l", "labels"}, new String[]{labelValue, s});
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testNullHelp() {
+    Enumeration.build().states("foo", "bar").name("nolabels2").help(null).register(registry);
+    fail("Expected IllegalStateException");
   }
 
   @Test

--- a/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/GaugeTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +30,12 @@ public class GaugeTest {
 
   private double getValue() {
     return registry.getSampleValue("nolabels").doubleValue();
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testNullHelp() {
+    Gauge.build().name("nolabels2").help(null).register(registry);
+    fail("Expected IllegalStateException");
   }
 
   @Test

--- a/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/HistogramTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Callable;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.rules.ExpectedException.none;
 
 
@@ -68,6 +69,11 @@ public class HistogramTest {
         new String[]{Collector.doubleToGoString(b)}).doubleValue();
   }
 
+  @Test(expected=IllegalStateException.class)
+  public void testNullHelp() {
+    Histogram.build().name("nolabels2").help(null).register(registry);
+    fail("Expected IllegalStateException");
+  }
   @Test
   public void testObserve() {
     noLabels.observe(2);

--- a/simpleclient/src/test/java/io/prometheus/client/InfoTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/InfoTest.java
@@ -1,6 +1,5 @@
 package io.prometheus.client;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -9,7 +8,7 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public class InfoTest {
@@ -32,6 +31,12 @@ public class InfoTest {
       values[i/2] = labels[i+1];
     }
     return registry.getSampleValue(metric + "_info", names, values);
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testNullHelp() {
+    Info.build().name("nolabels2").help(null).register(registry);
+    fail("Expected IllegalStateException");
   }
 
   @Test

--- a/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
+++ b/simpleclient/src/test/java/io/prometheus/client/SummaryTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Callable;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public class SummaryTest {
@@ -54,6 +55,12 @@ public class SummaryTest {
   }
   private double getLabeledQuantile(String labelValue, double q) {
     return registry.getSampleValue("labels_and_quantiles", new String[]{"l", "quantile"}, new String[]{labelValue, Collector.doubleToGoString(q)}).doubleValue();
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testNullHelp() {
+    Summary.build().name("nolabels2").help(null).register(registry);
+    fail("Expected IllegalStateException");
   }
 
   @Test


### PR DESCRIPTION
Fixed code to handle the scenario where help is set to `null`. Added JUnit tests to validate correct behavior.

A user may think they don't want/need help, and thus set help to `null`. The original code allows a `null` value when creating metrics (Gauge, etc..), but results in a `NullPointerException` in `TextWriter.writeEscapedHelp()` when writing the metric value.

If help is `null`, an `IllegalStateException` should be thrown since a non-null/non-empty value is required.

Signed-off-by: Doug Hoard <doug.hoard@gmail.com>

@fstab 