### PR TITLE
fix: patched typo in SimpleCollector.java JavaDoc

### DIFF
--- a/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
+++ b/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java
@@ -58,7 +58,7 @@ public abstract class SimpleCollector<Child> extends Collector {
   /**
    * Return the Child with the given labels, creating it if needed.
    * <p>
-   * Must be passed the same number of labels are were passed to {@link #labelNames}.
+   * Must be passed the same number of labels which were passed to {@link #labelNames}.
    */
   public Child labels(String... labelValues) {
     if (labelValues.length != labelNames.size()) {


### PR DESCRIPTION
Simple pull request to patch a JavaDoc error found when using `SimpleCollector.java`.