### PR TITLE
SubstrateVM awareness

### DIFF
--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/NativeImageChecker.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/NativeImageChecker.java
@@ -1,0 +1,13 @@
+package io.prometheus.client.hotspot;
+
+/**
+ * Contains utilities to check if we are running inside or building for native image. Default behavior is to check
+ * if specific for graalvm runtime property is present. For additional optimizations it is possible to do add
+ * "--initialize-at-build-time=io.prometheus.client.hotspot.NativeImageChecker" to graalvm native image build command and
+ * the native image will be identified during build time.
+ */
+public final class NativeImageChecker {
+    static final boolean isGraalVmNativeImage = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+
+    private NativeImageChecker() {}
+}

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -90,36 +90,38 @@ public class ThreadExports extends Collector {
                       threadBean.getTotalStartedThreadCount()));
     }
 
-    if (nameFilter.test(JVM_THREADS_DEADLOCKED)) {
-      sampleFamilies.add(
-              new GaugeMetricFamily(
-                      JVM_THREADS_DEADLOCKED,
-                      "Cycles of JVM-threads that are in deadlock waiting to acquire object monitors or ownable synchronizers",
-                      nullSafeArrayLength(threadBean.findDeadlockedThreads())));
-    }
-
-    if (nameFilter.test(JVM_THREADS_DEADLOCKED_MONITOR)) {
-      sampleFamilies.add(
-              new GaugeMetricFamily(
-                      JVM_THREADS_DEADLOCKED_MONITOR,
-                      "Cycles of JVM-threads that are in deadlock waiting to acquire object monitors",
-                      nullSafeArrayLength(threadBean.findMonitorDeadlockedThreads())));
-    }
-
-    if (nameFilter.test(JVM_THREADS_STATE)) {
-      GaugeMetricFamily threadStateFamily = new GaugeMetricFamily(
-              JVM_THREADS_STATE,
-              "Current count of threads by state",
-              Collections.singletonList("state"));
-
-      Map<String, Integer> threadStateCounts = getThreadStateCountMap();
-      for (Map.Entry<String, Integer> entry : threadStateCounts.entrySet()) {
-        threadStateFamily.addMetric(
-                Collections.singletonList(entry.getKey()),
-                entry.getValue()
-        );
+    if (!threadBean.getClass().getSimpleName().equals("SubstrateThreadMXBean")) {
+      if (nameFilter.test(JVM_THREADS_DEADLOCKED)) {
+        sampleFamilies.add(
+                new GaugeMetricFamily(
+                        JVM_THREADS_DEADLOCKED,
+                        "Cycles of JVM-threads that are in deadlock waiting to acquire object monitors or ownable synchronizers",
+                        nullSafeArrayLength(threadBean.findDeadlockedThreads())));
       }
-      sampleFamilies.add(threadStateFamily);
+
+      if (nameFilter.test(JVM_THREADS_DEADLOCKED_MONITOR)) {
+        sampleFamilies.add(
+                new GaugeMetricFamily(
+                        JVM_THREADS_DEADLOCKED_MONITOR,
+                        "Cycles of JVM-threads that are in deadlock waiting to acquire object monitors",
+                        nullSafeArrayLength(threadBean.findMonitorDeadlockedThreads())));
+      }
+
+      if (nameFilter.test(JVM_THREADS_STATE)) {
+        GaugeMetricFamily threadStateFamily = new GaugeMetricFamily(
+                JVM_THREADS_STATE,
+                "Current count of threads by state",
+                Collections.singletonList("state"));
+
+        Map<String, Integer> threadStateCounts = getThreadStateCountMap();
+        for (Map.Entry<String, Integer> entry : threadStateCounts.entrySet()) {
+          threadStateFamily.addMetric(
+                  Collections.singletonList(entry.getKey()),
+                  entry.getValue()
+          );
+        }
+        sampleFamilies.add(threadStateFamily);
+      }
     }
   }
 

--- a/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
+++ b/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/ThreadExports.java
@@ -90,7 +90,7 @@ public class ThreadExports extends Collector {
                       threadBean.getTotalStartedThreadCount()));
     }
 
-    if (!threadBean.getClass().getSimpleName().equals("SubstrateThreadMXBean")) {
+    if (!NativeImageChecker.isGraalVmNativeImage) {
       if (nameFilter.test(JVM_THREADS_DEADLOCKED)) {
         sampleFamilies.add(
                 new GaugeMetricFamily(


### PR DESCRIPTION
Fixes #801 

Group items, which are not supported in GraalVM inside conditional branch, which checks that class name is not a known of GraalVM.