### PR TITLE
Fix metric name filter in MultiCollector #891

### DIFF
--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/registry/MetricNameFilterTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/registry/MetricNameFilterTest.java
@@ -1,11 +1,20 @@
 package io.prometheus.metrics.model.registry;
 
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.CounterSnapshot.CounterDataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot.GaugeDataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 
 public class MetricNameFilterTest {
 
@@ -21,12 +30,12 @@ public class MetricNameFilterTest {
         registry.register(() -> CounterSnapshot.builder()
                 .name("counter1")
                 .help("test counter 1")
-                .dataPoint(CounterSnapshot.CounterDataPointSnapshot.builder()
+                .dataPoint(CounterDataPointSnapshot.builder()
                         .labels(Labels.of("path", "/hello"))
                         .value(1.0)
                         .build()
                 )
-                .dataPoint(CounterSnapshot.CounterDataPointSnapshot.builder()
+                .dataPoint(CounterDataPointSnapshot.builder()
                         .labels(Labels.of("path", "/goodbye"))
                         .value(2.0)
                         .build()
@@ -36,7 +45,7 @@ public class MetricNameFilterTest {
         registry.register(() -> CounterSnapshot.builder()
                 .name("counter2")
                 .help("test counter 2")
-                .dataPoint(CounterSnapshot.CounterDataPointSnapshot.builder()
+                .dataPoint(CounterDataPointSnapshot.builder()
                         .value(1.0)
                         .build()
                 )

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/registry/MultiCollectorNameFilterTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/registry/MultiCollectorNameFilterTest.java
@@ -1,0 +1,100 @@
+package io.prometheus.metrics.model.registry;
+
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.CounterSnapshot.CounterDataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot.GaugeDataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class MultiCollectorNameFilterTest {
+
+    private PrometheusRegistry registry;
+    private boolean[] collectCalled = {false};
+    private Predicate<String> includedNames = null;
+    List<String> prometheusNames = new ArrayList<>();
+
+    @Before
+    public void setUp() {
+        registry = new PrometheusRegistry();
+        collectCalled[0] = false;
+        includedNames = null;
+        prometheusNames = Collections.emptyList();
+
+        registry.register(new MultiCollector() {
+            @Override
+            public MetricSnapshots collect() {
+                collectCalled[0] = true;
+                return MetricSnapshots.builder()
+                        .metricSnapshot(CounterSnapshot.builder()
+                                .name("counter_1")
+                                .dataPoint(CounterDataPointSnapshot.builder().value(1.0).build())
+                                .build()
+                        )
+                        .metricSnapshot(GaugeSnapshot.builder()
+                                .name("gauge_2")
+                                .dataPoint(GaugeDataPointSnapshot.builder().value(1.0).build())
+                                .build()
+                        )
+                        .build();
+            }
+
+            @Override
+            public List<String> getPrometheusNames() {
+                return prometheusNames;
+            }
+        });
+    }
+
+    @Test
+    public void testPartialFilter() {
+
+        includedNames = name -> name.equals("counter_1");
+
+        MetricSnapshots snapshots = registry.scrape(includedNames);
+        Assert.assertTrue(collectCalled[0]);
+        Assert.assertEquals(1, snapshots.size());
+        Assert.assertEquals("counter_1", snapshots.get(0).getMetadata().getName());
+    }
+
+    @Test
+    public void testPartialFilterWithPrometheusNames() {
+
+        includedNames = name -> name.equals("counter_1");
+        prometheusNames = Arrays.asList("counter_1", "gauge_2");
+
+        MetricSnapshots snapshots = registry.scrape(includedNames);
+        Assert.assertTrue(collectCalled[0]);
+        Assert.assertEquals(1, snapshots.size());
+        Assert.assertEquals("counter_1", snapshots.get(0).getMetadata().getName());
+    }
+
+    @Test
+    public void testCompleteFilter_CollectCalled() {
+
+        includedNames = name -> !name.equals("counter_1") && !name.equals("gauge_2");
+
+        MetricSnapshots snapshots = registry.scrape(includedNames);
+        Assert.assertTrue(collectCalled[0]);
+        Assert.assertEquals(0, snapshots.size());
+    }
+
+    @Test
+    public void testCompleteFilter_CollectNotCalled() {
+
+        includedNames = name -> !name.equals("counter_1") && !name.equals("gauge_2");
+        prometheusNames = Arrays.asList("counter_1", "gauge_2");
+
+        MetricSnapshots snapshots = registry.scrape(includedNames);
+        Assert.assertFalse(collectCalled[0]);
+        Assert.assertEquals(0, snapshots.size());
+    }
+}


### PR DESCRIPTION
There was a bug that if a `MultiCollector` had empty `prometheusNames()` and `collect()` was called with a name filter, the collector was not scraped (wrong assumption that all names are excluded).

This PR fixes that bug.