### PR TITLE
Fix breaking scrape API change #892

### DIFF
--- a/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/HttpExchangeAdapter.java
+++ b/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/HttpExchangeAdapter.java
@@ -49,6 +49,17 @@ public class HttpExchangeAdapter implements PrometheusHttpExchange {
         public String getMethod() {
             return httpExchange.getRequestMethod();
         }
+
+        @Override
+        public String getRequestPath() {
+            URI requestURI = httpExchange.getRequestURI();
+            String uri = requestURI.toString();
+            int qx = uri.indexOf('?');
+            if (qx != -1) {
+                uri = uri.substring(0, qx);
+            }
+            return uri;
+        }
     }
 
     public class HttpResponse implements PrometheusHttpResponse {

--- a/prometheus-metrics-exporter-servlet-jakarta/src/main/java/io/prometheus/metrics/exporter/servlet/jakarta/HttpExchangeAdapter.java
+++ b/prometheus-metrics-exporter-servlet-jakarta/src/main/java/io/prometheus/metrics/exporter/servlet/jakarta/HttpExchangeAdapter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.Enumeration;
 
 public class HttpExchangeAdapter implements PrometheusHttpExchange {
@@ -66,6 +67,24 @@ public class HttpExchangeAdapter implements PrometheusHttpExchange {
         @Override
         public String getMethod() {
             return request.getMethod();
+        }
+
+        @Override
+        public String getRequestPath() {
+            StringBuilder uri = new StringBuilder();
+            String contextPath = request.getContextPath();
+            if (contextPath.startsWith("/")) {
+                uri.append(contextPath);
+            }
+            String servletPath = request.getServletPath();
+            if (servletPath.startsWith("/")) {
+                uri.append(servletPath);
+            }
+            String pathInfo = request.getPathInfo();
+            if (pathInfo != null) {
+                uri.append(pathInfo);
+            }
+            return uri.toString();
         }
     }
 

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/PrometheusScrapeRequest.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/PrometheusScrapeRequest.java
@@ -2,10 +2,16 @@ package io.prometheus.metrics.model.registry;
 
 /**
  * Infos extracted from the request received by the endpoint
- * 
  */
 public interface PrometheusScrapeRequest {
-	
-	String[] getParameterValues(String name);
 
+	/**
+	 * Absolute path of the HTTP request.
+	 */
+	String getRequestPath();
+
+	/**
+	 * See {@code jakarta.servlet.ServletRequest.getParameterValues(String name)}
+	 */
+	String[] getParameterValues(String name);
 }


### PR DESCRIPTION
Restore the `getRequestPath()` method in `PrometheusScrapeRequest` to fix #892.