### PR TITLE
Restore automatic module name #884

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Build client_java
         run: ./mvnw -B clean install -DskipTests
       - name: Make Javadoc
-        run: ./mvnw -B compile javadoc:javadoc javadoc:aggregate
+        run: ./mvnw -B clean compile javadoc:javadoc javadoc:aggregate
       - name: Move the Javadoc to docs/static/api/
         run: mv ./target/site/apidocs ./docs/static/api && echo && echo 'ls ./docs/static/api' && ls ./docs/static/api
       - name: Setup Pages

--- a/pom.xml
+++ b/pom.xml
@@ -193,13 +193,11 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <version>2.4.0</version>
                 <extensions>true</extensions>
-                <!--
                 <configuration>
                     <instructions>
                         <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
                     </instructions>
                 </configuration>
-                -->
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Issue #884 can be fixed by calling

```
./mvnw clean compile javadoc:javadoc javadoc:aggregate
```

instead of

```
./mvnw compile javadoc:javadoc javadoc:aggregate
```