### PR TITLE
Allow dots in metric names and label names

### DIFF
--- a/examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel_exemplars/greeting/GreetingServlet.java
+++ b/examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel_exemplars/greeting/GreetingServlet.java
@@ -27,7 +27,7 @@ public class GreetingServlet extends HttpServlet {
             .withUnit(Unit.SECONDS)
             .withLabelNames("http_status")
             .register();
-        histogram.withLabelValues("200");
+        histogram.initLabelValues("200");
     }
 
     @Override

--- a/examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel_exemplars/app/HelloWorldServlet.java
+++ b/examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel_exemplars/app/HelloWorldServlet.java
@@ -34,7 +34,7 @@ public class HelloWorldServlet extends HttpServlet {
                 .withUnit(Unit.SECONDS)
                 .withLabelNames("http_status")
                 .register();
-        histogram.withLabelValues("200");
+        histogram.initLabelValues("200");
     }
 
     @Override

--- a/examples/example-tomcat-servlet/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
+++ b/examples/example-tomcat-servlet/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
@@ -32,6 +32,11 @@ public class HelloWorldServlet extends HttpServlet {
             .withLabelNames("http_status")
             .register();
 
+    public HelloWorldServlet() {
+        counter.initLabelValues("200");
+        histogram.initLabelValues("200");
+    }
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         long start = System.nanoTime();

--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusProperties.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusProperties.java
@@ -58,7 +58,7 @@ public class PrometheusProperties {
      * May return {@code null} if no metric-specific properties are configured for a metric name.
      */
     public MetricsProperties getMetricProperties(String metricName) {
-        return metricProperties.get(metricName);
+        return metricProperties.get(metricName.replace(".", "_"));
     }
 
     public ExemplarsProperties getExemplarProperties() {

--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusPropertiesLoader.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusPropertiesLoader.java
@@ -39,6 +39,8 @@ public class PrometheusPropertiesLoader {
     // This will remove entries from properties when they are processed.
     private static Map<String, MetricsProperties> loadMetricsConfigs(Map<Object, Object> properties) {
         Map<String, MetricsProperties> result = new HashMap<>();
+        // Note that the metric name in the properties file must be as exposed in the Prometheus exposition formats,
+        // i.e. all dots replaced with underscores.
         Pattern pattern = Pattern.compile("io\\.prometheus\\.metrics\\.([^.]+)\\.");
         // Create a copy of the keySet() for iterating. We cannot iterate directly over keySet()
         // because entries are removed when MetricsConfig.load(...) is called.
@@ -49,7 +51,7 @@ public class PrometheusPropertiesLoader {
         for (String propertyName : propertyNames) {
             Matcher matcher = pattern.matcher(propertyName);
             if (matcher.find()) {
-                String metricName = matcher.group(1);
+                String metricName = matcher.group(1).replace(".", "_");
                 if (!result.containsKey(metricName)) {
                     result.put(metricName, MetricsProperties.load("io.prometheus.metrics." + metricName, properties));
                 }

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Counter.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Counter.java
@@ -9,12 +9,15 @@ import io.prometheus.metrics.model.registry.Collector;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.Exemplar;
 import io.prometheus.metrics.model.snapshots.Labels;
+import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
+
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
 
 /**
  * Counter metric.
@@ -109,8 +112,8 @@ public class Counter extends StatefulMetric<CounterDataPoint, Counter.DataPoint>
         return new CounterSnapshot(getMetadata(), data);
     }
 
-    static String normalizeName(String name) {
-        if (name != null && name.endsWith("_total")) {
+    static String stripTotalSuffix(String name) {
+        if (name != null && (name.endsWith("_total") || name.endsWith(".total"))) {
             name = name.substring(0, name.length() - 6);
         }
         return name;
@@ -231,12 +234,12 @@ public class Counter extends StatefulMetric<CounterDataPoint, Counter.DataPoint>
          * In the example above both {@code c1} and {@code c2} would be named {@code "events_total"} in Prometheus.
          * <p>
          * Throws an {@link IllegalArgumentException} if
-         * {@link io.prometheus.metrics.model.snapshots.MetricMetadata#isValidMetricName(String) MetricMetadata.isValidMetricName(name)}
+         * {@link io.prometheus.metrics.model.snapshots.PrometheusNaming#isValidMetricName(String) MetricMetadata.isValidMetricName(name)}
          * is {@code false}.
          */
         @Override
         public Builder withName(String name) {
-            return super.withName(normalizeName(name));
+            return super.withName(stripTotalSuffix(name));
         }
 
         @Override

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/CounterWithCallback.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/CounterWithCallback.java
@@ -80,12 +80,12 @@ public class CounterWithCallback extends CallbackMetric {
          * In the example above both {@code c1} and {@code c2} would be named {@code "events_total"} in Prometheus.
          * <p>
          * Throws an {@link IllegalArgumentException} if
-         * {@link io.prometheus.metrics.model.snapshots.MetricMetadata#isValidMetricName(String) MetricMetadata.isValidMetricName(name)}
+         * {@link io.prometheus.metrics.model.snapshots.PrometheusNaming#isValidMetricName(String) MetricMetadata.isValidMetricName(name)}
          * is {@code false}.
          */
         @Override
         public Builder withName(String name) {
-            return super.withName(Counter.normalizeName(name));
+            return super.withName(Counter.stripTotalSuffix(name));
         }
 
         @Override

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Info.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Info.java
@@ -2,15 +2,15 @@ package io.prometheus.metrics.core.metrics;
 
 import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.model.snapshots.InfoSnapshot;
-import io.prometheus.metrics.model.snapshots.Label;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.Unit;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
 
 /**
  * Info metric. Example:
@@ -90,15 +90,12 @@ public class Info extends MetricWithFixedMetadata {
          * In the example above both {@code info1} and {@code info2} will be named {@code "runtime_info"} in Prometheus.
          * <p>
          * Throws an {@link IllegalArgumentException} if
-         * {@link io.prometheus.metrics.model.snapshots.MetricMetadata#isValidMetricName(String) MetricMetadata.isValidMetricName(name)}
+         * {@link io.prometheus.metrics.model.snapshots.PrometheusNaming#isValidMetricName(String) MetricMetadata.isValidMetricName(name)}
          * is {@code false}.
          */
         @Override
         public Builder withName(String name) {
-            if (name != null && name.endsWith("_info")) {
-                name = name.substring(0, name.length() - 5);
-            }
-            return super.withName(name);
+            return super.withName(stripInfoSuffix(name));
         }
 
         /**
@@ -112,8 +109,8 @@ public class Info extends MetricWithFixedMetadata {
             return this;
         }
 
-        private static String normalizeName(String name) {
-            if (name != null && name.endsWith("_info")) {
+        private static String stripInfoSuffix(String name) {
+            if (name != null && (name.endsWith("_info") || name.endsWith(".info"))) {
                 name = name.substring(0, name.length() - 5);
             }
             return name;
@@ -121,7 +118,7 @@ public class Info extends MetricWithFixedMetadata {
 
         @Override
         public Info build() {
-            return new Info(withName(normalizeName(name)));
+            return new Info(this);
         }
 
         @Override

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/MetricWithFixedMetadata.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/MetricWithFixedMetadata.java
@@ -3,10 +3,13 @@ package io.prometheus.metrics.core.metrics;
 import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricMetadata;
+import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import io.prometheus.metrics.model.snapshots.Unit;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
 
 /**
  * Almost all metrics have fixed metadata, i.e. the metric name is known when the metric is created.
@@ -31,9 +34,8 @@ public abstract class MetricWithFixedMetadata extends Metric {
 
     private String makeName(String name, Unit unit) {
         if (unit != null) {
-            String suffix = "_" + unit;
-            if (!name.endsWith(suffix)) {
-                name = name + suffix;
+            if (!name.endsWith(unit.toString())) {
+                name = name + "_" + unit;
             }
         }
         return name;
@@ -51,7 +53,7 @@ public abstract class MetricWithFixedMetadata extends Metric {
         }
 
         public B withName(String name) {
-            if (!MetricMetadata.isValidMetricName(name)) {
+            if (!PrometheusNaming.isValidMetricName(name)) {
                 throw new IllegalArgumentException("'" + name + "': Illegal metric name.");
             }
             this.name = name;
@@ -70,7 +72,7 @@ public abstract class MetricWithFixedMetadata extends Metric {
 
         public B withLabelNames(String... labelNames) {
             for (String labelName : labelNames) {
-                if (!Labels.isValidLabelName(labelName)) {
+                if (!PrometheusNaming.isValidLabelName(labelName)) {
                     throw new IllegalArgumentException(labelName + ": illegal label name");
                 }
                 if (illegalLabelNames.contains(labelName)) {

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StateSet.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StateSet.java
@@ -3,6 +3,7 @@ package io.prometheus.metrics.core.metrics;
 import io.prometheus.metrics.config.MetricsProperties;
 import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.model.snapshots.Labels;
+import io.prometheus.metrics.model.snapshots.MetricMetadata;
 import io.prometheus.metrics.model.snapshots.StateSetSnapshot;
 import io.prometheus.metrics.core.datapoints.StateSetDataPoint;
 
@@ -10,6 +11,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
 
 /**
  * StateSet metric. Example:
@@ -58,7 +61,7 @@ public class StateSet extends StatefulMetric<StateSetDataPoint, StateSet.DataPoi
         exemplarsEnabled = getConfigProperty(properties, MetricsProperties::getExemplarsEnabled);
         this.names = builder.names; // builder.names is already a validated copy
         for (String name : names) {
-            if (this.getMetadata().getName().equals(name)) {
+            if (this.getMetadata().getPrometheusName().equals(prometheusName(name))) {
                 throw new IllegalArgumentException("Label name " + name + " is illegal (can't use the metric name as label name in state set metrics)");
             }
         }

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
@@ -62,6 +62,34 @@ abstract class StatefulMetric<D extends DataPoint, T extends D> extends MetricWi
         return collect(labels, metricData);
     }
 
+    /**
+     * Initialize label values.
+     * <p>
+     * Example: Imagine you have a counter for payments as follows
+     * <pre>
+     * payment_transactions_total{payment_type="credit card"} 7.0
+     * payment_transactions_total{payment_type="paypal"} 3.0
+     * </pre>
+     * Now, the data points for the {@code payment_type} label values get initialized when they are
+     * first used, i.e. the first time you call
+     * <pre>{@code
+     * counter.withLabelValues("paypal").inc();
+     * }</pre>
+     * the data point with label {@code payment_type="paypal"} will go from non-existent to having value {@code 1.0}.
+     * <p>
+     * In some cases this is confusing, and you want to have data points initialized on application start
+     * with an initial value of {@code 0.0}:
+     * <pre>
+     * payment_transactions_total{payment_type="credit card"} 0.0
+     * payment_transactions_total{payment_type="paypal"} 0.0
+     * </pre>
+     * {@code initLabelValues(...)} can be used to initialize label value, so that the data points
+     * show up in the exposition format with an initial value of zero.
+     */
+    public void initLabelValues(String... labelValues) {
+        withLabelValues(labelValues);
+    }
+
     public D withLabelValues(String... labelValues) {
         if (labelValues.length != labelNames.length) {
             if (labelValues.length == 0) {
@@ -73,7 +101,6 @@ abstract class StatefulMetric<D extends DataPoint, T extends D> extends MetricWi
         return data.computeIfAbsent(Arrays.asList(labelValues), l -> newDataPoint());
     }
 
-    // TODO: Remove automatically if label values have not been used in a while?
     public void remove(String... labelValues) {
         data.remove(Arrays.asList(labelValues));
     }

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/CounterTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/CounterTest.java
@@ -109,18 +109,18 @@ public class CounterTest {
 
     @Test
     public void testTotalStrippedFromName() {
-        Counter counter = Counter.newBuilder()
-                .withName("my_counter_total")
-                .withUnit(Unit.SECONDS)
-                .build();
-        Metrics.MetricFamily protobufData = new PrometheusProtobufWriter().convert(counter.collect());
-        assertEquals("name: \"my_counter_seconds_total\" type: COUNTER metric { counter { value: 0.0 } }", TextFormat.printer().shortDebugString(protobufData));
-
-        counter = Counter.newBuilder()
-                .withName("my_counter")
-                .build();
-        protobufData = new PrometheusProtobufWriter().convert(counter.collect());
-        assertEquals("name: \"my_counter_total\" type: COUNTER metric { counter { value: 0.0 } }", TextFormat.printer().shortDebugString(protobufData));
+        for (String name : new String[]{
+                "my_counter_total", "my.counter.total",
+                "my_counter_seconds_total", "my.counter.seconds.total",
+                "my_counter", "my.counter",
+                "my_counter_seconds", "my.counter.seconds"}) {
+            Counter counter = Counter.newBuilder()
+                    .withName(name)
+                    .withUnit(Unit.SECONDS)
+                    .build();
+            Metrics.MetricFamily protobufData = new PrometheusProtobufWriter().convert(counter.collect());
+            assertEquals("name: \"my_counter_seconds_total\" type: COUNTER metric { counter { value: 0.0 } }", TextFormat.printer().shortDebugString(protobufData));
+        }
     }
 
     @Test

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/HistogramTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/HistogramTest.java
@@ -1,19 +1,19 @@
 package io.prometheus.metrics.core.metrics;
 
 import io.prometheus.metrics.com_google_protobuf_3_21_7.TextFormat;
+import io.prometheus.metrics.core.datapoints.DistributionDataPoint;
+import io.prometheus.metrics.core.exemplars.ExemplarSamplerConfigTestUtil;
 import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
 import io.prometheus.metrics.expositionformats.PrometheusProtobufWriter;
 import io.prometheus.metrics.expositionformats.generated.com_google_protobuf_3_21_7.Metrics;
-import io.prometheus.metrics.core.exemplars.ExemplarSamplerConfigTestUtil;
-import io.prometheus.metrics.model.snapshots.MetricSnapshots;
-import io.prometheus.metrics.tracer.common.SpanContext;
-import io.prometheus.metrics.tracer.initializer.SpanContextSupplier;
 import io.prometheus.metrics.model.snapshots.ClassicHistogramBucket;
 import io.prometheus.metrics.model.snapshots.Exemplar;
 import io.prometheus.metrics.model.snapshots.Exemplars;
 import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
-import io.prometheus.metrics.core.datapoints.DistributionDataPoint;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.tracer.common.SpanContext;
+import io.prometheus.metrics.tracer.initializer.SpanContextSupplier;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -1044,18 +1044,8 @@ public class HistogramTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testIllegalLabelNameDot() {
-        // The Prometheus team are investigating to allow dots in future Prometheus versions, but for now it's invalid.
-        // The reason is that you cannot use illegal label names in the Prometheus query language.
-        Histogram.newBuilder()
-                .withName("test")
-                .withLabelNames("http.status");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
     public void testIllegalName() {
-        Histogram.newBuilder()
-                .withName("server.durations");
+        Histogram.newBuilder().withName("my_namespace/server.durations");
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusProtobufWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusProtobufWriter.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import static io.prometheus.metrics.expositionformats.ProtobufUtil.timestampFromMillis;
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
 
 /**
  * Write the Prometheus protobuf format as defined in
@@ -103,7 +104,7 @@ public class PrometheusProtobufWriter implements ExpositionFormatWriter {
         } else if (snapshot instanceof StateSetSnapshot) {
             for (StateSetSnapshot.StateSetDataPointSnapshot data : ((StateSetSnapshot) snapshot).getData()) {
                 for (int i = 0; i < data.size(); i++) {
-                    builder.addMetric(convert(data, snapshot.getMetadata().getName(), i));
+                    builder.addMetric(convert(data, snapshot.getMetadata().getPrometheusName(), i));
                 }
             }
             setMetadataUnlessEmpty(builder, snapshot.getMetadata(), null, Metrics.MetricType.GAUGE);
@@ -121,9 +122,9 @@ public class PrometheusProtobufWriter implements ExpositionFormatWriter {
             return;
         }
         if (nameSuffix == null) {
-            builder.setName(metadata.getName());
+            builder.setName(metadata.getPrometheusName());
         } else {
-            builder.setName(metadata.getName() + nameSuffix);
+            builder.setName(metadata.getPrometheusName() + nameSuffix);
         }
         if (metadata.getHelp() != null) {
             builder.setHelp(metadata.getHelp());
@@ -335,7 +336,7 @@ public class PrometheusProtobufWriter implements ExpositionFormatWriter {
     private void addLabels(Metrics.Metric.Builder metricBuilder, Labels labels) {
         for (int i = 0; i < labels.size(); i++) {
             metricBuilder.addLabel(Metrics.LabelPair.newBuilder()
-                    .setName(labels.getName(i))
+                    .setName(labels.getPrometheusName(i))
                     .setValue(labels.getValue(i))
                     .build());
         }
@@ -344,7 +345,7 @@ public class PrometheusProtobufWriter implements ExpositionFormatWriter {
     private void addLabels(Metrics.Exemplar.Builder metricBuilder, Labels labels) {
         for (int i = 0; i < labels.size(); i++) {
             metricBuilder.addLabel(Metrics.LabelPair.newBuilder()
-                    .setName(labels.getName(i))
+                    .setName(labels.getPrometheusName(i))
                     .setValue(labels.getValue(i))
                     .build());
         }

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
@@ -26,6 +26,7 @@ import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeEscape
 import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeLabels;
 import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeLong;
 import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeTimestamp;
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
 
 /**
  * Write the Prometheus text format. This is the default if you view a Prometheus endpoint with your Web browser.
@@ -102,7 +103,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
                         writeMetadata(writer, "_created", "gauge", metadata);
                         metadataWritten = true;
                     }
-                    writeNameAndLabels(writer, metadata.getName(), "_created", data.getLabels());
+                    writeNameAndLabels(writer, metadata.getPrometheusName(), "_created", data.getLabels());
                     writeTimestamp(writer, data.getCreatedTimestampMillis());
                     writeScrapeTimestampAndNewline(writer, data);
                 }
@@ -115,7 +116,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
             MetricMetadata metadata = snapshot.getMetadata();
             writeMetadata(writer, "_total", "counter", metadata);
             for (CounterSnapshot.CounterDataPointSnapshot data : snapshot.getData()) {
-                writeNameAndLabels(writer, metadata.getName(), "_total", data.getLabels());
+                writeNameAndLabels(writer, metadata.getPrometheusName(), "_total", data.getLabels());
                 writeDouble(writer, data.getValue());
                 writeScrapeTimestampAndNewline(writer, data);
             }
@@ -126,7 +127,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
         MetricMetadata metadata = snapshot.getMetadata();
         writeMetadata(writer, "", "gauge", metadata);
         for (GaugeSnapshot.GaugeDataPointSnapshot data : snapshot.getData()) {
-            writeNameAndLabels(writer, metadata.getName(), null, data.getLabels());
+            writeNameAndLabels(writer, metadata.getPrometheusName(), null, data.getLabels());
             writeDouble(writer, data.getValue());
             writeScrapeTimestampAndNewline(writer, data);
         }
@@ -140,18 +141,18 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
             long cumulativeCount = 0;
             for (int i = 0; i < buckets.size(); i++) {
                 cumulativeCount += buckets.getCount(i);
-                writeNameAndLabels(writer, metadata.getName(), "_bucket", data.getLabels(), "le", buckets.getUpperBound(i));
+                writeNameAndLabels(writer, metadata.getPrometheusName(), "_bucket", data.getLabels(), "le", buckets.getUpperBound(i));
                 writeLong(writer, cumulativeCount);
                 writeScrapeTimestampAndNewline(writer, data);
             }
             if (!snapshot.isGaugeHistogram()) {
                 if (data.hasCount()) {
-                    writeNameAndLabels(writer, metadata.getName(), "_count", data.getLabels());
+                    writeNameAndLabels(writer, metadata.getPrometheusName(), "_count", data.getLabels());
                     writeLong(writer, data.getCount());
                     writeScrapeTimestampAndNewline(writer, data);
                 }
                 if (data.hasSum()) {
-                    writeNameAndLabels(writer, metadata.getName(), "_sum", data.getLabels());
+                    writeNameAndLabels(writer, metadata.getPrometheusName(), "_sum", data.getLabels());
                     writeDouble(writer, data.getSum());
                     writeScrapeTimestampAndNewline(writer, data);
                 }
@@ -183,7 +184,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
                     writeMetadata(writer, "_gcount", "gauge", metadata);
                     metadataWritten = true;
                 }
-                writeNameAndLabels(writer, metadata.getName(), "_gcount", data.getLabels());
+                writeNameAndLabels(writer, metadata.getPrometheusName(), "_gcount", data.getLabels());
                 writeLong(writer, data.getCount());
                 writeScrapeTimestampAndNewline(writer, data);
             }
@@ -195,7 +196,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
                     writeMetadata(writer, "_gsum", "gauge", metadata);
                     metadataWritten = true;
                 }
-                writeNameAndLabels(writer, metadata.getName(), "_gsum", data.getLabels());
+                writeNameAndLabels(writer, metadata.getPrometheusName(), "_gsum", data.getLabels());
                 writeDouble(writer, data.getSum());
                 writeScrapeTimestampAndNewline(writer, data);
             }
@@ -214,17 +215,17 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
                 metadataWritten = true;
             }
             for (Quantile quantile : data.getQuantiles()) {
-                writeNameAndLabels(writer, metadata.getName(), null, data.getLabels(), "quantile", quantile.getQuantile());
+                writeNameAndLabels(writer, metadata.getPrometheusName(), null, data.getLabels(), "quantile", quantile.getQuantile());
                 writeDouble(writer, quantile.getValue());
                 writeScrapeTimestampAndNewline(writer, data);
             }
             if (data.hasCount()) {
-                writeNameAndLabels(writer, metadata.getName(), "_count", data.getLabels());
+                writeNameAndLabels(writer, metadata.getPrometheusName(), "_count", data.getLabels());
                 writeLong(writer, data.getCount());
                 writeScrapeTimestampAndNewline(writer, data);
             }
             if (data.hasSum()) {
-                writeNameAndLabels(writer, metadata.getName(), "_sum", data.getLabels());
+                writeNameAndLabels(writer, metadata.getPrometheusName(), "_sum", data.getLabels());
                 writeDouble(writer, data.getSum());
                 writeScrapeTimestampAndNewline(writer, data);
             }
@@ -235,7 +236,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
         MetricMetadata metadata = snapshot.getMetadata();
         writeMetadata(writer, "_info", "gauge", metadata);
         for (InfoSnapshot.InfoDataPointSnapshot data : snapshot.getData()) {
-            writeNameAndLabels(writer, metadata.getName(), "_info", data.getLabels());
+            writeNameAndLabels(writer, metadata.getPrometheusName(), "_info", data.getLabels());
             writer.write("1");
             writeScrapeTimestampAndNewline(writer, data);
         }
@@ -246,13 +247,13 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
         writeMetadata(writer, "", "gauge", metadata);
         for (StateSetSnapshot.StateSetDataPointSnapshot data : snapshot.getData()) {
             for (int i = 0; i < data.size(); i++) {
-                writer.write(metadata.getName());
+                writer.write(metadata.getPrometheusName());
                 writer.write('{');
                 for (int j = 0; j < data.getLabels().size(); j++) {
                     if (j > 0) {
                         writer.write(",");
                     }
-                    writer.write(data.getLabels().getName(j));
+                    writer.write(data.getLabels().getPrometheusName(j));
                     writer.write("=\"");
                     writeEscapedLabelValue(writer, data.getLabels().getValue(j));
                     writer.write("\"");
@@ -260,7 +261,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
                 if (!data.getLabels().isEmpty()) {
                     writer.write(",");
                 }
-                writer.write(metadata.getName());
+                writer.write(metadata.getPrometheusName());
                 writer.write("=\"");
                 writeEscapedLabelValue(writer, data.getName(i));
                 writer.write("\"} ");
@@ -278,7 +279,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
         MetricMetadata metadata = snapshot.getMetadata();
         writeMetadata(writer, "", "untyped", metadata);
         for (UnknownSnapshot.UnknownDataPointSnapshot data : snapshot.getData()) {
-            writeNameAndLabels(writer, metadata.getName(), null, data.getLabels());
+            writeNameAndLabels(writer, metadata.getPrometheusName(), null, data.getLabels());
             writeDouble(writer, data.getValue());
             writeScrapeTimestampAndNewline(writer, data);
         }
@@ -303,7 +304,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
     private void writeMetadata(OutputStreamWriter writer, String suffix, String typeString, MetricMetadata metadata) throws IOException {
         if (metadata.getHelp() != null && !metadata.getHelp().isEmpty()) {
             writer.write("# HELP ");
-            writer.write(metadata.getName());
+            writer.write(metadata.getPrometheusName());
             if (suffix != null) {
                 writer.write(suffix);
             }
@@ -312,7 +313,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
             writer.write('\n');
         }
         writer.write("# TYPE ");
-        writer.write(metadata.getName());
+        writer.write(metadata.getPrometheusName());
         if (suffix != null) {
             writer.write(suffix);
         }

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
+
 public class TextFormatUtil {
 
     static void writeLong(OutputStreamWriter writer, long value) throws IOException {
@@ -61,7 +63,7 @@ public class TextFormatUtil {
             if (i > 0) {
                 writer.write(",");
             }
-            writer.write(labels.getName(i));
+            writer.write(labels.getPrometheusName(i));
             writer.write("=\"");
             writeEscapedLabelValue(writer, labels.getValue(i));
             writer.write("\"");

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/Collector.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/Collector.java
@@ -1,10 +1,10 @@
 package io.prometheus.metrics.model.registry;
 
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
-import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 
-import java.util.List;
 import java.util.function.Predicate;
+
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
 
 /**
  * To be registered with the Prometheus collector registry.
@@ -26,7 +26,7 @@ public interface Collector {
      */
     default MetricSnapshot collect(Predicate<String> includedNames) {
         MetricSnapshot result = collect();
-        if (includedNames.test(result.getMetadata().getName())) {
+        if (includedNames.test(result.getMetadata().getPrometheusName())) {
             return result;
         } else {
             return null;
@@ -36,7 +36,7 @@ public interface Collector {
     /**
      * Override this and return {@code null} if a collector does not have a constant name (name may change between scrapes).
      */
-    default String getName() {
-        return collect().getMetadata().getName();
+    default String getPrometheusName() {
+        return collect().getMetadata().getPrometheusName();
     }
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/MultiCollector.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/MultiCollector.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
+
 /**
  * Like {@link Collector}, but collecting multiple Snapshots at once.
  */
@@ -27,7 +29,7 @@ public interface MultiCollector {
         MetricSnapshots allSnapshots = collect();
         MetricSnapshots.Builder result = MetricSnapshots.newBuilder();
         for (MetricSnapshot snapshot : allSnapshots) {
-            if (includedNames.test(snapshot.getMetadata().getName())) {
+            if (includedNames.test(snapshot.getMetadata().getPrometheusName())) {
                 result.addMetricSnapshot(snapshot);
             }
         }
@@ -38,7 +40,7 @@ public interface MultiCollector {
      * Override this and return an empty list if the MultiCollector does not return a constant list of names
      * (names may be added / removed between scrapes).
      */
-    default List<String> getNames() {
-        return collect().stream().map(snapshot -> snapshot.getMetadata().getName()).collect(Collectors.toList());
+    default List<String> getPrometheusNames() {
+        return collect().stream().map(snapshot -> snapshot.getMetadata().getPrometheusName()).collect(Collectors.toList());
     }
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/InfoSnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/InfoSnapshot.java
@@ -20,9 +20,6 @@ public final class InfoSnapshot extends MetricSnapshot {
      */
     public InfoSnapshot(MetricMetadata metadata, Collection<InfoDataPointSnapshot> data) {
         super(metadata, data);
-        if (metadata.getName().endsWith("_info")) {
-            throw new IllegalArgumentException("The name of an info snapshot must not include the _info suffix");
-        }
         if (metadata.hasUnit()) {
             throw new IllegalArgumentException("An Info metric cannot have a unit.");
         }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
@@ -1,28 +1,37 @@
 package io.prometheus.metrics.model.snapshots;
 
-import java.util.regex.Pattern;
-
 /**
  * Immutable container for metric metadata: name, help, unit.
  */
 public final class MetricMetadata {
-    private static final Pattern METRIC_NAME_RE = Pattern.compile("^[a-zA-Z_:][a-zA-Z0-9_:]+$");
-    // According to OpenMetrics _count and _sum (and _gcount, _gsum) should also be reserved suffixes.
-    // However, popular instrumentation libraries have many Gauges with a name ending in _count. Examples:
-    // * Micrometer: jvm_buffer_count
-    // * OpenTelemetry: process_runtime_jvm_buffer_count
-    // We allow the _count and _sum suffixes here so that these names are supported, even though this might
-    // conflict if there is a histogram or summary named "jvm_buffer" or "process_runtime_jvm_buffer".
-    private static final String[] RESERVED_SUFFIXES = {"_total", "_created", "_bucket", "_info"};
 
     /**
-     * Name is the name without suffix.
+     * Name without suffix.
+     * <p>
      * For example, the name for a counter "http_requests_total" is "http_requests".
-     * The name of an info called "target_info" is "target".
+     * The name of an info called "jvm_info" is "jvm".
+     * <p>
+     * We allow dots in label names. Dots are automatically replaced with underscores in Prometheus
+     * exposition formats. However, if metrics from this library are exposed in OpenTelemetry
+     * format dots are retained.
+     * <p>
      * See {@link #MetricMetadata(String, String, Unit)} for more info on naming conventions.
      */
     private final String name;
+
+    /**
+     * Same as name, except if name contains dots, then the prometheusName is {@code name.replace(".", "_")}.
+     */
+    private final String prometheusName;
+
+    /**
+     * optional, may be {@code null}.
+     */
     private final String help;
+
+    /**
+     * optional, may be {@code null}.
+     */
     private final Unit unit;
 
     /**
@@ -40,28 +49,10 @@ public final class MetricMetadata {
     }
 
     /**
-     * Naming conventions:
-     * <ul>
-     *     <li>The name MUST NOT include the {@code _total} suffix for counter metrics or the
-     *         {@code _info} suffix for info metrics.
-     *         If in doubt, use {@link #sanitizeMetricName(String)} to remove the suffix.</li>
-     *     <li>If name is {@code null}, a {@link NullPointerException} is thrown.</li>
-     *     <li>If {@link #isValidMetricName(String) isValidMetricName(name)} is false,
-     *         an {@link IllegalArgumentException} is thrown.
-     *         Use {@link #sanitizeMetricName(String)} to convert arbitrary Strings to valid names.</li>
-     *     <li>If unit != null, the name SHOULD contain the unit as a suffix. Example:
-     *         <pre>
-     *         new MetricMetadata("cache_size_bytes", "current size of the cache", Unit.BYTES);
-     *         </pre>
-     *         This is not enforced. No Exception will be thrown if the name does not have the unit as suffix.</li>
-     *     <li>The name MUST NOT contain the {@code _total} or {@code _created} suffixes for counters,
-     *         the {@code _count}, {@code _sum}, or {@code _created} suffixes for summaries,
-     *         the {@code _count}, {@code _sum}, {@code _bucket}, or {@code _created} suffixes for classic histograms,
-     *         the {@code _gcount}, {@code _gsum}, {@code _bucket} suffixes for classic gauge histograms,
-     *         or the {@code _info} suffix for info metrics.</li>
-     * </ul>
-     *
-     * @param name must follow the naming conventions described above.
+     * Constructor.
+     * @param name must not be {@code null}. {@link PrometheusNaming#isValidMetricName(String) isValidMetricName(name)}
+     *             must be {@code true}. Use {@link PrometheusNaming#sanitizeMetricName(String)} to convert arbitrary
+     *             strings into valid names.
      * @param help optional. May be {@code null}.
      * @param unit optional. May be {@code null}.
      */
@@ -70,14 +61,27 @@ public final class MetricMetadata {
         this.help = help;
         this.unit = unit;
         validate();
+        this.prometheusName = name.contains(".") ? PrometheusNaming.prometheusName(name) : name;
     }
 
     /**
      * The name does not include the {@code _total} suffix for counter metrics
      * or the {@code _info} suffix for Info metrics.
+     * <p>
+     * The name may contain dots. Use {@link #getPrometheusName()} to get the name in Prometheus format,
+     * i.e. with dots replaced by underscores.
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Same as {@link #getName()} but with dots replaced by underscores.
+     * <p>
+     * This is used by Prometheus exposition formats.
+     */
+    public String getPrometheusName() {
+        return prometheusName;
     }
 
     public String getHelp() {
@@ -96,73 +100,10 @@ public final class MetricMetadata {
         if (name == null) {
             throw new IllegalArgumentException("Missing required field: name is null");
         }
-        if (!isValidMetricName(name)) {
-            throw new IllegalArgumentException("'" + name + "': illegal metric name");
+        String error = PrometheusNaming.validateMetricName(name);
+        if (error != null) {
+            throw new IllegalArgumentException("'" + name + "': Illegal metric name. " + error
+                    + " Call " + PrometheusNaming.class.getSimpleName() + ".sanitizeMetricName(name) to avoid this error.");
         }
-    }
-
-    /**
-     * Test if a metric name is valid. Rules:
-     * <ul>
-     * <li>The name must match {@link #METRIC_NAME_RE}.</li>
-     * <li>The name MUST NOT end with one of the {@link #RESERVED_SUFFIXES}.</li>
-     * </ul>
-     * If a metric has a {@link Unit}, the metric name SHOULD end with the unit as a suffix (note that in
-     * <a href="https://openmetrics.io/">OpenMetrics</a> this is a MUST, but this library does not enforce Unit
-     * suffixes).
-     * <p>
-     * Example: If you create a Counter for a processing time with {@link Unit#SECONDS}, the name should be
-     * {@code processing_time_seconds}. When exposed in OpenMetrics Text format, this will be represented as two
-     * values: {@code processing_time_seconds_total} for the counter value, and the optional
-     * {@code processing_time_seconds_created} timestamp.
-     * <p>
-     * Use {@link #sanitizeMetricName(String)} to convert arbitrary Strings to valid metric names.
-     */
-    public static boolean isValidMetricName(String name) {
-        for (String reservedSuffix : RESERVED_SUFFIXES) {
-            if (name.endsWith(reservedSuffix)) {
-                return false;
-            }
-        }
-        return METRIC_NAME_RE.matcher(name).matches();
-    }
-
-    /**
-     * Convert arbitrary metric names to valid Prometheus metric names.
-     */
-    public static String sanitizeMetricName(String metricName) {
-        if (metricName.isEmpty()) {
-            throw new IllegalArgumentException("Cannot convert an empty string into a valid metric name.");
-        }
-        int length = metricName.length();
-        char[] sanitized = new char[length];
-        for (int i = 0; i < length; i++) {
-            char ch = metricName.charAt(i);
-            if (ch == ':' ||
-                    (ch >= 'a' && ch <= 'z') ||
-                    (ch >= 'A' && ch <= 'Z') ||
-                    (i > 0 && ch >= '0' && ch <= '9')) {
-                sanitized[i] = ch;
-            } else {
-                sanitized[i] = '_';
-            }
-        }
-        String sanitizedString = new String(sanitized);
-        boolean modified = true;
-        while (modified) {
-            modified = false;
-            for (String reservedSuffix : RESERVED_SUFFIXES) {
-                if (sanitizedString.equals(reservedSuffix)) {
-                    // This is for the corner case when you call sanitizeMetricName("_total").
-                    // In that case the result will be "total".
-                    return reservedSuffix.substring(1);
-                }
-                if (sanitizedString.endsWith(reservedSuffix)) {
-                    sanitizedString = sanitizedString.substring(0, sanitizedString.length() - reservedSuffix.length());
-                    modified = true;
-                }
-            }
-        }
-        return sanitizedString;
     }
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricSnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricSnapshot.java
@@ -20,10 +20,13 @@ public abstract class MetricSnapshot {
     }
 
     protected MetricSnapshot(MetricMetadata metadata, Collection<? extends DataPointSnapshot> data) {
-        this.metadata = metadata;
-        if (data == null) {
-            throw new NullPointerException();
+        if (metadata == null) {
+            throw new NullPointerException("metadata");
         }
+        if (data == null) {
+            throw new NullPointerException("data");
+        }
+        this.metadata = metadata;
         List<? extends DataPointSnapshot> dataCopy = new ArrayList<>(data);
         dataCopy.sort(Comparator.comparing(DataPointSnapshot::getLabels));
         this.data = Collections.unmodifiableList(dataCopy);
@@ -56,7 +59,7 @@ public abstract class MetricSnapshot {
         /**
          * The name is required.
          * If the name is missing or invalid, {@code build()} will throw an {@link IllegalArgumentException}.
-         * See {@link MetricMetadata#isValidMetricName(String)} for info on valid metric names.
+         * See {@link PrometheusNaming#isValidMetricName(String)} for info on valid metric names.
          */
         public T withName(String name) {
             this.name = name;

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricSnapshots.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricSnapshots.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Comparator.comparing;
 
@@ -36,10 +37,10 @@ public class MetricSnapshots implements Iterable<MetricSnapshot> {
      */
     public MetricSnapshots(Collection<MetricSnapshot> snapshots) {
         List<MetricSnapshot> list = new ArrayList<>(snapshots);
-        list.sort(comparing(s -> s.getMetadata().getName()));
+        list.sort(comparing(s -> s.getMetadata().getPrometheusName()));
         for (int i = 0; i < snapshots.size() - 1; i++) {
-            if (list.get(i).getMetadata().getName().equals(list.get(i + 1).getMetadata().getName())) {
-                throw new IllegalArgumentException(list.get(i).getMetadata().getName() + ": duplicate metric name");
+            if (list.get(i).getMetadata().getPrometheusName().equals(list.get(i + 1).getMetadata().getPrometheusName())) {
+                throw new IllegalArgumentException(list.get(i).getMetadata().getPrometheusName() + ": duplicate metric name");
             }
         }
         this.snapshots = unmodifiableList(list);
@@ -79,7 +80,7 @@ public class MetricSnapshots implements Iterable<MetricSnapshot> {
 
         public boolean containsMetricName(String name) {
             for (MetricSnapshot snapshot : snapshots) {
-                if (snapshot.getMetadata().getName().equals(name)) {
+                if (snapshot.getMetadata().getPrometheusName().equals(prometheusName(name))) {
                     return true;
                 }
             }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
@@ -1,0 +1,178 @@
+package io.prometheus.metrics.model.snapshots;
+
+import java.util.regex.Pattern;
+
+/**
+ * Utility for Prometheus Metric and Label naming.
+ * <p>
+ * Note that this library allows dots in metric and label names. Dots will automatically be replaced with underscores
+ * in Prometheus exposition formats. However, if metrics are exposed in OpenTelemetry format the dots are retained.
+ */
+public class PrometheusNaming {
+
+    /**
+     * Legal characters for metric names, including dot.
+     */
+    private static final Pattern METRIC_NAME_PATTERN = Pattern.compile("^[a-zA-Z_.:][a-zA-Z0-9_.:]+$");
+
+    /**
+     * Legal characters for label names, including dot.
+     */
+    private static final Pattern LABEL_NAME_PATTERN = Pattern.compile("^[a-zA-Z_.][a-zA-Z0-9_.]*$");
+
+    /**
+     * According to OpenMetrics {@code _count} and {@code _sum} (and {@code _gcount}, {@code _gsum}) should also be
+     * reserved metric name suffixes. However, popular instrumentation libraries have Gauges with names
+     * ending in {@code _count}.
+     * Examples:
+     * <ul>
+     * <li>Micrometer: {@code jvm_buffer_count}</li>
+     * <li>OpenTelemetry: {@code process_runtime_jvm_buffer_count}</li>
+     * </ul>
+     * We do not treat {@code _count} and {@code _sum} as reserved suffixes here for compatibility with these libraries.
+     * However, there is a risk of name conflict if someone creates a gauge named {@code my_data_count} and a
+     * histogram or summary named {@code my_data}, because the histogram or summary will implicitly have a sample
+     * named {@code my_data_count}.
+     */
+    private static final String[] RESERVED_METRIC_NAME_SUFFIXES = {
+            "_total", "_created", "_bucket", "_info",
+            ".total", ".created", ".bucket", ".info"
+    };
+
+    /**
+     * Test if a metric name is valid. Rules:
+     * <ul>
+     * <li>The name must match {@link #METRIC_NAME_PATTERN}.</li>
+     * <li>The name MUST NOT end with one of the {@link #RESERVED_METRIC_NAME_SUFFIXES}.</li>
+     * </ul>
+     * If a metric has a {@link Unit}, the metric name SHOULD end with the unit as a suffix.
+     * Note that <a href="https://openmetrics.io/">OpenMetrics</a> requires metric names to have their unit as suffix,
+     * and we implement this in {@code prometheus-metrics-core}. However, {@code prometheus-metrics-model}
+     * does not enforce Unit suffixes.
+     * <p>
+     * Example: If you create a Counter for a processing time with Unit {@link Unit#SECONDS SECONDS},
+     * the name should be {@code processing_time_seconds}. When exposed in OpenMetrics Text format,
+     * this will be represented as two values: {@code processing_time_seconds_total} for the counter value,
+     * and the optional {@code processing_time_seconds_created} timestamp.
+     * <p>
+     * Use {@link #sanitizeMetricName(String)} to convert arbitrary Strings to valid metric names.
+     */
+    public static boolean isValidMetricName(String name) {
+        return validateMetricName(name) == null;
+    }
+
+    /**
+     * Same as {@link #isValidMetricName(String)}, but produces an error message.
+     * <p>
+     * The name is valid if the error message is {@code null}.
+     */
+    static String validateMetricName(String name) {
+        for (String reservedSuffix : RESERVED_METRIC_NAME_SUFFIXES) {
+            if (name.endsWith(reservedSuffix)) {
+                return "The metric name must not include the '" + reservedSuffix + "' suffix.";
+            }
+        }
+        if (!METRIC_NAME_PATTERN.matcher(name).matches()) {
+            return "The metric name contains unsupported characters";
+        }
+        return null;
+    }
+
+    public static boolean isValidLabelName(String name) {
+        return LABEL_NAME_PATTERN.matcher(name).matches() &&
+                !(name.startsWith("__") || name.startsWith("._") || name.startsWith("..") || name.startsWith("_."));
+    }
+
+    /**
+     * Get the metric or label name that is used in Prometheus exposition format.
+     *
+     * @param name must be a valid metric or label name,
+     *             i.e. {@link #isValidMetricName(String) isValidMetricName(name)}
+     *             or {@link #isValidLabelName(String) isValidLabelName(name)}  must be true.
+     * @return the name with dots replaced by underscores.
+     */
+    public static String prometheusName(String name) {
+        return name.replace(".", "_");
+    }
+
+    /**
+     * Convert an arbitrary string to a name where {@link #isValidMetricName(String) isValidMetricName(name)} is true.
+     */
+    public static String sanitizeMetricName(String metricName) {
+        if (metricName.isEmpty()) {
+            throw new IllegalArgumentException("Cannot convert an empty string to a valid metric name.");
+        }
+        String sanitizedName = replaceIllegalCharsInMetricName(metricName);
+        boolean modified = true;
+        while (modified) {
+            modified = false;
+            for (String reservedSuffix : RESERVED_METRIC_NAME_SUFFIXES) {
+                if (sanitizedName.equals(reservedSuffix)) {
+                    // This is for the corner case when you call sanitizeMetricName("_total").
+                    // In that case the result will be "total".
+                    return reservedSuffix.substring(1);
+                }
+                if (sanitizedName.endsWith(reservedSuffix)) {
+                    sanitizedName = sanitizedName.substring(0, sanitizedName.length() - reservedSuffix.length());
+                    modified = true;
+                }
+            }
+        }
+        return sanitizedName;
+    }
+
+    /**
+     * Convert an arbitrary string to a name where {@link #isValidLabelName(String) isValidLabelName(name)} is true.
+     */
+    public static String sanitizeLabelName(String labelName) {
+        if (labelName.isEmpty()) {
+            throw new IllegalArgumentException("Cannot convert an empty string to a valid label name.");
+        }
+        String sanitizedName = replaceIllegalCharsInLabelName(labelName);
+        while (sanitizedName.startsWith("__") || sanitizedName.startsWith("_.") || sanitizedName.startsWith("._") || sanitizedName.startsWith("..")) {
+            sanitizedName = sanitizedName.substring(1);
+        }
+        return sanitizedName;
+    }
+
+    /**
+     * Returns a string that matches {@link #METRIC_NAME_PATTERN}.
+     */
+    private static String replaceIllegalCharsInMetricName(String name) {
+        int length = name.length();
+        char[] sanitized = new char[length];
+        for (int i = 0; i < length; i++) {
+            char ch = name.charAt(i);
+            if (ch == ':' ||
+                    ch == '.' ||
+                    (ch >= 'a' && ch <= 'z') ||
+                    (ch >= 'A' && ch <= 'Z') ||
+                    (i > 0 && ch >= '0' && ch <= '9')) {
+                sanitized[i] = ch;
+            } else {
+                sanitized[i] = '_';
+            }
+        }
+        return new String(sanitized);
+    }
+
+    /**
+     * Returns a string that matches {@link #LABEL_NAME_PATTERN}.
+     */
+    private static String replaceIllegalCharsInLabelName(String name) {
+        int length = name.length();
+        char[] sanitized = new char[length];
+        for (int i = 0; i < length; i++) {
+            char ch = name.charAt(i);
+            if (ch == '.' ||
+                    (ch >= 'a' && ch <= 'z') ||
+                    (ch >= 'A' && ch <= 'Z') ||
+                    (i > 0 && ch >= '0' && ch <= '9')) {
+                sanitized[i] = ch;
+            } else {
+                sanitized[i] = '_';
+            }
+        }
+        return new String(sanitized);
+    }
+}

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/StateSetSnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/StateSetSnapshot.java
@@ -30,8 +30,8 @@ public final class StateSetSnapshot extends MetricSnapshot {
             throw new IllegalArgumentException("An state set metric cannot have a unit.");
         }
         for (StateSetDataPointSnapshot entry : getData()) {
-            if (entry.getLabels().contains(getMetadata().getName())) {
-                throw new IllegalArgumentException("Label name " + getMetadata().getName() + " is reserved.");
+            if (entry.getLabels().contains(getMetadata().getPrometheusName())) {
+                throw new IllegalArgumentException("Label name " + getMetadata().getPrometheusName() + " is reserved.");
             }
         }
     }

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/registry/PrometheusRegistryTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/registry/PrometheusRegistryTest.java
@@ -1,0 +1,82 @@
+package io.prometheus.metrics.model.registry;
+
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PrometheusRegistryTest {
+
+    Collector noName = new Collector() {
+        @Override
+        public MetricSnapshot collect() {
+            return GaugeSnapshot.newBuilder()
+                    .withName("no_name_gauge")
+                    .build();
+        }
+
+        @Override
+        public String getPrometheusName() {
+            return null;
+        }
+    };
+
+    Collector counterA1 = () -> CounterSnapshot.newBuilder()
+            .withName("counter_a")
+            .build();
+
+    Collector counterA2 = () -> CounterSnapshot.newBuilder()
+            .withName("counter.a")
+            .build();
+
+    Collector counterB = () -> CounterSnapshot.newBuilder()
+            .withName("counter_b")
+            .build();
+
+    Collector gaugeA = () -> GaugeSnapshot.newBuilder()
+            .withName("gauge_a")
+            .build();
+
+    @Test
+    public void registerNoName() {
+        PrometheusRegistry registry = new PrometheusRegistry();
+        // If the collector does not have a name at registration time, there is no conflict during registration.
+        registry.register(noName);
+        registry.register(noName);
+        // However, at scrape time the collector has to provide a metric name, and then we'll get a duplicat name error.
+        try {
+            registry.scrape();
+        } catch (IllegalStateException e) {
+            Assert.assertTrue(e.getMessage().contains("duplicate") && e.getMessage().contains("no_name_gauge"));
+            return;
+        }
+        Assert.fail("Expected duplicate name exception");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void registerDuplicateName() {
+        PrometheusRegistry registry = new PrometheusRegistry();
+        registry.register(counterA1);
+        registry.register(counterA2);
+    }
+
+    @Test
+    public void registerOk() {
+        PrometheusRegistry registry = new PrometheusRegistry();
+        registry.register(counterA1);
+        registry.register(counterB);
+        registry.register(gaugeA);
+        MetricSnapshots snapshots = registry.scrape();
+        Assert.assertEquals(3, snapshots.size());
+
+        registry.unregister(counterB);
+        snapshots = registry.scrape();
+        Assert.assertEquals(2, snapshots.size());
+
+        registry.register(counterB);
+        snapshots = registry.scrape();
+        Assert.assertEquals(3, snapshots.size());
+    }
+}

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/GaugeSnapshotTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/GaugeSnapshotTest.java
@@ -88,6 +88,11 @@ public class GaugeSnapshotTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testTotalSuffixPresentDot() {
+        CounterSnapshot.newBuilder().withName("test.total").build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testValueMissing() {
         CounterDataPointSnapshot.newBuilder().build();
     }

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/InfoSnapshotTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/InfoSnapshotTest.java
@@ -43,4 +43,18 @@ public class InfoSnapshotTest {
         iterator.next();
         iterator.remove();
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNameMustNotIncludeSuffix() {
+        InfoSnapshot.newBuilder()
+                .withName("jvm_info")
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNameMustNotIncludeSuffixDot() {
+        InfoSnapshot.newBuilder()
+                .withName("jvm.info")
+                .build();
+    }
 }

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/LabelsTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/LabelsTest.java
@@ -2,8 +2,10 @@ package io.prometheus.metrics.model.snapshots;
 
 import io.prometheus.metrics.model.snapshots.Labels;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.sanitizeLabelName;
 import static org.junit.Assert.assertNotEquals;
 
 public class LabelsTest {
@@ -47,6 +49,20 @@ public class LabelsTest {
         assertNotEquals(labels2, labels1);
     }
 
+    @Test
+    public void testComparePrometheusNames() {
+        Labels labels1 = Labels.of("my_a", "val");
+        Labels labels2 = Labels.of("my.b", "val");
+        assertLessThan(labels1, labels2); // this is true because it compares "my_a" to "my_b".
+    }
+
+    @Test
+    public void testEqualsHashcodeDots() {
+        Labels labels1 = Labels.of("my_a", "val");
+        Labels labels2 = Labels.of("my.a", "val");
+        Assert.assertEquals(labels1, labels2);
+        Assert.assertEquals(labels1.hashCode(), labels2.hashCode());
+    }
 
     @Test
     public void testCompareEquals() {
@@ -60,7 +76,7 @@ public class LabelsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testIllegalLabelName() {
-        Labels.of("http.status_code", "200");
+        Labels.of("my_service/status", "200");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -68,13 +84,48 @@ public class LabelsTest {
         Labels.of("__name__", "requests_total");
     }
 
-    @Test
-    public void testSanitizeLabelName() {
-        Assert.assertEquals("_my_label", Labels.sanitizeLabelName("...my/label"));
-    }
-
     @Test(expected = IllegalArgumentException.class)
     public void testDuplicateLabelName() {
         Labels.of("name1", "value1", "name2", "value2", "name1", "value3");
+    }
+
+    @Test
+    public void testMakePrometheusNames() {
+        String[] names = new String[]{};
+        String[] prometheusNames = Labels.makePrometheusNames(names);
+        Assert.assertSame(names, prometheusNames);
+
+        names = new String[]{"no_dots", "at_all"};
+        prometheusNames = Labels.makePrometheusNames(names);
+        Assert.assertSame(names, prometheusNames);
+
+        names = new String[]{"dots", "here.it.is"};
+        prometheusNames = Labels.makePrometheusNames(names);
+        Assert.assertNotSame(names, prometheusNames);
+        Assert.assertSame(names[0], prometheusNames[0]);
+        Assert.assertEquals("here.it.is", names[1]);
+        Assert.assertEquals("here_it_is", prometheusNames[1]);
+    }
+
+    @Test
+    public void testMerge() {
+        Labels labels1 = Labels.of("key.1", "value 1", "key.3", "value 3");
+        Labels labels2 = Labels.of("key_2", "value 2");
+        Labels merged = labels2.merge(labels1);
+        Assert.assertEquals("key.1", merged.getName(0));
+        Assert.assertEquals("key_2", merged.getName(1));
+        Assert.assertEquals("key.3", merged.getName(2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMergeDuplicateName() {
+        Labels labels1 = Labels.of("key_one", "v1");
+        Labels labels2 = Labels.of("key.one", "v2");
+        labels2.merge(labels1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDuplicateName() {
+        Labels.of("key_one", "v1", "key.one", "v2");
     }
 }

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
@@ -1,9 +1,10 @@
 package io.prometheus.metrics.model.snapshots;
 
-import io.prometheus.metrics.model.snapshots.MetricMetadata;
-import io.prometheus.metrics.model.snapshots.Unit;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.sanitizeMetricName;
 
 public class MetricMetadataTest {
 
@@ -19,37 +20,38 @@ public class MetricMetadataTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testIllegalName() {
-        new MetricMetadata("http.server.duration");
+        new MetricMetadata("my_namespace/http_server_duration"); // let's see when we decide to allow slashes :)
     }
 
     @Test
     public void testSanitizationIllegalCharacters() {
-        MetricMetadata metadata = new MetricMetadata(MetricMetadata.sanitizeMetricName("http.server.duration"), "help string", Unit.SECONDS);
-        Assert.assertEquals("http_server_duration", metadata.getName());
+        MetricMetadata metadata = new MetricMetadata(sanitizeMetricName("my_namespace/http.server.duration"), "help string", Unit.SECONDS);
+        Assert.assertEquals("my_namespace_http.server.duration", metadata.getName());
+        Assert.assertEquals("my_namespace_http_server_duration", metadata.getPrometheusName());
         Assert.assertEquals("help string", metadata.getHelp());
         Assert.assertEquals("seconds", metadata.getUnit().toString());
     }
 
     @Test
     public void testSanitizationCounter() {
-        MetricMetadata metadata = new MetricMetadata(MetricMetadata.sanitizeMetricName("my_events_total"));
+        MetricMetadata metadata = new MetricMetadata(sanitizeMetricName("my_events_total"));
         Assert.assertEquals("my_events", metadata.getName());
     }
 
     @Test
     public void testSanitizationInfo() {
-        MetricMetadata metadata = new MetricMetadata(MetricMetadata.sanitizeMetricName("target_info"));
+        MetricMetadata metadata = new MetricMetadata(sanitizeMetricName("target_info"));
         Assert.assertEquals("target", metadata.getName());
     }
 
     @Test
     public void testSanitizationWeirdCornerCase() {
-        MetricMetadata metadata = new MetricMetadata(MetricMetadata.sanitizeMetricName("_total_created"));
+        MetricMetadata metadata = new MetricMetadata(sanitizeMetricName("_total_created"));
         Assert.assertEquals("total", metadata.getName());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testSanitizeEmptyString() {
-        MetricMetadata.sanitizeMetricName("");
+        sanitizeMetricName("");
     }
 }

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
@@ -1,0 +1,34 @@
+package io.prometheus.metrics.model.snapshots;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.sanitizeLabelName;
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.sanitizeMetricName;
+
+public class PrometheusNamingTest {
+
+    @Test
+    public void testSanitizeMetricName() {
+        Assert.assertEquals("_abc_def", prometheusName(sanitizeMetricName("0abc.def")));
+        Assert.assertEquals("___ab_:c0", prometheusName(sanitizeMetricName("___ab.:c0")));
+        Assert.assertEquals("my_prefix_my_metric", sanitizeMetricName("my_prefix/my_metric"));
+        Assert.assertEquals("my_counter", prometheusName(sanitizeMetricName("my_counter_total")));
+        Assert.assertEquals("jvm", sanitizeMetricName("jvm.info"));
+        Assert.assertEquals("jvm", sanitizeMetricName("jvm_info"));
+        Assert.assertEquals("jvm", sanitizeMetricName("jvm.info"));
+        Assert.assertEquals("a.b", sanitizeMetricName("a.b"));
+    }
+
+    @Test
+    public void testSanitizeLabelName() {
+        Assert.assertEquals("_abc_def", prometheusName(sanitizeLabelName("0abc.def")));
+        Assert.assertEquals("_abc", prometheusName(sanitizeLabelName("_abc")));
+        Assert.assertEquals("_abc", prometheusName(sanitizeLabelName("__abc")));
+        Assert.assertEquals("_abc", prometheusName(sanitizeLabelName("___abc")));
+        Assert.assertEquals("_abc", prometheusName(sanitizeLabelName("_.abc")));
+        Assert.assertEquals("abc.def", sanitizeLabelName("abc.def"));
+        Assert.assertEquals("abc.def2", sanitizeLabelName("abc.def2"));
+    }
+}


### PR DESCRIPTION
Internal refactoring to allow dots in metric names and label names.

This feature is currently not exposed, because all Prometheus exposition formats use the Prometheus names, i.e. names with `.` replaced by `_`.

However, if we add OpenTelemetry metrics as exposition format in the future, OpenTelemetry woudl use the names with dots. This PR is to prepare for adding OpenTelemetry as an exposition format.