### PR TITLE
Remove unneccessary name filter

### DIFF
--- a/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusHttpRequest.java
+++ b/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusHttpRequest.java
@@ -62,7 +62,12 @@ public interface PrometheusHttpRequest {
                     }
                 }
             }
-            return result.toArray(new String[0]);
+            if (result.isEmpty()) {
+                // Servlet API: getParameterValues() returns null if the parameter does not exist.
+                return null;
+            } else {
+                return result.toArray(new String[0]);
+            }
         } catch (UnsupportedEncodingException e) {
             // UTF-8 encoding not supported.
             throw new RuntimeException(e);

--- a/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusScrapeHandler.java
+++ b/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusScrapeHandler.java
@@ -114,7 +114,7 @@ public class PrometheusScrapeHandler {
 
     private Predicate<String> makeNameFilter(String[] includedNames) {
         Predicate<String> result = null;
-        if (includedNames != null) {
+        if (includedNames != null && includedNames.length > 0) {
             result = MetricNameFilter.builder().nameMustBeEqualTo(includedNames).build();
         }
         if (result != null && nameFilter != null) {


### PR DESCRIPTION
The `HTTPServer` exporter created an unneccessary empty name filter when no `name[]` parameter is present.

This PR removes this.