### PR TITLE
Make some fields public and add children()/labelNames() methods in SimpleCollector

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
+++ b/simpleclient/src/main/java/io/prometheus/client/CollectorRegistry.java
@@ -101,7 +101,7 @@ public class CollectorRegistry {
   /**
    * A snapshot of the current collectors.
    */
-  private Set<Collector> collectors() {
+  public Set<Collector> collectors() {
     synchronized (namesCollectorsLock) {
       return new HashSet<Collector>(collectorsToNames.keySet());
     }

--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -1,6 +1,8 @@
 package io.prometheus.client;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.Arrays;
@@ -47,9 +49,9 @@ import java.util.List;
  * by one of the dimensions altogether.
  */
 public abstract class SimpleCollector<Child> extends Collector {
-  protected final String fullname;
-  protected final String help;
-  protected final String unit;
+  public final String fullname;
+  public final String help;
+  public final String unit;
   protected final List<String> labelNames;
 
   protected final ConcurrentMap<List<String>, Child> children = new ConcurrentHashMap<List<String>, Child>();
@@ -97,6 +99,20 @@ public abstract class SimpleCollector<Child> extends Collector {
   public void clear() {
     children.clear();
     initializeNoLabelsChild();
+  }
+
+  /**
+   * Return label names.
+   */
+  public List<String> labelNames() {
+    return Collections.unmodifiableList(labelNames);
+  }
+
+  /**
+   * Return all children.
+   */
+  public Map<List<String>, Child> children() {
+    return Collections.unmodifiableMap(children);
   }
   
   /**


### PR DESCRIPTION
## Motivation:
 Make some inner fields/methods accessible to provide an optional `collect` way.