### PR TITLE
Fixes issue #887: Sort histogram bounds before validation

### DIFF
--- a/prometheus-metrics-simpleclient-bridge/src/main/java/io/prometheus/metrics/simpleclient/bridge/SimpleclientCollector.java
+++ b/prometheus-metrics-simpleclient-bridge/src/main/java/io/prometheus/metrics/simpleclient/bridge/SimpleclientCollector.java
@@ -288,8 +288,8 @@ public class SimpleclientCollector implements MultiCollector {
 
     private ClassicHistogramBuckets makeBuckets(Map<Double, Long> cumulativeBuckets) {
         List<Double> upperBounds = new ArrayList<>(cumulativeBuckets.size());
-        Collections.sort(upperBounds);
         upperBounds.addAll(cumulativeBuckets.keySet());
+        Collections.sort(upperBounds);
         ClassicHistogramBuckets.Builder result = ClassicHistogramBuckets.builder();
         long previousCount = 0L;
         for (Double upperBound : upperBounds) {

--- a/prometheus-metrics-simpleclient-bridge/src/test/java/io/prometheus/metrics/simpleclient/bridge/SimpleclientCollectorTest.java
+++ b/prometheus-metrics-simpleclient-bridge/src/test/java/io/prometheus/metrics/simpleclient/bridge/SimpleclientCollectorTest.java
@@ -94,7 +94,7 @@ public class SimpleclientCollectorTest {
                 .name("response_size_bytes")
                 .help("response size in Bytes")
                 .labelNames("status")
-                .buckets(64, 256)
+                .buckets(64, 256, 512.1)
                 .register(origRegistry);
         histogram.labels("200").observeWithExemplar(38, "trace_id", "1", "span_id", "2");
         histogram.labels("200").observeWithExemplar(127, "trace_id", "3", "span_id", "4");


### PR DESCRIPTION
Fixed issue #887 

Do sorting after the bounds array is filled. And added to the unit test the bucket value at which the error occurred.