### PR TITLE
Fix time unit for process_cpu_seconds_total #881

### DIFF
--- a/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/ProcessMetrics.java
+++ b/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/ProcessMetrics.java
@@ -94,7 +94,7 @@ public class ProcessMetrics {
                         // through implemented interfaces until the method can be made accessible and invoked.
                         Long processCpuTime = callLongGetter("getProcessCpuTime", osBean);
                         if (processCpuTime != null) {
-                            callback.call(Unit.millisToSeconds(processCpuTime));
+                            callback.call(Unit.nanosToSeconds(processCpuTime));
                         }
                     } catch (Exception ignored) {
                     }

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/ProcessMetricsTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/ProcessMetricsTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mockito;
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.RuntimeMXBean;
+import java.util.concurrent.TimeUnit;
 
 import static io.prometheus.metrics.instrumentation.jvm.TestUtil.convertToOpenMetricsFormat;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,7 +30,7 @@ public class ProcessMetricsTest {
 
     @Before
     public void setUp() throws IOException {
-        when(sunOsBean.getProcessCpuTime()).thenReturn(72L);
+        when(sunOsBean.getProcessCpuTime()).thenReturn(TimeUnit.MILLISECONDS.toNanos(72));
         when(sunOsBean.getOpenFileDescriptorCount()).thenReturn(127L);
         when(sunOsBean.getMaxFileDescriptorCount()).thenReturn(244L);
         when(runtimeBean.getStartTime()).thenReturn(37100L);


### PR DESCRIPTION
Fixes the bug reported in #881:

> In `io.prometheus.metrics.instrumentation.jvm.ProcessMetrics`, the value returned from `callLongGetter("getProcessCpuTime", osBean)` is in nanoseconds, but is scaled with `Unit.millisToSeconds(processCpuTime)`