### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 11.0.10

### DIFF
--- a/simpleclient_jetty_jdk8/pom.xml
+++ b/simpleclient_jetty_jdk8/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>11.0.9</version>
+            <version>11.0.10</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 11.0.9
- [CVE-2022-2191](https://www.oscs1024.com/hd/CVE-2022-2191)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 11.0.9 to 11.0.10 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS