### PR TITLE
Fix Java 21 build

### DIFF
--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/HistogramTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/HistogramTest.java
@@ -530,7 +530,7 @@ public class HistogramTest {
                         "sample_count: 2 " +
                                 "sample_sum: -7.0 " +
                                 "schema: 2 " +
-                                "zero_threshold: 2.9387358770557188E-39 " +
+                                "zero_threshold: " + Math.pow(2.0, -128.0) + " " +
                                 "zero_count: 0 " +
                                 "negative_span { offset: 7 length: 2 } " +
                                 "negative_delta: 1 " +
@@ -564,7 +564,7 @@ public class HistogramTest {
                         "sample_count: 2 " +
                                 "sample_sum: 7.0 " +
                                 "schema: 2 " +
-                                "zero_threshold: 2.9387358770557188E-39 " +
+                                "zero_threshold: " + Math.pow(2.0, -128.0) + " " +
                                 "zero_count: 0 " +
                                 "positive_span { offset: 7 length: 2 } " +
                                 "positive_delta: 1 " +


### PR DESCRIPTION
Java 21 has the following changes:

* `Math.pow(2.0, -128.0)` is 2.938735877055719E-39 (was 2.9387358770557188E-39 with previous Java versions)
* It's no longer possible to create Threads with invalid Thread ids.

Turns out, we have tests for that, so the tests need to be adapted to work with Java 21.