### PR TITLE
fixed flaky test

### DIFF
--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/samplebuilder/CustomMappingSampleBuilderTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/samplebuilder/CustomMappingSampleBuilderTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +34,7 @@ public class CustomMappingSampleBuilderTest {
 
     @Test
     public void test_WHEN_OneMatch_THEN_ShouldReturnConverted() {
-        final Map<String, String> labels = new LinkedHashMap<String, String>();
+        final Map<String, String> labels = new HashMap<String, String>();
         labels.put("service", "${0}");
         final MapperConfig mapperConfig = new MapperConfig(
                 "app.okhttpclient.client.HttpClient.*.total",
@@ -57,7 +58,7 @@ public class CustomMappingSampleBuilderTest {
 
     @Test
     public void test_WHEN_MoreMatches_THEN_ShouldReturnFirstOne() {
-        final Map<String, String> labels = new LinkedHashMap<String, String>();
+        final Map<String, String> labels = new HashMap<String, String>();
         labels.put("service", "${0}");
         final MapperConfig mapperConfig = new MapperConfig(
                 "app.okhttpclient.client.HttpClient.*.total",

--- a/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/samplebuilder/CustomMappingSampleBuilderTest.java
+++ b/simpleclient_dropwizard/src/test/java/io/prometheus/client/dropwizard/samplebuilder/CustomMappingSampleBuilderTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -33,7 +33,7 @@ public class CustomMappingSampleBuilderTest {
 
     @Test
     public void test_WHEN_OneMatch_THEN_ShouldReturnConverted() {
-        final Map<String, String> labels = new HashMap<String, String>();
+        final Map<String, String> labels = new LinkedHashMap<String, String>();
         labels.put("service", "${0}");
         final MapperConfig mapperConfig = new MapperConfig(
                 "app.okhttpclient.client.HttpClient.*.total",
@@ -57,7 +57,7 @@ public class CustomMappingSampleBuilderTest {
 
     @Test
     public void test_WHEN_MoreMatches_THEN_ShouldReturnFirstOne() {
-        final Map<String, String> labels = new HashMap<String, String>();
+        final Map<String, String> labels = new LinkedHashMap<String, String>();
         labels.put("service", "${0}");
         final MapperConfig mapperConfig = new MapperConfig(
                 "app.okhttpclient.client.HttpClient.*.total",
@@ -81,7 +81,7 @@ public class CustomMappingSampleBuilderTest {
 
     @Test
     public void test_WHEN_MoreMatchesReverseOrder_THEN_ShouldReturnFirstOne() {
-        final Map<String, String> labels = new HashMap<String, String>();
+        final Map<String, String> labels = new LinkedHashMap<String, String>();
         labels.put("service", "${0}");
         labels.put("status", "${1}");
         final MapperConfig mapperConfig = new MapperConfig(
@@ -106,7 +106,7 @@ public class CustomMappingSampleBuilderTest {
 
     @Test
     public void test_WHEN_MoreToFormatInLabelsAndName_THEN_ShouldReturnCorrectSample() {
-        final Map<String, String> labels = new HashMap<String, String>();
+        final Map<String, String> labels = new LinkedHashMap<String, String>();
         labels.put("service", "${0}_${1}");
         labels.put("status", "s_${1}");
         final MapperConfig mapperConfig = new MapperConfig(
@@ -131,7 +131,7 @@ public class CustomMappingSampleBuilderTest {
 
     @Test
     public void test_WHEN_MetricNameSuffixRequested_THEN_ShouldReturnCorrectSample() {
-        final Map<String, String> labels = new HashMap<String, String>();
+        final Map<String, String> labels = new LinkedHashMap<String, String>();
         labels.put("service", "${0}");
         labels.put("status", "s_${1}");
         final MapperConfig mapperConfig = new MapperConfig(
@@ -156,7 +156,7 @@ public class CustomMappingSampleBuilderTest {
 
     @Test
     public void test_WHEN_AdditionalLabels_THEN_ShouldReturnCorrectSample() {
-        final Map<String, String> labels = new HashMap<String, String>();
+        final Map<String, String> labels = new LinkedHashMap<String, String>();
         labels.put("service", "${0}");
         labels.put("status", "s_${1}");
         final MapperConfig mapperConfig = new MapperConfig(


### PR DESCRIPTION
Fixed flaky test in [828](https://github.com/prometheus/client_java/issues/828)

The cause of failure is because the test used a `HashMap` to store `labels`, however, as per [Oracle's documentation](https://docs.oracle.com/javase/7/docs/api/java/util/HashMap.html):

> The HashMap class is roughly equivalent to Hashtable, except that it is unsynchronized and permits nulls. This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.

So the order of labels in the `Collector.MetricFamilySamples.Sample `object is non-deterministic. It can be fixed by replacing `HashMap` with `LinkedHashMap`, such that the order of entries is deterministic.