### PR TITLE
Remove scrape() from getPrometheusName() default implementation

### DIFF
--- a/integration-tests/it-exporter/it-exporter-httpserver-sample/src/main/java/io/prometheus/metrics/it/exporter/httpserver/HTTPServerSample.java
+++ b/integration-tests/it-exporter/it-exporter-httpserver-sample/src/main/java/io/prometheus/metrics/it/exporter/httpserver/HTTPServerSample.java
@@ -53,17 +53,8 @@ public class HTTPServerSample {
         gauge.labelValues("outside").set(27.0);
 
         if (mode == Mode.error) {
-            Collector failingCollector = new Collector() {
-
-                @Override
-                public String getPrometheusName() {
-                    return null;
-                }
-
-                @Override
-                public MetricSnapshot collect() {
-                    throw new RuntimeException("Simulating an error.");
-                }
+            Collector failingCollector = () -> {
+                throw new RuntimeException("Simulating an error.");
             };
 
             PrometheusRegistry.defaultRegistry.register(failingCollector);

--- a/integration-tests/it-exporter/it-exporter-servlet-jetty-sample/src/main/java/io/prometheus/metrics/it/exporter/servlet/jetty/ExporterServletJettySample.java
+++ b/integration-tests/it-exporter/it-exporter-servlet-jetty-sample/src/main/java/io/prometheus/metrics/it/exporter/servlet/jetty/ExporterServletJettySample.java
@@ -57,17 +57,8 @@ public class ExporterServletJettySample {
         gauge.labelValues("outside").set(27.0);
 
         if (mode == Mode.error) {
-            Collector failingCollector = new Collector() {
-
-                @Override
-                public String getPrometheusName() {
-                    return null;
-                }
-
-                @Override
-                public MetricSnapshot collect() {
-                    throw new RuntimeException("Simulating an error.");
-                }
+            Collector failingCollector = () -> {
+                throw new RuntimeException("Simulating an error.");
             };
 
             PrometheusRegistry.defaultRegistry.register(failingCollector);

--- a/integration-tests/it-exporter/it-exporter-servlet-tomcat-sample/src/main/java/io/prometheus/metrics/it/exporter/servlet/tomcat/ExporterServletTomcatSample.java
+++ b/integration-tests/it-exporter/it-exporter-servlet-tomcat-sample/src/main/java/io/prometheus/metrics/it/exporter/servlet/tomcat/ExporterServletTomcatSample.java
@@ -61,17 +61,8 @@ public class ExporterServletTomcatSample {
         gauge.labelValues("outside").set(27.0);
 
         if (mode == Mode.error) {
-            Collector failingCollector = new Collector() {
-
-                @Override
-                public String getPrometheusName() {
-                    return null;
-                }
-
-                @Override
-                public MetricSnapshot collect() {
-                    throw new RuntimeException("Simulating an error.");
-                }
+            Collector failingCollector = () -> {
+                throw new RuntimeException("Simulating an error.");
             };
 
             PrometheusRegistry.defaultRegistry.register(failingCollector);

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/Collector.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/Collector.java
@@ -34,10 +34,20 @@ public interface Collector {
     }
 
     /**
-     * Override this and return {@code null} if a collector does not have a constant name,
-     * or if you don't want this library to call {@link #collect()} during registration of this collector.
+     * This is called in two places:
+     * <ol>
+     * <li>During registration to check if a metric with that name already exists.</li>
+     * <li>During scrape to check if this collector can be skipped because a name filter is present and the metric name is excluded.</li>
+     * </ol>
+     * Returning {@code null} means checks are omitted (registration the metric always succeeds),
+     * and the collector is always scraped (the result is dropped after scraping if a name filter is present and
+     * the metric name is excluded).
+     * <p>
+     * If your metric has a name that does not change at runtime it is a good idea to overwrite this and return the name.
+     * <p>
+     * All metrics in {@code prometheus-metrics-core} override this.
      */
     default String getPrometheusName() {
-        return collect().getMetadata().getPrometheusName();
+        return null;
     }
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/MultiCollector.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/MultiCollector.java
@@ -3,9 +3,9 @@ package io.prometheus.metrics.model.registry;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Like {@link Collector}, but collecting multiple Snapshots at once.
@@ -35,10 +35,18 @@ public interface MultiCollector {
     }
 
     /**
-     * Override this and return an empty list if the MultiCollector does not return a constant list of names
-     * (names may be added / removed between scrapes).
+     * This is called in two places:
+     * <ol>
+     * <li>During registration to check if a metric with that name already exists.</li>
+     * <li>During scrape to check if the collector can be skipped because a name filter is present and all names are excluded.</li>
+     * </ol>
+     * Returning an empty list means checks are omitted (registration metric always succeeds),
+     * and the collector is always scraped (if a name filter is present and all names are excluded the result is dropped).
+     * <p>
+     * If your collector returns a constant list of metrics that have names that do not change at runtime
+     * it is a good idea to overwrite this and return the names.
      */
     default List<String> getPrometheusNames() {
-        return collect().stream().map(snapshot -> snapshot.getMetadata().getPrometheusName()).collect(Collectors.toList());
+        return Collections.emptyList();
     }
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/PrometheusRegistry.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/PrometheusRegistry.java
@@ -40,7 +40,10 @@ public class PrometheusRegistry {
 
     public void unregister(Collector collector) {
         collectors.remove(collector);
-        prometheusNames.remove(collector.getPrometheusName());
+        String prometheusName = collector.getPrometheusName();
+        if (prometheusName != null) {
+            prometheusNames.remove(collector.getPrometheusName());
+        }
     }
 
     public void unregister(MultiCollector collector) {
@@ -88,7 +91,7 @@ public class PrometheusRegistry {
         }
         for (MultiCollector collector : multiCollectors) {
             List<String> prometheusNames = collector.getPrometheusNames();
-            boolean excluded = true; // the multi-collector is excluded unless at least one name matches
+            boolean excluded = prometheusNames.size() > 0; // the multi-collector is excluded unless at least one name matches
             for (String prometheusName : prometheusNames) {
                 if (includedNames.test(prometheusName)) {
                     excluded = false;

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/registry/PrometheusRegistryTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/registry/PrometheusRegistryTest.java
@@ -9,35 +9,57 @@ import org.junit.Test;
 
 public class PrometheusRegistryTest {
 
-    Collector noName = new Collector() {
+    Collector noName = () -> GaugeSnapshot.builder()
+            .name("no_name_gauge")
+            .build();
+
+    Collector counterA1 = new Collector() {
         @Override
         public MetricSnapshot collect() {
-            return GaugeSnapshot.builder()
-                    .name("no_name_gauge")
-                    .build();
+            return CounterSnapshot.builder().name("counter_a").build();
         }
 
         @Override
         public String getPrometheusName() {
-            return null;
+            return "counter_a";
         }
     };
 
-    Collector counterA1 = () -> CounterSnapshot.builder()
-            .name("counter_a")
-            .build();
+    Collector counterA2 = new Collector() {
+        @Override
+        public MetricSnapshot collect() {
+            return CounterSnapshot.builder().name("counter.a").build();
+        }
 
-    Collector counterA2 = () -> CounterSnapshot.builder()
-            .name("counter.a")
-            .build();
+        @Override
+        public String getPrometheusName() {
+            return "counter_a";
+        }
+    };
 
-    Collector counterB = () -> CounterSnapshot.builder()
-            .name("counter_b")
-            .build();
+    Collector counterB = new Collector() {
+        @Override
+        public MetricSnapshot collect() {
+            return CounterSnapshot.builder().name("counter_b").build();
+        }
 
-    Collector gaugeA = () -> GaugeSnapshot.builder()
-            .name("gauge_a")
-            .build();
+        @Override
+        public String getPrometheusName() {
+            return "counter_b";
+        }
+    };
+
+    Collector gaugeA = new Collector() {
+        @Override
+        public MetricSnapshot collect() {
+            return GaugeSnapshot.builder().name("gauge_a").build();
+        }
+
+        @Override
+        public String getPrometheusName() {
+            return "gauge_a";
+        }
+    };
 
     @Test
     public void registerNoName() {

--- a/prometheus-metrics-simpleclient-bridge/src/main/java/io/prometheus/metrics/simpleclient/bridge/SimpleclientCollector.java
+++ b/prometheus-metrics-simpleclient-bridge/src/main/java/io/prometheus/metrics/simpleclient/bridge/SimpleclientCollector.java
@@ -61,16 +61,6 @@ public class SimpleclientCollector implements MultiCollector {
         return convert(simpleclientRegistry.metricFamilySamples());
     }
 
-    @Override
-    public MetricSnapshots collect(Predicate<String> includedNames) {
-        return MultiCollector.super.collect(includedNames);
-    }
-
-    @Override
-    public List<String> getPrometheusNames() {
-        return MultiCollector.super.getPrometheusNames();
-    }
-
     private MetricSnapshots convert(Enumeration<Collector.MetricFamilySamples> samples) {
         MetricSnapshots.Builder result = MetricSnapshots.builder();
         while (samples.hasMoreElements()) {


### PR DESCRIPTION
The `Collector` (and `MultiCollector`) interface defines a method `getPrometheusName()` (or `getPrometheusNames()`) to get the list of metric names produced by the collector.

This method is optional. It is used during registration to check for duplicate metrics, and it is used during scrape if a name filter is present to check if this collector can be skipped because the name(s) are excluded.

The default implementation was to call `collect()` to learn the Prometheus names. However, this leads to two `collect()` calls when scraping: The first to check the name filter, the second for the actual scrape.

With this PR we change this to returning `null` (or empty list) indicating that the names are unknown.

This does not affect the metrics in `prometheus-metrics-core`, because all metrics in `prometheus-metrics-core` override this.