### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 11.0.10

### DIFF
--- a/simpleclient_jetty/pom.xml
+++ b/simpleclient_jetty/pom.xml
@@ -17,7 +17,7 @@
     </description>
 
     <properties>
-        <jetty.version>10.0.10</jetty.version>
+        <jetty.version>11.0.10</jetty.version>
     </properties>
 
     <licenses>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 10.0.10
- [CVE-2022-2191](https://www.oscs1024.com/hd/CVE-2022-2191)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 10.0.10 to 11.0.10 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS