### PR TITLE
UTF-8 support in metric and label names

### DIFF
--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/NamingProperties.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/NamingProperties.java
@@ -1,0 +1,43 @@
+package io.prometheus.metrics.config;
+
+import java.util.Map;
+
+public class NamingProperties {
+
+    private static final String VALIDATION_SCHEME = "validationScheme";
+    private final String validationScheme;
+
+    private NamingProperties(String validation) {
+        this.validationScheme = validation;
+    }
+
+    public String getValidationScheme() {
+        return validationScheme;
+    }
+
+    static NamingProperties load(String prefix, Map<Object, Object> properties) throws PrometheusPropertiesException {
+        String validationScheme = Util.loadString(prefix + "." + VALIDATION_SCHEME, properties);
+        return new NamingProperties(validationScheme);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+            private String validationScheme;
+
+            private Builder() {}
+
+            public Builder validation(String validationScheme) {
+                this.validationScheme = validationScheme;
+                return this;
+            }
+
+            public NamingProperties build() {
+                return new NamingProperties(validationScheme);
+            }
+    }
+
+}

--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusProperties.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusProperties.java
@@ -19,6 +19,7 @@ public class PrometheusProperties {
     private final ExporterFilterProperties exporterFilterProperties;
     private final ExporterHttpServerProperties exporterHttpServerProperties;
     private final ExporterOpenTelemetryProperties exporterOpenTelemetryProperties;
+    private final NamingProperties namingProperties;
 
     /**
      * Get the properties instance. When called for the first time, {@code get()} loads the properties from the following locations:
@@ -39,7 +40,8 @@ public class PrometheusProperties {
             ExporterProperties exporterProperties,
             ExporterFilterProperties exporterFilterProperties,
             ExporterHttpServerProperties httpServerConfig,
-            ExporterOpenTelemetryProperties otelConfig) {
+            ExporterOpenTelemetryProperties otelConfig,
+            NamingProperties namingProperties) {
         this.defaultMetricsProperties = defaultMetricsProperties;
         this.metricProperties.putAll(metricProperties);
         this.exemplarProperties = exemplarProperties;
@@ -47,6 +49,7 @@ public class PrometheusProperties {
         this.exporterFilterProperties = exporterFilterProperties;
         this.exporterHttpServerProperties = httpServerConfig;
         this.exporterOpenTelemetryProperties = otelConfig;
+        this.namingProperties = namingProperties;
     }
 
     /**
@@ -82,5 +85,9 @@ public class PrometheusProperties {
 
     public ExporterOpenTelemetryProperties getExporterOpenTelemetryProperties() {
         return exporterOpenTelemetryProperties;
+    }
+
+    public NamingProperties getNamingProperties() {
+        return namingProperties;
     }
 }

--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusPropertiesLoader.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusPropertiesLoader.java
@@ -33,8 +33,9 @@ public class PrometheusPropertiesLoader {
         ExporterFilterProperties exporterFilterProperties = ExporterFilterProperties.load("io.prometheus.exporter.filter", properties);
         ExporterHttpServerProperties exporterHttpServerProperties = ExporterHttpServerProperties.load("io.prometheus.exporter.httpServer", properties);
         ExporterOpenTelemetryProperties exporterOpenTelemetryProperties = ExporterOpenTelemetryProperties.load("io.prometheus.exporter.opentelemetry", properties);
+        NamingProperties namingProperties = NamingProperties.load("io.prometheus.naming", properties);
         validateAllPropertiesProcessed(properties);
-        return new PrometheusProperties(defaultMetricsProperties, metricsConfigs, exemplarConfig, exporterProperties, exporterFilterProperties, exporterHttpServerProperties, exporterOpenTelemetryProperties);
+        return new PrometheusProperties(defaultMetricsProperties, metricsConfigs, exemplarConfig, exporterProperties, exporterFilterProperties, exporterHttpServerProperties, exporterOpenTelemetryProperties, namingProperties);
     }
 
     // This will remove entries from properties when they are processed.

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/HistogramTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/HistogramTest.java
@@ -1,17 +1,12 @@
 package io.prometheus.metrics.core.metrics;
 
+import io.prometheus.metrics.model.snapshots.*;
 import io.prometheus.metrics.shaded.com_google_protobuf_3_21_7.TextFormat;
 import io.prometheus.metrics.core.datapoints.DistributionDataPoint;
 import io.prometheus.metrics.core.exemplars.ExemplarSamplerConfigTestUtil;
 import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
 import io.prometheus.metrics.expositionformats.PrometheusProtobufWriter;
 import io.prometheus.metrics.expositionformats.generated.com_google_protobuf_3_21_7.Metrics;
-import io.prometheus.metrics.model.snapshots.ClassicHistogramBucket;
-import io.prometheus.metrics.model.snapshots.Exemplar;
-import io.prometheus.metrics.model.snapshots.Exemplars;
-import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
-import io.prometheus.metrics.model.snapshots.Labels;
-import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import io.prometheus.metrics.tracer.common.SpanContext;
 import io.prometheus.metrics.tracer.initializer.SpanContextSupplier;
 import org.junit.After;
@@ -723,7 +718,7 @@ public class HistogramTest {
         // text
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         OpenMetricsTextFormatWriter writer = new OpenMetricsTextFormatWriter(false, true);
-        writer.write(out, MetricSnapshots.of(snapshot));
+        writer.write(out, MetricSnapshots.of(snapshot), EscapingScheme.NO_ESCAPING);
         Assert.assertEquals(expectedTextFormat, out.toString());
     }
 

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/InfoTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/InfoTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.metrics.core.metrics;
 
 import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
+import io.prometheus.metrics.model.snapshots.EscapingScheme;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import io.prometheus.metrics.shaded.com_google_protobuf_3_21_7.TextFormat;
@@ -98,7 +99,7 @@ public class InfoTest {
     private void assertTextFormat(String expected, Info info) throws IOException {
         OpenMetricsTextFormatWriter writer = new OpenMetricsTextFormatWriter(true, true);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        writer.write(outputStream, MetricSnapshots.of(info.collect()));
+        writer.write(outputStream, MetricSnapshots.of(info.collect()), EscapingScheme.NO_ESCAPING);
         String result = outputStream.toString(StandardCharsets.UTF_8.name());
         if (!result.contains(expected)) {
             throw new AssertionError(expected + " is not contained in the following output:\n" + result);

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/ExpositionFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/ExpositionFormatWriter.java
@@ -1,5 +1,6 @@
 package io.prometheus.metrics.expositionformats;
 
+import io.prometheus.metrics.model.snapshots.EscapingScheme;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 
 import java.io.IOException;
@@ -11,6 +12,6 @@ public interface ExpositionFormatWriter {
     /**
      * Text formats use UTF-8 encoding.
      */
-    void write(OutputStream out, MetricSnapshots metricSnapshots) throws IOException;
+    void write(OutputStream out, MetricSnapshots metricSnapshots, EscapingScheme escapingScheme) throws IOException;
     String getContentType();
 }

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetricsTextFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetricsTextFormatWriter.java
@@ -278,9 +278,7 @@ public class OpenMetricsTextFormatWriter implements ExpositionFormatWriter {
 
         if (!labels.isEmpty() || additionalLabelName != null) {
             writeLabels(writer, labels, additionalLabelName, additionalLabelValue, metricInsideBraces);
-        }
-
-        if (metricInsideBraces) {
+        } else if (metricInsideBraces) {
             writer.write('}');
         }
 

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetricsTextFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetricsTextFormatWriter.java
@@ -274,7 +274,7 @@ public class OpenMetricsTextFormatWriter implements ExpositionFormatWriter {
             metricInsideBraces = true;
             writer.write('{');
         }
-        writeName(writer, name + (suffix != null ? suffix : ""));
+        writeName(writer, name + (suffix != null ? suffix : ""), NameType.Metric);
 
         if (!labels.isEmpty() || additionalLabelName != null) {
             writeLabels(writer, labels, additionalLabelName, additionalLabelValue, metricInsideBraces);
@@ -307,20 +307,20 @@ public class OpenMetricsTextFormatWriter implements ExpositionFormatWriter {
 
     private void writeMetadata(OutputStreamWriter writer, String typeName, MetricMetadata metadata) throws IOException {
         writer.write("# TYPE ");
-        writeName(writer, metadata.getPrometheusName());
+        writeName(writer, metadata.getPrometheusName(), NameType.Metric);
         writer.write(' ');
         writer.write(typeName);
         writer.write('\n');
         if (metadata.getUnit() != null) {
             writer.write("# UNIT ");
-            writeName(writer, metadata.getPrometheusName());
+            writeName(writer, metadata.getPrometheusName(), NameType.Metric);
             writer.write(' ');
             writeEscapedString(writer, metadata.getUnit().toString());
             writer.write('\n');
         }
         if (metadata.getHelp() != null && !metadata.getHelp().isEmpty()) {
             writer.write("# HELP ");
-            writeName(writer, metadata.getPrometheusName());
+            writeName(writer, metadata.getPrometheusName(), NameType.Metric);
             writer.write(' ');
             writeEscapedString(writer, metadata.getHelp());
             writer.write('\n');

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetricsTextFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetricsTextFormatWriter.java
@@ -272,6 +272,8 @@ public class OpenMetricsTextFormatWriter implements ExpositionFormatWriter {
     private void writeNameAndLabels(OutputStreamWriter writer, String name, String suffix, Labels labels,
                                     String additionalLabelName, double additionalLabelValue) throws IOException {
         boolean metricInsideBraces = false;
+        // If the name does not pass the legacy validity check, we must put the
+        // metric name inside the braces.
         if (PrometheusNaming.validateLegacyMetricName(name) != null) {
             metricInsideBraces = true;
             writer.write('{');

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetricsTextFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetricsTextFormatWriter.java
@@ -40,9 +40,11 @@ public class OpenMetricsTextFormatWriter implements ExpositionFormatWriter {
         return CONTENT_TYPE;
     }
 
-    public void write(OutputStream out, MetricSnapshots metricSnapshots) throws IOException {
+    public void write(OutputStream out, MetricSnapshots metricSnapshots, EscapingScheme escapingScheme) throws IOException {
         OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
-        for (MetricSnapshot snapshot : metricSnapshots) {
+        for (MetricSnapshot s : metricSnapshots) {
+            MetricSnapshot snapshot = PrometheusNaming.escapeMetricSnapshot(s, escapingScheme);
+
             if (snapshot.getDataPoints().size() > 0) {
                 if (snapshot instanceof CounterSnapshot) {
                     writeCounter(writer, (CounterSnapshot) snapshot);

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetricsTextFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetricsTextFormatWriter.java
@@ -1,22 +1,6 @@
 package io.prometheus.metrics.expositionformats;
 
-import io.prometheus.metrics.model.snapshots.ClassicHistogramBuckets;
-import io.prometheus.metrics.model.snapshots.CounterSnapshot;
-import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.DistributionDataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.Exemplar;
-import io.prometheus.metrics.model.snapshots.Exemplars;
-import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
-import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
-import io.prometheus.metrics.model.snapshots.InfoSnapshot;
-import io.prometheus.metrics.model.snapshots.Labels;
-import io.prometheus.metrics.model.snapshots.MetricMetadata;
-import io.prometheus.metrics.model.snapshots.MetricSnapshot;
-import io.prometheus.metrics.model.snapshots.MetricSnapshots;
-import io.prometheus.metrics.model.snapshots.Quantile;
-import io.prometheus.metrics.model.snapshots.StateSetSnapshot;
-import io.prometheus.metrics.model.snapshots.SummarySnapshot;
-import io.prometheus.metrics.model.snapshots.UnknownSnapshot;
+import io.prometheus.metrics.model.snapshots.*;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -24,11 +8,7 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeDouble;
-import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeEscapedLabelValue;
-import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeLabels;
-import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeLong;
-import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeTimestamp;
+import static io.prometheus.metrics.expositionformats.TextFormatUtil.*;
 
 /**
  * Write the OpenMetrics text format as defined on <a href="https://openmetrics.io/">https://openmetrics.io</a>.
@@ -214,7 +194,7 @@ public class OpenMetricsTextFormatWriter implements ExpositionFormatWriter {
                     }
                     writer.write(data.getLabels().getPrometheusName(j));
                     writer.write("=\"");
-                    writeEscapedLabelValue(writer, data.getLabels().getValue(j));
+                    writeEscapedString(writer, data.getLabels().getValue(j));
                     writer.write("\"");
                 }
                 if (!data.getLabels().isEmpty()) {
@@ -222,7 +202,7 @@ public class OpenMetricsTextFormatWriter implements ExpositionFormatWriter {
                 }
                 writer.write(metadata.getPrometheusName());
                 writer.write("=\"");
-                writeEscapedLabelValue(writer, data.getName(i));
+                writeEscapedString(writer, data.getName(i));
                 writer.write("\"} ");
                 if (data.isTrue(i)) {
                     writer.write("1");
@@ -289,13 +269,21 @@ public class OpenMetricsTextFormatWriter implements ExpositionFormatWriter {
 
     private void writeNameAndLabels(OutputStreamWriter writer, String name, String suffix, Labels labels,
                                     String additionalLabelName, double additionalLabelValue) throws IOException {
-        writer.write(name);
-        if (suffix != null) {
-            writer.write(suffix);
+        boolean metricInsideBraces = false;
+        if (PrometheusNaming.validateLegacyMetricName(name) != null) {
+            metricInsideBraces = true;
+            writer.write('{');
         }
+        writeName(writer, name + (suffix != null ? suffix : ""));
+
         if (!labels.isEmpty() || additionalLabelName != null) {
-            writeLabels(writer, labels, additionalLabelName, additionalLabelValue);
+            writeLabels(writer, labels, additionalLabelName, additionalLabelValue, metricInsideBraces);
         }
+
+        if (metricInsideBraces) {
+            writer.write('}');
+        }
+
         writer.write(' ');
     }
 
@@ -306,7 +294,7 @@ public class OpenMetricsTextFormatWriter implements ExpositionFormatWriter {
         }
         if (exemplar != null) {
             writer.write(" # ");
-            writeLabels(writer, exemplar.getLabels(), null, 0);
+            writeLabels(writer, exemplar.getLabels(), null, 0, false);
             writer.write(' ');
             writeDouble(writer, exemplar.getValue());
             if (exemplar.hasTimestamp()) {
@@ -319,22 +307,22 @@ public class OpenMetricsTextFormatWriter implements ExpositionFormatWriter {
 
     private void writeMetadata(OutputStreamWriter writer, String typeName, MetricMetadata metadata) throws IOException {
         writer.write("# TYPE ");
-        writer.write(metadata.getPrometheusName());
+        writeName(writer, metadata.getPrometheusName());
         writer.write(' ');
         writer.write(typeName);
         writer.write('\n');
         if (metadata.getUnit() != null) {
             writer.write("# UNIT ");
-            writer.write(metadata.getPrometheusName());
+            writeName(writer, metadata.getPrometheusName());
             writer.write(' ');
-            writeEscapedLabelValue(writer, metadata.getUnit().toString());
+            writeEscapedString(writer, metadata.getUnit().toString());
             writer.write('\n');
         }
         if (metadata.getHelp() != null && !metadata.getHelp().isEmpty()) {
             writer.write("# HELP ");
-            writer.write(metadata.getPrometheusName());
+            writeName(writer, metadata.getPrometheusName());
             writer.write(' ');
-            writeEscapedLabelValue(writer, metadata.getHelp());
+            writeEscapedString(writer, metadata.getHelp());
             writer.write('\n');
         }
     }

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusProtobufWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusProtobufWriter.java
@@ -1,24 +1,9 @@
 package io.prometheus.metrics.expositionformats;
 
+import io.prometheus.metrics.model.snapshots.*;
 import io.prometheus.metrics.shaded.com_google_protobuf_3_21_7.TextFormat;
 import io.prometheus.metrics.expositionformats.generated.com_google_protobuf_3_21_7.Metrics;
-import io.prometheus.metrics.model.snapshots.ClassicHistogramBuckets;
-import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot.CounterDataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.Exemplar;
-import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
-import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
-import io.prometheus.metrics.model.snapshots.InfoSnapshot;
-import io.prometheus.metrics.model.snapshots.Labels;
-import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.MetricMetadata;
-import io.prometheus.metrics.model.snapshots.MetricSnapshot;
-import io.prometheus.metrics.model.snapshots.MetricSnapshots;
-import io.prometheus.metrics.model.snapshots.NativeHistogramBuckets;
-import io.prometheus.metrics.model.snapshots.Quantiles;
-import io.prometheus.metrics.model.snapshots.StateSetSnapshot;
-import io.prometheus.metrics.model.snapshots.SummarySnapshot;
-import io.prometheus.metrics.model.snapshots.UnknownSnapshot;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -61,7 +46,7 @@ public class PrometheusProtobufWriter implements ExpositionFormatWriter {
     }
 
     @Override
-    public void write(OutputStream out, MetricSnapshots metricSnapshots) throws IOException {
+    public void write(OutputStream out, MetricSnapshots metricSnapshots, EscapingScheme escapingScheme) throws IOException {
         for (MetricSnapshot snapshot : metricSnapshots) {
             if (snapshot.getDataPoints().size() > 0) {
                 convert(snapshot).writeDelimitedTo(out);

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
@@ -282,9 +282,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
 
         if (!labels.isEmpty() || additionalLabelName != null) {
             writeLabels(writer, labels, additionalLabelName, additionalLabelValue, metricInsideBraces);
-        }
-
-        if (metricInsideBraces) {
+        } else if (metricInsideBraces) {
             writer.write('}');
         }
 

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
@@ -37,11 +37,13 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
         return CONTENT_TYPE;
     }
 
-    public void write(OutputStream out, MetricSnapshots metricSnapshots) throws IOException {
+    public void write(OutputStream out, MetricSnapshots metricSnapshots, EscapingScheme escapingScheme) throws IOException {
         // See https://prometheus.io/docs/instrumenting/exposition_formats/
         // "unknown", "gauge", "counter", "stateset", "info", "histogram", "gaugehistogram", and "summary".
         OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
-        for (MetricSnapshot snapshot : metricSnapshots) {
+        for (MetricSnapshot s : metricSnapshots) {
+            MetricSnapshot snapshot = PrometheusNaming.escapeMetricSnapshot(s, escapingScheme);
+
             if (snapshot.getDataPoints().size() > 0) {
                 if (snapshot instanceof CounterSnapshot) {
                     writeCounter(writer, (CounterSnapshot) snapshot);
@@ -61,7 +63,9 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
             }
         }
         if (writeCreatedTimestamps) {
-            for (MetricSnapshot snapshot : metricSnapshots) {
+            for (MetricSnapshot ms : metricSnapshots) {
+                MetricSnapshot snapshot = PrometheusNaming.escapeMetricSnapshot(ms, escapingScheme);
+
                 if (snapshot.getDataPoints().size() > 0) {
                     if (snapshot instanceof CounterSnapshot) {
                         writeCreated(writer, snapshot);

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
@@ -278,6 +278,8 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
     private void writeNameAndLabels(OutputStreamWriter writer, String name, String suffix, Labels labels,
                                     String additionalLabelName, double additionalLabelValue) throws IOException {
         boolean metricInsideBraces = false;
+        // If the name does not pass the legacy validity check, we must put the
+        // metric name inside the braces.
         if (PrometheusNaming.validateLegacyMetricName(name) != null) {
             metricInsideBraces = true;
             writer.write('{');

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
@@ -278,7 +278,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
             metricInsideBraces = true;
             writer.write('{');
         }
-        writeName(writer, name + (suffix != null ? suffix : ""));
+        writeName(writer, name + (suffix != null ? suffix : ""), NameType.Metric);
 
         if (!labels.isEmpty() || additionalLabelName != null) {
             writeLabels(writer, labels, additionalLabelName, additionalLabelValue, metricInsideBraces);
@@ -294,13 +294,13 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
     private void writeMetadata(OutputStreamWriter writer, String suffix, String typeString, MetricMetadata metadata) throws IOException {
         if (metadata.getHelp() != null && !metadata.getHelp().isEmpty()) {
             writer.write("# HELP ");
-            writeName(writer, metadata.getPrometheusName() + (suffix != null ? suffix : ""));
+            writeName(writer, metadata.getPrometheusName() + (suffix != null ? suffix : ""), NameType.Metric);
             writer.write(' ');
             writeEscapedHelp(writer, metadata.getHelp());
             writer.write('\n');
         }
         writer.write("# TYPE ");
-        writeName(writer, metadata.getPrometheusName() + (suffix != null ? suffix : ""));
+        writeName(writer, metadata.getPrometheusName() + (suffix != null ? suffix : ""), NameType.Metric);
         writer.write(' ');
         writer.write(typeString);
         writer.write('\n');

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
@@ -2,6 +2,7 @@ package io.prometheus.metrics.expositionformats;
 
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.PrometheusNaming;
+import io.prometheus.metrics.model.snapshots.ValidationScheme;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -95,7 +96,7 @@ public class TextFormatUtil {
                 }
                 break;
             case Label:
-                if (PrometheusNaming.isValidLegacyLabelName(name)) {
+                if (PrometheusNaming.isValidLegacyLabelName(name) && PrometheusNaming.nameValidationScheme == ValidationScheme.LEGACY_VALIDATION) {
                     writer.write(name);
                     return;
                 }

--- a/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
+++ b/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
@@ -1869,7 +1869,6 @@ public class ExpositionFormatsTest {
         writer = expositionFormats.findWriter(acceptHeaderValue);
         Assert.assertEquals(expectedFmt, writer.getContentType() + escapingScheme.toHeaderFormat());
 
-        // TODO review if this is ok
         nameEscapingScheme = EscapingScheme.VALUE_ENCODING_ESCAPING;
 
         // OM format, no version

--- a/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
+++ b/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
@@ -125,7 +125,7 @@ public class ExpositionFormatsTest {
                     "timestamp_ms: 1672850585820 " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
 
         CounterSnapshot counter = CounterSnapshot.builder()
                 .name("service_time_seconds")
@@ -170,7 +170,7 @@ public class ExpositionFormatsTest {
                 "my_counter_total 1.1\n";
         String prometheusProtobuf = "" +
                 "name: \"my_counter_total\" type: COUNTER metric { counter { value: 1.1 } }";
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         CounterSnapshot counter = CounterSnapshot.builder()
                 .name("my_counter")
                 .dataPoint(CounterDataPointSnapshot.builder().value(1.1).build())
@@ -202,7 +202,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
 
         CounterSnapshot counter = CounterSnapshot.builder()
                 .name("my.request.count")
@@ -248,7 +248,7 @@ public class ExpositionFormatsTest {
                     "timestamp_ms: 1672850585820 " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         GaugeSnapshot gauge = GaugeSnapshot.builder()
                 .name("disk_usage_ratio")
                 .help("percentage used")
@@ -288,7 +288,7 @@ public class ExpositionFormatsTest {
                 "temperature_centigrade 22.3\n";
         String prometheusProtobuf = "" +
                 "name: \"temperature_centigrade\" type: GAUGE metric { gauge { value: 22.3 } }";
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         GaugeSnapshot gauge = GaugeSnapshot.builder()
                 .name("temperature_centigrade")
                 .dataPoint(GaugeDataPointSnapshot.builder()
@@ -326,7 +326,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
 
         GaugeSnapshot gauge = GaugeSnapshot.builder()
                 .name("my.temperature.celsius")
@@ -352,7 +352,7 @@ public class ExpositionFormatsTest {
                 "# TYPE \"gauge.name\" gauge\n" +
                 "{\"gauge.name\",\"name*2\"=\"val with \\\\backslash and \\\"quotes\\\"\",\"name.1\"=\"val with\\nnew line\"} +Inf\n" +
                 "{\"gauge.name\",\"name*2\"=\"佖佥\",\"name.1\"=\"Björn\"} 3.14E42\n";
-        PrometheusNaming.nameValidationScheme = ValidationScheme.UTF8Validation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
 
         GaugeSnapshot gauge = GaugeSnapshot.builder()
                 .name("gauge.name")
@@ -466,7 +466,7 @@ public class ExpositionFormatsTest {
                     "timestamp_ms: 1672850585820 " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         SummarySnapshot summary = SummarySnapshot.builder()
                 .name("http_request_duration_seconds")
                 .help("request duration")
@@ -535,7 +535,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         SummarySnapshot summary = SummarySnapshot.builder()
                 .name("latency_seconds")
                 .help("latency")
@@ -571,7 +571,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         SummarySnapshot summary = SummarySnapshot.builder()
                 .name("latency_seconds")
                 .dataPoint(SummaryDataPointSnapshot.builder()
@@ -604,7 +604,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
         //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         SummarySnapshot summary = SummarySnapshot.builder()
                 .name("latency_seconds")
                 .dataPoint(SummaryDataPointSnapshot.builder()
@@ -637,7 +637,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         SummarySnapshot summary = SummarySnapshot.builder()
                 .name("latency_seconds")
                 .dataPoint(SummaryDataPointSnapshot.builder()
@@ -653,7 +653,7 @@ public class ExpositionFormatsTest {
 
     @Test
     public void testSummaryEmptyData() throws IOException {
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         // SummaryData can be present but empty (no count, no sum, no quantiles).
         // This should be treated like no data is present.
         SummarySnapshot summary = SummarySnapshot.builder()
@@ -692,7 +692,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         SummarySnapshot summary = SummarySnapshot.builder()
                 .name("latency_seconds")
                 .dataPoint(SummaryDataPointSnapshot.builder()
@@ -738,7 +738,7 @@ public class ExpositionFormatsTest {
                     "summary { sample_count: 1 sample_sum: 0.03 } " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
 
         SummarySnapshot summary = SummarySnapshot.builder()
                 .name("my.request.duration.seconds")
@@ -860,7 +860,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         HistogramSnapshot histogram = HistogramSnapshot.builder()
                 .name("response_size_bytes")
                 .help("help")
@@ -922,7 +922,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         HistogramSnapshot histogram = HistogramSnapshot.builder()
                 .name("request_latency_seconds")
                 .dataPoint(HistogramSnapshot.HistogramDataPointSnapshot.builder()
@@ -966,7 +966,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         HistogramSnapshot histogram = HistogramSnapshot.builder()
                 .name("request_latency_seconds")
                 .dataPoint(HistogramSnapshot.HistogramDataPointSnapshot.builder()
@@ -1086,7 +1086,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         HistogramSnapshot gaugeHistogram = HistogramSnapshot.builder()
                 .gaugeHistogram(true)
                 .name("cache_size_bytes")
@@ -1150,7 +1150,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         HistogramSnapshot gaugeHistogram = HistogramSnapshot.builder()
                 .gaugeHistogram(true)
                 .name("queue_size_bytes")
@@ -1197,7 +1197,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         HistogramSnapshot gaugeHistogram = HistogramSnapshot.builder()
                 .gaugeHistogram(true)
                 .name("queue_size_bytes")
@@ -1245,7 +1245,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
 
         HistogramSnapshot histogram = HistogramSnapshot.builder()
                 .name("my.request.duration.seconds")
@@ -1373,7 +1373,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         HistogramSnapshot nativeHistogram = HistogramSnapshot.builder()
                 .name("response_size_bytes")
                 .help("help")
@@ -1454,7 +1454,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         HistogramSnapshot nativeHistogram = HistogramSnapshot.builder()
                 .name("latency_seconds")
                 .dataPoint(HistogramSnapshot.HistogramDataPointSnapshot.builder()
@@ -1501,7 +1501,7 @@ public class ExpositionFormatsTest {
                     "} " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
 
         HistogramSnapshot histogram = HistogramSnapshot.builder()
                 .name("my.request.duration.seconds")
@@ -1538,7 +1538,7 @@ public class ExpositionFormatsTest {
                 "# HELP version_info version information\n" +
                 "# TYPE version_info gauge\n" +
                 "version_info{version=\"1.2.3\"} 1\n";
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         InfoSnapshot info = InfoSnapshot.builder()
                 .name("version")
                 .help("version information")
@@ -1573,7 +1573,7 @@ public class ExpositionFormatsTest {
                     "gauge { value: 1.0 } " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         InfoSnapshot info = InfoSnapshot.builder()
                 .name("jvm.status")
                 .help("JVM status info")
@@ -1603,7 +1603,7 @@ public class ExpositionFormatsTest {
                 "state{env=\"dev\",state=\"state2\"} 0 " + scrapeTimestamp1s + "\n" +
                 "state{env=\"prod\",state=\"state1\"} 0 " + scrapeTimestamp2s + "\n" +
                 "state{env=\"prod\",state=\"state2\"} 1 " + scrapeTimestamp2s + "\n";
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         StateSetSnapshot stateSet = StateSetSnapshot.builder()
                 .name("state")
                 .help("complete state set example")
@@ -1637,7 +1637,7 @@ public class ExpositionFormatsTest {
                 "# TYPE state gauge\n" +
                 "state{state=\"a\"} 1\n" +
                 "state{state=\"bb\"} 0\n";
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         StateSetSnapshot stateSet = StateSetSnapshot.builder()
                 .name("state")
                 .dataPoint(StateSetSnapshot.StateSetDataPointSnapshot.builder()
@@ -1679,7 +1679,7 @@ public class ExpositionFormatsTest {
                     "gauge { value: 0.0 } " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         StateSetSnapshot stateSet = StateSetSnapshot.builder()
                 .name("my.application.state")
                 .help("My application state")
@@ -1708,7 +1708,7 @@ public class ExpositionFormatsTest {
                 "# TYPE my_special_thing_bytes untyped\n" +
                 "my_special_thing_bytes{env=\"dev\"} 0.2 " + scrapeTimestamp1s + "\n" +
                 "my_special_thing_bytes{env=\"prod\"} 0.7 " + scrapeTimestamp2s + "\n";
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         UnknownSnapshot unknown = UnknownSnapshot.builder()
                 .name("my_special_thing_bytes")
                 .help("help message")
@@ -1741,7 +1741,7 @@ public class ExpositionFormatsTest {
         String prometheus = "" +
                 "# TYPE other untyped\n" +
                 "other 22.3\n";
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         UnknownSnapshot unknown = UnknownSnapshot.builder()
                 .name("other")
                 .dataPoint(UnknownDataPointSnapshot.builder()
@@ -1776,7 +1776,7 @@ public class ExpositionFormatsTest {
                     "untyped { value: 0.7 } " +
                 "}";
                 //@formatter:on
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         UnknownSnapshot unknown = UnknownSnapshot.builder()
                 .name("some.unknown.metric")
                 .help("help message")
@@ -1803,7 +1803,7 @@ public class ExpositionFormatsTest {
                 "# HELP test_total Some text and \\n some \" escaping\n" +
                 "# TYPE test_total counter\n" +
                 "test_total 1.0\n";
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         CounterSnapshot counter = CounterSnapshot.builder()
                 .name("test")
                 .help("Some text and \n some \" escaping") // example from https://openMetrics.io
@@ -1824,7 +1824,7 @@ public class ExpositionFormatsTest {
         String prometheus = "" +
                 "# TYPE test_total counter\n" +
                 "test_total{a=\"x\",b=\"escaping\\\" example \\n \"} 1.0\n";
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         CounterSnapshot counter = CounterSnapshot.builder()
                 .name("test")
                 .dataPoint(CounterDataPointSnapshot.builder()

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/TestUtil.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/TestUtil.java
@@ -1,6 +1,7 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
+import io.prometheus.metrics.model.snapshots.EscapingScheme;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 
 import java.io.ByteArrayOutputStream;
@@ -12,7 +13,7 @@ public class TestUtil {
     static String convertToOpenMetricsFormat(MetricSnapshots snapshots) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         OpenMetricsTextFormatWriter writer = new OpenMetricsTextFormatWriter(true, true);
-        writer.write(out, snapshots);
+        writer.write(out, snapshots, EscapingScheme.NO_ESCAPING);
         return out.toString(StandardCharsets.UTF_8.name());
     }
 }

--- a/prometheus-metrics-model/pom.xml
+++ b/prometheus-metrics-model/pom.xml
@@ -37,6 +37,12 @@
     </developers>
 
     <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/EscapingScheme.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/EscapingScheme.java
@@ -4,9 +4,19 @@ import static io.prometheus.metrics.model.snapshots.PrometheusNaming.ESCAPING_KE
 import static io.prometheus.metrics.model.snapshots.PrometheusNaming.nameEscapingScheme;
 
 public enum EscapingScheme {
+    // NO_ESCAPING indicates that a name will not be escaped.
     NO_ESCAPING("allow-utf-8"),
+
+    // UNDERSCORE_ESCAPING replaces all legacy-invalid characters with underscores.
     UNDERSCORE_ESCAPING("underscores"),
+
+    // DOTS_ESCAPING is similar to UNDERSCORE_ESCAPING, except that dots are
+    // converted to `_dot_` and pre-existing underscores are converted to `__`.
     DOTS_ESCAPING("dots"),
+
+    // VALUE_ENCODING_ESCAPING prepends the name with `U__` and replaces all invalid
+    // characters with the Unicode value, surrounded by underscores. Single
+    // underscores are replaced with double underscores.
     VALUE_ENCODING_ESCAPING("values"),
     ;
 
@@ -20,6 +30,10 @@ public enum EscapingScheme {
         this.value = value;
     }
 
+    // fromAcceptHeader returns an EscapingScheme depending on the Accept header. Iff the
+    // header contains an escaping=allow-utf-8 term, it will select NO_ESCAPING. If a valid
+    // "escaping" term exists, that will be used. Otherwise, the global default will
+    // be returned.
     public static EscapingScheme fromAcceptHeader(String acceptHeader) {
         for (String p : acceptHeader.split(";")) {
             String[] toks = p.split("=");
@@ -32,6 +46,7 @@ public enum EscapingScheme {
                 try {
                     return EscapingScheme.forString(value);
                 } catch (IllegalArgumentException e) {
+                    // If the escaping parameter is unknown, ignore it.
                     return nameEscapingScheme;
                 }
             }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/EscapingScheme.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/EscapingScheme.java
@@ -1,0 +1,60 @@
+package io.prometheus.metrics.model.snapshots;
+
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.ESCAPING_KEY;
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.nameEscapingScheme;
+
+public enum EscapingScheme {
+    NO_ESCAPING("allow-utf-8"),
+    UNDERSCORE_ESCAPING("underscores"),
+    DOTS_ESCAPING("dots"),
+    VALUE_ENCODING_ESCAPING("values"),
+    ;
+
+    public final String getValue() {
+        return value;
+    }
+
+    private final String value;
+
+    EscapingScheme(String value) {
+        this.value = value;
+    }
+
+    public static EscapingScheme fromAcceptHeader(String acceptHeader) {
+        for (String p : acceptHeader.split(";")) {
+            String[] toks = p.split("=");
+            if (toks.length != 2) {
+                continue;
+            }
+            String key = toks[0].trim();
+            String value = toks[1].trim();
+            if (key.equals(ESCAPING_KEY)) {
+                try {
+                    return EscapingScheme.forString(value);
+                } catch (IllegalArgumentException e) {
+                    return nameEscapingScheme;
+                }
+            }
+        }
+        return nameEscapingScheme;
+    }
+
+    private static EscapingScheme forString(String value) {
+        switch(value) {
+            case "allow-utf-8":
+                return NO_ESCAPING;
+            case "underscores":
+                return UNDERSCORE_ESCAPING;
+            case "dots":
+                return DOTS_ESCAPING;
+            case "values":
+                return VALUE_ENCODING_ESCAPING;
+            default:
+                throw new IllegalArgumentException("Unknown escaping scheme: " + value);
+        }
+    }
+
+    public String toHeaderFormat() {
+        return "; " + ESCAPING_KEY + "=" + value;
+    }
+}

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/Labels.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/Labels.java
@@ -75,7 +75,7 @@ public class Labels implements Comparable<Labels>, Iterable<Label> {
     static String[] makePrometheusNames(String[] names) {
         String[] prometheusNames = names;
         for (int i=0; i<names.length; i++) {
-            if (names[i].contains(".")) {
+            if (names[i].contains(".") && PrometheusNaming.nameValidationScheme == ValidationScheme.LEGACY_VALIDATION) {
                 if (prometheusNames == names) {
                     prometheusNames = Arrays.copyOf(names, names.length);
                 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
@@ -61,7 +61,7 @@ public final class MetricMetadata {
         this.help = help;
         this.unit = unit;
         validate();
-        this.prometheusName = name.contains(".") ? PrometheusNaming.prometheusName(name) : name;
+        this.prometheusName = name.contains(".") && PrometheusNaming.nameValidationScheme == ValidationScheme.LEGACY_VALIDATION ? PrometheusNaming.prometheusName(name) : name;
     }
 
     /**

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
@@ -1,6 +1,9 @@
 package io.prometheus.metrics.model.snapshots;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -10,7 +13,15 @@ import java.util.regex.Pattern;
  * in Prometheus exposition formats. However, if metrics are exposed in OpenTelemetry format the dots are retained.
  */
 public class PrometheusNaming {
-    public static ValidationScheme nameValidationScheme = ValidationScheme.LegacyValidation;
+    public static ValidationScheme nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
+
+    public static EscapingScheme nameEscapingScheme = EscapingScheme.VALUE_ENCODING_ESCAPING;
+
+    public static final String ESCAPING_KEY = "escaping";
+
+    private static final String LOWERHEX = "0123456789abcdef";
+
+    private static final String METRIC_NAME_LABEL= "__name__";
 
     /**
      * Legal characters for metric names, including dot.
@@ -69,9 +80,9 @@ public class PrometheusNaming {
 
     static String validateMetricName(String name) {
         switch (nameValidationScheme) {
-            case LegacyValidation:
+            case LEGACY_VALIDATION:
                 return validateLegacyMetricName(name);
-            case UTF8Validation:
+            case UTF_8_VALIDATION:
                 if(name.isEmpty() || !StandardCharsets.UTF_8.newEncoder().canEncode(name)) {
                     return "The metric name contains unsupported characters";
                 }
@@ -100,9 +111,9 @@ public class PrometheusNaming {
 
     public static boolean isValidLegacyMetricName(String name) {
         switch (nameValidationScheme) {
-            case LegacyValidation:
+            case LEGACY_VALIDATION:
                 return LEGACY_METRIC_NAME_PATTERN.matcher(name).matches();
-            case UTF8Validation:
+            case UTF_8_VALIDATION:
                 return METRIC_NAME_PATTERN.matcher(name).matches();
             default:
                 throw new RuntimeException("Invalid name validation scheme requested: " + nameValidationScheme);
@@ -111,10 +122,10 @@ public class PrometheusNaming {
 
     public static boolean isValidLabelName(String name) {
         switch (nameValidationScheme) {
-            case LegacyValidation:
+            case LEGACY_VALIDATION:
                 return isValidLegacyLabelName(name) &&
                         !(name.startsWith("__") || name.startsWith("._") || name.startsWith("..") || name.startsWith("_."));
-            case UTF8Validation:
+            case UTF_8_VALIDATION:
                 return StandardCharsets.UTF_8.newEncoder().canEncode(name);
             default:
                 throw new RuntimeException("Invalid name validation scheme requested: " + nameValidationScheme);
@@ -123,9 +134,9 @@ public class PrometheusNaming {
 
     public static boolean isValidLegacyLabelName(String name) {
         switch (nameValidationScheme) {
-            case LegacyValidation:
+            case LEGACY_VALIDATION:
                 return LEGACY_LABEL_NAME_PATTERN.matcher(name).matches();
-            case UTF8Validation:
+            case UTF_8_VALIDATION:
                 return LABEL_NAME_PATTERN.matcher(name).matches();
             default:
                 throw new RuntimeException("Invalid name validation scheme requested: " + nameValidationScheme);
@@ -142,9 +153,9 @@ public class PrometheusNaming {
      */
     public static String prometheusName(String name) {
         switch (nameValidationScheme) {
-            case LegacyValidation:
+            case LEGACY_VALIDATION:
                 return name.replace(".", "_");
-            case UTF8Validation:
+            case UTF_8_VALIDATION:
                 return name;
             default:
                 throw new RuntimeException("Invalid name validation scheme requested: " + nameValidationScheme);
@@ -230,5 +241,358 @@ public class PrometheusNaming {
             }
         }
         return new String(sanitized);
+    }
+
+    public static MetricSnapshot escapeMetricSnapshot(MetricSnapshot v, EscapingScheme scheme) {
+        if (v == null) {
+            return null;
+        }
+
+        if (scheme == EscapingScheme.NO_ESCAPING) {
+            return v;
+        }
+
+        String outName;
+
+        if (v.getMetadata().getPrometheusName() == null || isValidLegacyMetricName(v.getMetadata().getPrometheusName())) {
+            outName = v.getMetadata().getPrometheusName();
+        } else {
+            outName = escapeName(v.getMetadata().getPrometheusName(), scheme);
+        }
+
+        List<DataPointSnapshot> outDataPoints = new ArrayList<>();
+
+        for (DataPointSnapshot d : v.getDataPoints()) {
+            if (!metricNeedsEscaping(d)) {
+                outDataPoints.add(d);
+                continue;
+            }
+
+            Labels.Builder outLabelsBuilder = Labels.builder();
+
+            for (Label l : d.getLabels()) {
+                if (METRIC_NAME_LABEL.equals(l.getName())) {
+                    if (l.getValue() == null || isValidLegacyMetricName(l.getValue())) {
+                        outLabelsBuilder.label(l.getName(), l.getValue());
+                        continue;
+                    }
+                    outLabelsBuilder.label(l.getName(), escapeName(l.getValue(), scheme));
+                    continue;
+                }
+                if (l.getName() == null || isValidLegacyMetricName(l.getName())) {
+                    outLabelsBuilder.label(l.getName(), l.getValue());
+                }
+                outLabelsBuilder.label(escapeName(l.getName(), scheme), l.getValue());
+            }
+
+            Labels outLabels = outLabelsBuilder.build();
+            DataPointSnapshot outDataPointSnapshot = null;
+
+            if (v instanceof CounterSnapshot) {
+                outDataPointSnapshot = CounterSnapshot.CounterDataPointSnapshot.builder()
+                        .value(((CounterSnapshot.CounterDataPointSnapshot) d).getValue())
+                        .exemplar(((CounterSnapshot.CounterDataPointSnapshot) d).getExemplar())
+                        .labels(outLabels)
+                        .createdTimestampMillis(d.getCreatedTimestampMillis())
+                        .scrapeTimestampMillis(d.getScrapeTimestampMillis())
+                        .build();
+            } else if (v instanceof GaugeSnapshot) {
+                outDataPointSnapshot = GaugeSnapshot.GaugeDataPointSnapshot.builder()
+                        .value(((GaugeSnapshot.GaugeDataPointSnapshot) d).getValue())
+                        .exemplar(((GaugeSnapshot.GaugeDataPointSnapshot) d).getExemplar())
+                        .labels(outLabels)
+                        .scrapeTimestampMillis(d.getScrapeTimestampMillis())
+                        .build();
+            } else if (v instanceof HistogramSnapshot) {
+                outDataPointSnapshot = HistogramSnapshot.HistogramDataPointSnapshot.builder()
+                        .classicHistogramBuckets(((HistogramSnapshot.HistogramDataPointSnapshot) d).getClassicBuckets())
+                        .nativeSchema(((HistogramSnapshot.HistogramDataPointSnapshot) d).getNativeSchema())
+                        .nativeZeroCount(((HistogramSnapshot.HistogramDataPointSnapshot) d).getNativeZeroCount())
+                        .nativeZeroThreshold(((HistogramSnapshot.HistogramDataPointSnapshot) d).getNativeZeroThreshold())
+                        .nativeBucketsForPositiveValues(((HistogramSnapshot.HistogramDataPointSnapshot) d).getNativeBucketsForPositiveValues())
+                        .nativeBucketsForNegativeValues(((HistogramSnapshot.HistogramDataPointSnapshot) d).getNativeBucketsForNegativeValues())
+                        .count(((HistogramSnapshot.HistogramDataPointSnapshot) d).getCount())
+                        .sum(((HistogramSnapshot.HistogramDataPointSnapshot) d).getSum())
+                        .exemplars(((HistogramSnapshot.HistogramDataPointSnapshot) d).getExemplars())
+                        .labels(outLabels)
+                        .createdTimestampMillis(d.getCreatedTimestampMillis())
+                        .scrapeTimestampMillis(d.getScrapeTimestampMillis())
+                        .build();
+            } else if (v instanceof SummarySnapshot) {
+                outDataPointSnapshot = SummarySnapshot.SummaryDataPointSnapshot.builder()
+                        .quantiles(((SummarySnapshot.SummaryDataPointSnapshot) d).getQuantiles())
+                        .count(((SummarySnapshot.SummaryDataPointSnapshot) d).getCount())
+                        .sum(((SummarySnapshot.SummaryDataPointSnapshot) d).getSum())
+                        .exemplars(((SummarySnapshot.SummaryDataPointSnapshot) d).getExemplars())
+                        .labels(outLabels)
+                        .createdTimestampMillis(d.getCreatedTimestampMillis())
+                        .scrapeTimestampMillis(d.getScrapeTimestampMillis())
+                        .build();
+            } else if (v instanceof InfoSnapshot) {
+                outDataPointSnapshot = InfoSnapshot.InfoDataPointSnapshot.builder()
+                        .labels(outLabels)
+                        .scrapeTimestampMillis(d.getScrapeTimestampMillis())
+                        .build();
+            } else if (v instanceof StateSetSnapshot) {
+                StateSetSnapshot.StateSetDataPointSnapshot.Builder builder = StateSetSnapshot.StateSetDataPointSnapshot.builder()
+                        .labels(outLabels)
+                        .scrapeTimestampMillis(d.getScrapeTimestampMillis());
+                for (StateSetSnapshot.State state : ((StateSetSnapshot.StateSetDataPointSnapshot) d)) {
+                    builder.state(state.getName(), state.isTrue());
+                }
+                outDataPointSnapshot = builder.build();
+            } else if (v instanceof UnknownSnapshot) {
+                outDataPointSnapshot = UnknownSnapshot.UnknownDataPointSnapshot.builder()
+                        .labels(outLabels)
+                        .value(((UnknownSnapshot.UnknownDataPointSnapshot) d).getValue())
+                        .exemplar(((UnknownSnapshot.UnknownDataPointSnapshot) d).getExemplar())
+                        .scrapeTimestampMillis(d.getScrapeTimestampMillis())
+                        .build();
+            }
+
+            outDataPoints.add(outDataPointSnapshot);
+        }
+
+        MetricSnapshot out;
+
+        if (v instanceof CounterSnapshot) {
+            CounterSnapshot.Builder builder = CounterSnapshot.builder()
+                    .name(outName)
+                    .help(v.getMetadata().getHelp())
+                    .unit(v.getMetadata().getUnit());
+            for (DataPointSnapshot d : outDataPoints) {
+                builder.dataPoint((CounterSnapshot.CounterDataPointSnapshot) d);
+            }
+            out = builder.build();
+        } else if (v instanceof GaugeSnapshot) {
+            GaugeSnapshot.Builder builder = GaugeSnapshot.builder()
+                    .name(outName)
+                    .help(v.getMetadata().getHelp())
+                    .unit(v.getMetadata().getUnit());
+            for (DataPointSnapshot d : outDataPoints) {
+                builder.dataPoint((GaugeSnapshot.GaugeDataPointSnapshot) d);
+            }
+            out = builder.build();
+        } else if (v instanceof HistogramSnapshot) {
+            HistogramSnapshot.Builder builder = HistogramSnapshot.builder()
+                    .name(outName)
+                    .help(v.getMetadata().getHelp())
+                    .unit(v.getMetadata().getUnit())
+                    .gaugeHistogram(((HistogramSnapshot) v).isGaugeHistogram());
+            for (DataPointSnapshot d : outDataPoints) {
+                builder.dataPoint((HistogramSnapshot.HistogramDataPointSnapshot) d);
+            }
+            out = builder.build();
+        } else if (v instanceof SummarySnapshot) {
+            SummarySnapshot.Builder builder = SummarySnapshot.builder()
+                    .name(outName)
+                    .help(v.getMetadata().getHelp())
+                    .unit(v.getMetadata().getUnit());
+            for (DataPointSnapshot d : outDataPoints) {
+                builder.dataPoint((SummarySnapshot.SummaryDataPointSnapshot) d);
+            }
+            out = builder.build();
+        } else if (v instanceof InfoSnapshot) {
+            InfoSnapshot.Builder builder = InfoSnapshot.builder()
+                    .name(outName)
+                    .help(v.getMetadata().getHelp());
+            for (DataPointSnapshot d : outDataPoints) {
+                builder.dataPoint((InfoSnapshot.InfoDataPointSnapshot) d);
+            }
+            out = builder.build();
+        } else if (v instanceof StateSetSnapshot) {
+            StateSetSnapshot.Builder builder = StateSetSnapshot.builder()
+                    .name(outName)
+                    .help(v.getMetadata().getHelp());
+            for (DataPointSnapshot d : outDataPoints) {
+                builder.dataPoint((StateSetSnapshot.StateSetDataPointSnapshot) d);
+            }
+            out = builder.build();
+        } else if (v instanceof UnknownSnapshot) {
+            UnknownSnapshot.Builder builder = UnknownSnapshot.builder()
+                    .name(outName)
+                    .help(v.getMetadata().getHelp())
+                    .unit(v.getMetadata().getUnit());
+            for (DataPointSnapshot d : outDataPoints) {
+                builder.dataPoint((UnknownSnapshot.UnknownDataPointSnapshot) d);
+            }
+            out = builder.build();
+        } else {
+            throw new IllegalArgumentException("Unknown MetricSnapshot type: " + v.getClass());
+        }
+
+        return out;
+    }
+
+    static boolean metricNeedsEscaping(DataPointSnapshot d) {
+        Labels labels = d.getLabels();
+        for (Label l : labels) {
+            if (l.getName().equals(METRIC_NAME_LABEL) && !isValidLegacyMetricName(l.getValue())) {
+                return true;
+            }
+            if (!isValidLegacyMetricName(l.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static String escapeName(String name, EscapingScheme scheme) {
+        if (name.isEmpty()) {
+            return name;
+        }
+        StringBuilder escaped = new StringBuilder();
+        switch (scheme) {
+            case NO_ESCAPING:
+                return name;
+            case UNDERSCORE_ESCAPING:
+                if (isValidLegacyMetricName(name)) {
+                    return name;
+                }
+                for (int i = 0; i < name.length(); i++) {
+                    char c = name.charAt(i);
+                    if (isValidLegacyChar(c, i)) {
+                        escaped.append(c);
+                    } else {
+                        escaped.append('_');
+                    }
+                }
+                return escaped.toString();
+            case DOTS_ESCAPING:
+                for (int i = 0; i < name.length(); i++) {
+                    char c = name.charAt(i);
+                    if (c == '_') {
+                        escaped.append("__");
+                    } else if (c == '.') {
+                        escaped.append("_dot_");
+                    } else if (isValidLegacyChar(c, i)) {
+                        escaped.append(c);
+                    } else {
+                        escaped.append('_');
+                    }
+                }
+                return escaped.toString();
+            case VALUE_ENCODING_ESCAPING:
+                if (isValidLegacyMetricName(name)) {
+                    return name;
+                }
+                escaped.append("U__");
+                for (int i = 0; i < name.length(); i++) {
+                    char c = name.charAt(i);
+                    if (isValidLegacyChar(c, i)) {
+                        escaped.append(c);
+                    } else if (!isValidUTF8Byte(c)) {
+                        escaped.append("_FFFD_");
+                    } else if (c < 0x100) {
+                        // TODO Check if this is ok
+                        escaped.append('_');
+                        escaped.append(encodeByte(c));
+                        escaped.append('_');
+                    } else {
+                        escaped.append('_');
+                        escaped.append(encodeShort((short) c));
+                        escaped.append('_');
+                    }
+                }
+                return escaped.toString();
+            default:
+                throw new IllegalArgumentException("Invalid escaping scheme " + scheme);
+        }
+    }
+
+    static String unescapeName(String name, EscapingScheme scheme) {
+        if (name.isEmpty()) {
+            return name;
+        }
+        switch (scheme) {
+            case NO_ESCAPING:
+                return name;
+            case UNDERSCORE_ESCAPING:
+                // It is not possible to unescape from underscore replacement.
+                return name;
+            case DOTS_ESCAPING:
+                name = name.replaceAll("_dot_", ".");
+                name = name.replaceAll("__", "_");
+                return name;
+            case VALUE_ENCODING_ESCAPING:
+                // TODO Check if this is ok
+                Matcher matcher = Pattern.compile("U__").matcher(name);
+                if (matcher.find()) {
+                    String escapedName = name.substring(matcher.end());
+                    StringBuilder unescaped = new StringBuilder();
+                    TOP:
+                    for (int i = 0; i < escapedName.length(); i++) {
+                        // All non-underscores are treated normally.
+                        if (escapedName.charAt(i) != '_') {
+                            unescaped.append(escapedName.charAt(i));
+                            continue;
+                        }
+                        i++;
+                        if (i >= escapedName.length()) {
+                            return name;
+                        }
+                        // A double underscore is a single underscore.
+                        if (escapedName.charAt(i) == '_') {
+                            unescaped.append('_');
+                            continue;
+                        }
+                        // We think we are in a UTF-8 code, process it.
+                        long utf8Val = 0;
+                        for (int j = 0; i < escapedName.length(); j++) {
+                            // This is too many characters for a UTF-8 value.
+                            if (j > 4) {
+                                return name;
+                            }
+                            // Found a closing underscore, convert to a char, check validity, and append.
+                            if (escapedName.charAt(i) == '_') {
+                                char utf8Char = (char) utf8Val;
+                                if (!Character.isDefined(utf8Char)) {
+                                    return name;
+                                }
+                                unescaped.append(utf8Char);
+                                continue TOP;
+                            }
+                            char r = Character.toLowerCase(escapedName.charAt(i));
+                            utf8Val *= 16;
+                            if (r >= '0' && r <= '9') {
+                                utf8Val += r - '0';
+                            } else if (r >= 'a' && r <= 'f') {
+                                utf8Val += r - 'a' + 10;
+                            } else {
+                                return name;
+                            }
+                            i++;
+                        }
+                        // Didn't find closing underscore, invalid.
+                        return name;
+                    }
+                    return unescaped.toString();
+                } else {
+                    return name;
+                }
+            default:
+                throw new IllegalArgumentException("Invalid escaping scheme " + scheme);
+        }
+    }
+
+    static boolean isValidLegacyChar(char c, int i) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == ':' || (c >= '0' && c <= '9' && i > 0);
+    }
+
+    private static boolean isValidUTF8Byte(char b) {
+        byte[] bytes = Character.toString(b).getBytes(StandardCharsets.UTF_8);
+        return bytes.length == 1;
+    }
+
+    private static String encodeByte(char b) {
+        return encodeShort((short) b);
+    }
+
+    private static String encodeShort(short b) {
+        StringBuilder encoded = new StringBuilder();
+        for (int s = 12; s >= 0; s -= 4) {
+            encoded.append(LOWERHEX.charAt((b >> s) & 0xF));
+        }
+        return encoded.toString();
     }
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
@@ -53,8 +53,6 @@ public class PrometheusNaming {
      */
     private static final Pattern LEGACY_LABEL_NAME_PATTERN = Pattern.compile("^[a-zA-Z_.][a-zA-Z0-9_.]*$");
 
-    private static final Pattern LABEL_NAME_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
-
     /**
      * According to OpenMetrics {@code _count} and {@code _sum} (and {@code _gcount}, {@code _gsum}) should also be
      * reserved metric name suffixes. However, popular instrumentation libraries have Gauges with names

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
@@ -180,14 +180,7 @@ public class PrometheusNaming {
      * @return the name with dots replaced by underscores.
      */
     public static String prometheusName(String name) {
-        switch (nameValidationScheme) {
-            case LEGACY_VALIDATION:
-                return name.replace(".", "_");
-            case UTF_8_VALIDATION:
-                return name;
-            default:
-                throw new RuntimeException("Invalid name validation scheme requested: " + nameValidationScheme);
-        }
+        return name.replace(".", "_");
     }
 
     /**

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
@@ -74,6 +74,16 @@ public class PrometheusNaming {
             ".total", ".created", ".bucket", ".info"
     };
 
+    static ValidationScheme initValidationScheme() {
+        if (PrometheusProperties.get() != null && PrometheusProperties.get().getNamingProperties() != null) {
+            String validationScheme = PrometheusProperties.get().getNamingProperties().getValidationScheme();
+            if (validationScheme != null && validationScheme.equals("utf-8")) {
+                return ValidationScheme.UTF_8_VALIDATION;
+            }
+        }
+        return ValidationScheme.LEGACY_VALIDATION;
+    }
+
     /**
      * Test if a metric name is valid. Rules:
      * <ul>
@@ -94,16 +104,6 @@ public class PrometheusNaming {
      */
     public static boolean isValidMetricName(String name) {
         return validateMetricName(name) == null;
-    }
-
-    static ValidationScheme initValidationScheme() {
-        if (PrometheusProperties.get() != null && PrometheusProperties.get().getNamingProperties() != null) {
-            String validationScheme = PrometheusProperties.get().getNamingProperties().getValidationScheme();
-            if (validationScheme != null && validationScheme.equals("utf-8")) {
-                return ValidationScheme.UTF_8_VALIDATION;
-            }
-        }
-        return ValidationScheme.LEGACY_VALIDATION;
     }
 
     static String validateMetricName(String name) {
@@ -151,8 +151,7 @@ public class PrometheusNaming {
     public static boolean isValidLabelName(String name) {
         switch (nameValidationScheme) {
             case LEGACY_VALIDATION:
-                return isValidLegacyLabelName(name) &&
-                        !(name.startsWith("__") || name.startsWith("._") || name.startsWith("..") || name.startsWith("_."));
+                return isValidLegacyLabelName(name);
             case UTF_8_VALIDATION:
                 return StandardCharsets.UTF_8.newEncoder().canEncode(name);
             default:
@@ -161,14 +160,8 @@ public class PrometheusNaming {
     }
 
     public static boolean isValidLegacyLabelName(String name) {
-        switch (nameValidationScheme) {
-            case LEGACY_VALIDATION:
-                return LEGACY_LABEL_NAME_PATTERN.matcher(name).matches();
-            case UTF_8_VALIDATION:
-                return LABEL_NAME_PATTERN.matcher(name).matches();
-            default:
-                throw new RuntimeException("Invalid name validation scheme requested: " + nameValidationScheme);
-        }
+        return LEGACY_LABEL_NAME_PATTERN.matcher(name).matches() &&
+                !(name.startsWith("__") || name.startsWith("._") || name.startsWith("..") || name.startsWith("_."));
     }
 
     /**

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
@@ -73,7 +73,7 @@ public class PrometheusNaming {
             case LegacyValidation:
                 return validateLegacyMetricName(name);
             case UTF8Validation:
-                if(!StandardCharsets.UTF_8.newEncoder().canEncode(name)) {
+                if(name.isEmpty() || !StandardCharsets.UTF_8.newEncoder().canEncode(name)) {
                     return "The metric name contains unsupported characters";
                 }
                 return null;
@@ -93,22 +93,30 @@ public class PrometheusNaming {
                 return "The metric name must not include the '" + reservedSuffix + "' suffix.";
             }
         }
-        if (!METRIC_NAME_PATTERN.matcher(name).matches()) {
+        if (!isValidLegacyMetricName(name)) {
             return "The metric name contains unsupported characters";
         }
         return null;
     }
 
+    public static boolean isValidLegacyMetricName(String name) {
+        return METRIC_NAME_PATTERN.matcher(name).matches();
+    }
+
     public static boolean isValidLabelName(String name) {
         switch (nameValidationScheme) {
             case LegacyValidation:
-                return LABEL_NAME_PATTERN.matcher(name).matches() &&
+                return isValidLegacyLabelName(name) &&
                         !(name.startsWith("__") || name.startsWith("._") || name.startsWith("..") || name.startsWith("_."));
             case UTF8Validation:
                 return StandardCharsets.UTF_8.newEncoder().canEncode(name);
             default:
                 throw new RuntimeException("Invalid name validation scheme requested: " + nameValidationScheme);
         }
+    }
+
+    public static boolean isValidLegacyLabelName(String name) {
+        return LABEL_NAME_PATTERN.matcher(name).matches();
     }
 
     /**

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/ValidationScheme.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/ValidationScheme.java
@@ -1,6 +1,6 @@
 package io.prometheus.metrics.model.snapshots;
 
 public enum ValidationScheme {
-    LegacyValidation,
-    UTF8Validation
+    LEGACY_VALIDATION,
+    UTF_8_VALIDATION
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/ValidationScheme.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/ValidationScheme.java
@@ -1,6 +1,13 @@
 package io.prometheus.metrics.model.snapshots;
 
+// ValidationScheme is an enum for determining how metric and label names will
+// be validated by this library.
 public enum ValidationScheme {
+    // LEGACY_VALIDATION is a setting that requires that metric and label names
+    // conform to the original character requirements.
     LEGACY_VALIDATION,
+
+    // UTF_8_VALIDATION only requires that metric and label names be valid UTF-8
+    // strings.
     UTF_8_VALIDATION
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/ValidationScheme.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/ValidationScheme.java
@@ -1,0 +1,6 @@
+package io.prometheus.metrics.model.snapshots;
+
+public enum ValidationScheme {
+    LegacyValidation,
+    UTF8Validation
+}

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
@@ -120,7 +120,6 @@ public class PrometheusNamingTest {
         got = unescapeName(got, EscapingScheme.VALUE_ENCODING_ESCAPING);
         Assert.assertEquals("no:escaping_required", got);
 
-        // TODO should add test for legacy validation?
         // name with dots
         got = escapeName("mysystem.prod.west.cpu.load", EscapingScheme.UNDERSCORE_ESCAPING);
         Assert.assertEquals("mysystem_prod_west_cpu_load", got);

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
@@ -3,9 +3,7 @@ package io.prometheus.metrics.model.snapshots;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
-import static io.prometheus.metrics.model.snapshots.PrometheusNaming.sanitizeLabelName;
-import static io.prometheus.metrics.model.snapshots.PrometheusNaming.sanitizeMetricName;
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.*;
 
 public class PrometheusNamingTest {
 
@@ -30,5 +28,55 @@ public class PrometheusNamingTest {
         Assert.assertEquals("_abc", prometheusName(sanitizeLabelName("_.abc")));
         Assert.assertEquals("abc.def", sanitizeLabelName("abc.def"));
         Assert.assertEquals("abc.def2", sanitizeLabelName("abc.def2"));
+    }
+
+    @Test
+    public void testMetricNameIsValid() {
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        Assert.assertNull(validateMetricName("Avalid_23name"));
+        Assert.assertNull(validateMetricName("_Avalid_23name"));
+        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("1valid_23name"));
+        Assert.assertNull(validateMetricName("avalid_23name"));
+        Assert.assertNull(validateMetricName("Ava:lid_23name"));
+        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("a lid_23name"));
+        Assert.assertNull(validateMetricName(":leading_colon"));
+        Assert.assertNull(validateMetricName("colon:in:the:middle"));
+        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName(""));
+        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("a\ud800z"));
+        PrometheusNaming.nameValidationScheme = ValidationScheme.UTF8Validation;
+        Assert.assertNull(validateMetricName("Avalid_23name"));
+        Assert.assertNull(validateMetricName("_Avalid_23name"));
+        Assert.assertNull(validateMetricName("1valid_23name"));
+        Assert.assertNull(validateMetricName("avalid_23name"));
+        Assert.assertNull(validateMetricName("Ava:lid_23name"));
+        Assert.assertNull(validateMetricName("a lid_23name"));
+        Assert.assertNull(validateMetricName(":leading_colon"));
+        Assert.assertNull(validateMetricName("colon:in:the:middle"));
+        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName(""));
+        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("a\ud800z"));
+    }
+
+    @Test
+    public void testLabelNameIsValid() {
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        Assert.assertTrue(isValidLabelName("Avalid_23name"));
+        Assert.assertTrue(isValidLabelName("_Avalid_23name"));
+        Assert.assertFalse(isValidLabelName("1valid_23name"));
+        Assert.assertTrue(isValidLabelName("avalid_23name"));
+        Assert.assertFalse(isValidLabelName("Ava:lid_23name"));
+        Assert.assertFalse(isValidLabelName("a lid_23name"));
+        Assert.assertFalse(isValidLabelName(":leading_colon"));
+        Assert.assertFalse(isValidLabelName("colon:in:the:middle"));
+        Assert.assertFalse(isValidLabelName("a\ud800z"));
+        PrometheusNaming.nameValidationScheme = ValidationScheme.UTF8Validation;
+        Assert.assertTrue(isValidLabelName("Avalid_23name"));
+        Assert.assertTrue(isValidLabelName("_Avalid_23name"));
+        Assert.assertTrue(isValidLabelName("1valid_23name"));
+        Assert.assertTrue(isValidLabelName("avalid_23name"));
+        Assert.assertTrue(isValidLabelName("Ava:lid_23name"));
+        Assert.assertTrue(isValidLabelName("a lid_23name"));
+        Assert.assertTrue(isValidLabelName(":leading_colon"));
+        Assert.assertTrue(isValidLabelName("colon:in:the:middle"));
+        Assert.assertFalse(isValidLabelName("a\ud800z"));
     }
 }

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
@@ -9,7 +9,7 @@ public class PrometheusNamingTest {
 
     @Test
     public void testSanitizeMetricName() {
-        nameValidationScheme = ValidationScheme.LegacyValidation;
+        nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         Assert.assertEquals("_abc_def", prometheusName(sanitizeMetricName("0abc.def")));
         Assert.assertEquals("___ab_:c0", prometheusName(sanitizeMetricName("___ab.:c0")));
         Assert.assertEquals("my_prefix_my_metric", sanitizeMetricName("my_prefix/my_metric"));
@@ -22,7 +22,7 @@ public class PrometheusNamingTest {
 
     @Test
     public void testSanitizeLabelName() {
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         Assert.assertEquals("_abc_def", prometheusName(sanitizeLabelName("0abc.def")));
         Assert.assertEquals("_abc", prometheusName(sanitizeLabelName("_abc")));
         Assert.assertEquals("_abc", prometheusName(sanitizeLabelName("__abc")));
@@ -34,7 +34,7 @@ public class PrometheusNamingTest {
 
     @Test
     public void testMetricNameIsValid() {
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         Assert.assertNull(validateMetricName("Avalid_23name"));
         Assert.assertNull(validateMetricName("_Avalid_23name"));
         Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("1valid_23name"));
@@ -45,7 +45,7 @@ public class PrometheusNamingTest {
         Assert.assertNull(validateMetricName("colon:in:the:middle"));
         Assert.assertEquals("The metric name contains unsupported characters", validateMetricName(""));
         Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("a\ud800z"));
-        PrometheusNaming.nameValidationScheme = ValidationScheme.UTF8Validation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
         Assert.assertNull(validateMetricName("Avalid_23name"));
         Assert.assertNull(validateMetricName("_Avalid_23name"));
         Assert.assertNull(validateMetricName("1valid_23name"));
@@ -60,7 +60,7 @@ public class PrometheusNamingTest {
 
     @Test
     public void testLabelNameIsValid() {
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
         Assert.assertTrue(isValidLabelName("Avalid_23name"));
         Assert.assertTrue(isValidLabelName("_Avalid_23name"));
         Assert.assertFalse(isValidLabelName("1valid_23name"));
@@ -70,7 +70,7 @@ public class PrometheusNamingTest {
         Assert.assertFalse(isValidLabelName(":leading_colon"));
         Assert.assertFalse(isValidLabelName("colon:in:the:middle"));
         Assert.assertFalse(isValidLabelName("a\ud800z"));
-        PrometheusNaming.nameValidationScheme = ValidationScheme.UTF8Validation;
+        PrometheusNaming.nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
         Assert.assertTrue(isValidLabelName("Avalid_23name"));
         Assert.assertTrue(isValidLabelName("_Avalid_23name"));
         Assert.assertTrue(isValidLabelName("1valid_23name"));

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
@@ -34,18 +34,7 @@ public class PrometheusNamingTest {
 
     @Test
     public void testMetricNameIsValid() {
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
-        Assert.assertNull(validateMetricName("Avalid_23name"));
-        Assert.assertNull(validateMetricName("_Avalid_23name"));
-        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("1valid_23name"));
-        Assert.assertNull(validateMetricName("avalid_23name"));
-        Assert.assertNull(validateMetricName("Ava:lid_23name"));
-        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("a lid_23name"));
-        Assert.assertNull(validateMetricName(":leading_colon"));
-        Assert.assertNull(validateMetricName("colon:in:the:middle"));
-        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName(""));
-        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("a\ud800z"));
-        PrometheusNaming.nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
+        nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
         Assert.assertNull(validateMetricName("Avalid_23name"));
         Assert.assertNull(validateMetricName("_Avalid_23name"));
         Assert.assertNull(validateMetricName("1valid_23name"));
@@ -56,21 +45,22 @@ public class PrometheusNamingTest {
         Assert.assertNull(validateMetricName("colon:in:the:middle"));
         Assert.assertEquals("The metric name contains unsupported characters", validateMetricName(""));
         Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("a\ud800z"));
+        nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
+        Assert.assertNull(validateMetricName("Avalid_23name"));
+        Assert.assertNull(validateMetricName("_Avalid_23name"));
+        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("1valid_23name"));
+        Assert.assertNull(validateMetricName("avalid_23name"));
+        Assert.assertNull(validateMetricName("Ava:lid_23name"));
+        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("a lid_23name"));
+        Assert.assertNull(validateMetricName(":leading_colon"));
+        Assert.assertNull(validateMetricName("colon:in:the:middle"));
+        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName(""));
+        Assert.assertEquals("The metric name contains unsupported characters", validateMetricName("a\ud800z"));
     }
 
     @Test
     public void testLabelNameIsValid() {
-        PrometheusNaming.nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
-        Assert.assertTrue(isValidLabelName("Avalid_23name"));
-        Assert.assertTrue(isValidLabelName("_Avalid_23name"));
-        Assert.assertFalse(isValidLabelName("1valid_23name"));
-        Assert.assertTrue(isValidLabelName("avalid_23name"));
-        Assert.assertFalse(isValidLabelName("Ava:lid_23name"));
-        Assert.assertFalse(isValidLabelName("a lid_23name"));
-        Assert.assertFalse(isValidLabelName(":leading_colon"));
-        Assert.assertFalse(isValidLabelName("colon:in:the:middle"));
-        Assert.assertFalse(isValidLabelName("a\ud800z"));
-        PrometheusNaming.nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
+        nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
         Assert.assertTrue(isValidLabelName("Avalid_23name"));
         Assert.assertTrue(isValidLabelName("_Avalid_23name"));
         Assert.assertTrue(isValidLabelName("1valid_23name"));
@@ -80,5 +70,321 @@ public class PrometheusNamingTest {
         Assert.assertTrue(isValidLabelName(":leading_colon"));
         Assert.assertTrue(isValidLabelName("colon:in:the:middle"));
         Assert.assertFalse(isValidLabelName("a\ud800z"));
+        nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
+        Assert.assertTrue(isValidLabelName("Avalid_23name"));
+        Assert.assertTrue(isValidLabelName("_Avalid_23name"));
+        Assert.assertFalse(isValidLabelName("1valid_23name"));
+        Assert.assertTrue(isValidLabelName("avalid_23name"));
+        Assert.assertFalse(isValidLabelName("Ava:lid_23name"));
+        Assert.assertFalse(isValidLabelName("a lid_23name"));
+        Assert.assertFalse(isValidLabelName(":leading_colon"));
+        Assert.assertFalse(isValidLabelName("colon:in:the:middle"));
+        Assert.assertFalse(isValidLabelName("a\ud800z"));
+    }
+
+    @Test
+    public void testEscapeName() {
+        nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
+
+        // empty string
+        String got = escapeName("", EscapingScheme.UNDERSCORE_ESCAPING);
+        Assert.assertEquals("", got);
+        got = unescapeName(got, EscapingScheme.UNDERSCORE_ESCAPING);
+        Assert.assertEquals("", got);
+
+        got = escapeName("", EscapingScheme.DOTS_ESCAPING);
+        Assert.assertEquals("", got);
+        got = unescapeName(got, EscapingScheme.DOTS_ESCAPING);
+        Assert.assertEquals("", got);
+
+        got = escapeName("", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("", got);
+        got = unescapeName(got, EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("", got);
+
+        // legacy valid name
+        got = escapeName("no:escaping_required", EscapingScheme.UNDERSCORE_ESCAPING);
+        Assert.assertEquals("no:escaping_required", got);
+        got = unescapeName(got, EscapingScheme.UNDERSCORE_ESCAPING);
+        Assert.assertEquals("no:escaping_required", got);
+
+        got = escapeName("no:escaping_required", EscapingScheme.DOTS_ESCAPING);
+        // Dots escaping will escape underscores even though it's not strictly
+        // necessary for compatibility.
+        Assert.assertEquals("no:escaping__required", got);
+        got = unescapeName(got, EscapingScheme.DOTS_ESCAPING);
+        Assert.assertEquals("no:escaping_required", got);
+
+        got = escapeName("no:escaping_required", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("no:escaping_required", got);
+        got = unescapeName(got, EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("no:escaping_required", got);
+
+        // TODO should add test for legacy validation?
+        // name with dots
+        got = escapeName("mysystem.prod.west.cpu.load", EscapingScheme.UNDERSCORE_ESCAPING);
+        Assert.assertEquals("mysystem_prod_west_cpu_load", got);
+        got = unescapeName(got, EscapingScheme.UNDERSCORE_ESCAPING);
+        Assert.assertEquals("mysystem_prod_west_cpu_load", got);
+
+        got = escapeName("mysystem.prod.west.cpu.load", EscapingScheme.DOTS_ESCAPING);
+        Assert.assertEquals("mysystem_dot_prod_dot_west_dot_cpu_dot_load", got);
+        got = unescapeName(got, EscapingScheme.DOTS_ESCAPING);
+        Assert.assertEquals("mysystem.prod.west.cpu.load", got);
+
+        got = escapeName("mysystem.prod.west.cpu.load", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("U__mysystem_2e_prod_2e_west_2e_cpu_2e_load", got);
+        got = unescapeName(got, EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("mysystem.prod.west.cpu.load", got);
+
+        // name with dots and colon
+        got = escapeName("http.status:sum", EscapingScheme.UNDERSCORE_ESCAPING);
+        Assert.assertEquals("http_status:sum", got);
+        got = unescapeName(got, EscapingScheme.UNDERSCORE_ESCAPING);
+        Assert.assertEquals("http_status:sum", got);
+
+        got = escapeName("http.status:sum", EscapingScheme.DOTS_ESCAPING);
+        Assert.assertEquals("http_dot_status:sum", got);
+        got = unescapeName(got, EscapingScheme.DOTS_ESCAPING);
+        Assert.assertEquals("http.status:sum", got);
+
+        got = escapeName("http.status:sum", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("U__http_2e_status:sum", got);
+        got = unescapeName(got, EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("http.status:sum", got);
+
+        // name with unicode characters > 0x100
+        got = escapeName("花火", EscapingScheme.UNDERSCORE_ESCAPING);
+        Assert.assertEquals("__", got);
+        got = unescapeName(got, EscapingScheme.UNDERSCORE_ESCAPING);
+        Assert.assertEquals("__", got);
+
+        got = escapeName("花火", EscapingScheme.DOTS_ESCAPING);
+        Assert.assertEquals("__", got);
+        got = unescapeName(got, EscapingScheme.DOTS_ESCAPING);
+        // Dots-replacement does not know the difference between two replaced
+        // characters and a single underscore.
+        Assert.assertEquals("_", got);
+
+        got = escapeName("花火", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("U___82b1__706b_", got);
+        got = unescapeName(got, EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("花火", got);
+
+        nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
+    }
+
+    @Test
+    public void testValueUnescapeErrors() {
+        nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
+        String got;
+
+        // empty string
+        got = unescapeName("", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("", got);
+
+        // basic case, no error
+        got = unescapeName("U__no:unescapingrequired", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("no:unescapingrequired", got);
+
+        // capitals ok, no error
+        got = unescapeName("U__capitals_2E_ok", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("capitals.ok", got);
+
+        // underscores, no error
+        got = unescapeName("U__underscores__doubled__", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("underscores_doubled_", got);
+
+        // invalid single underscore
+        got = unescapeName("U__underscores_doubled_", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("U__underscores_doubled_", got);
+
+        // invalid single underscore, 2
+        got = unescapeName("U__underscores__doubled_", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("U__underscores__doubled_", got);
+
+        // giant fake UTF-8 code
+        got = unescapeName("U__my__hack_2e_attempt_872348732fabdabbab_", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("U__my__hack_2e_attempt_872348732fabdabbab_", got);
+
+        // trailing UTF-8
+        got = unescapeName("U__my__hack_2e", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("U__my__hack_2e", got);
+
+        // invalid UTF-8 value
+        got = unescapeName("U__bad__utf_2eg_", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("U__bad__utf_2eg_", got);
+
+        // surrogate UTF-8 value
+        got = unescapeName("U__bad__utf_D900_", EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("U__bad__utf_D900_", got);
+
+        nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
+    }
+
+    @Test
+    public void testEscapeMetricSnapshotEmpty() {
+        nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
+        MetricSnapshot original = CounterSnapshot.builder().name("empty").build();
+        MetricSnapshot got = escapeMetricSnapshot(original, EscapingScheme.VALUE_ENCODING_ESCAPING);
+        Assert.assertEquals("empty", got.getMetadata().getName());
+        Assert.assertEquals("empty", original.getMetadata().getName());
+        nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
+    }
+
+    @Test
+    public void testEscapeMetricSnapshotSimpleNoEscapingNeeded() {
+        nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
+        MetricSnapshot original = CounterSnapshot.builder()
+                .name("my_metric")
+                .help("some help text")
+                .dataPoint(CounterSnapshot.CounterDataPointSnapshot.builder()
+                        .value(34.2)
+                        .labels(Labels.builder()
+                                .label("__name__", "my_metric")
+                                .label("some_label", "labelvalue")
+                                .build())
+                        .build()
+                )
+                .build();
+        MetricSnapshot got = escapeMetricSnapshot(original, EscapingScheme.VALUE_ENCODING_ESCAPING);
+
+        Assert.assertEquals("my_metric", got.getMetadata().getName());
+        Assert.assertEquals("some help text", got.getMetadata().getHelp());
+        Assert.assertEquals(1, got.getDataPoints().size());
+        CounterSnapshot.CounterDataPointSnapshot data = (CounterSnapshot.CounterDataPointSnapshot) got.getDataPoints().get(0);
+        Assert.assertEquals(34.2, data.getValue(), 0.0);
+        Assert.assertEquals(Labels.builder()
+                .label("__name__", "my_metric")
+                .label("some_label", "labelvalue")
+                .build(), data.getLabels());
+        Assert.assertEquals("my_metric", original.getMetadata().getName());
+        Assert.assertEquals("some help text", original.getMetadata().getHelp());
+        Assert.assertEquals(1, original.getDataPoints().size());
+        data = (CounterSnapshot.CounterDataPointSnapshot) original.getDataPoints().get(0);
+        Assert.assertEquals(34.2, data.getValue(), 0.0);
+        Assert.assertEquals(Labels.builder()
+                .label("__name__", "my_metric")
+                .label("some_label", "labelvalue")
+                .build(), data.getLabels());
+
+        nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
+    }
+
+    @Test
+    public void testEscapeMetricSnapshotLabelNameEscapingNeeded() {
+        nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
+        MetricSnapshot original = CounterSnapshot.builder()
+                .name("my_metric")
+                .help("some help text")
+                .dataPoint(CounterSnapshot.CounterDataPointSnapshot.builder()
+                        .value(34.2)
+                        .labels(Labels.builder()
+                                .label("__name__", "my_metric")
+                                .label("some.label", "labelvalue")
+                                .build())
+                        .build()
+                )
+                .build();
+        MetricSnapshot got = escapeMetricSnapshot(original, EscapingScheme.VALUE_ENCODING_ESCAPING);
+
+        Assert.assertEquals("my_metric", got.getMetadata().getName());
+        Assert.assertEquals("some help text", got.getMetadata().getHelp());
+        Assert.assertEquals(1, got.getDataPoints().size());
+        CounterSnapshot.CounterDataPointSnapshot data = (CounterSnapshot.CounterDataPointSnapshot) got.getDataPoints().get(0);
+        Assert.assertEquals(34.2, data.getValue(), 0.0);
+        Assert.assertEquals(Labels.builder()
+                .label("__name__", "my_metric")
+                .label("U__some_2e_label", "labelvalue")
+                .build(), data.getLabels());
+        Assert.assertEquals("my_metric", original.getMetadata().getName());
+        Assert.assertEquals("some help text", original.getMetadata().getHelp());
+        Assert.assertEquals(1, original.getDataPoints().size());
+        data = (CounterSnapshot.CounterDataPointSnapshot) original.getDataPoints().get(0);
+        Assert.assertEquals(34.2, data.getValue(), 0.0);
+        Assert.assertEquals(Labels.builder()
+                .label("__name__", "my_metric")
+                .label("some.label", "labelvalue")
+                .build(), data.getLabels());
+
+        nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
+    }
+
+    @Test
+    public void testEscapeMetricSnapshotCounterEscapingNeeded() {
+        nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
+        MetricSnapshot original = CounterSnapshot.builder()
+                .name("my.metric")
+                .help("some help text")
+                .dataPoint(CounterSnapshot.CounterDataPointSnapshot.builder()
+                        .value(34.2)
+                        .labels(Labels.builder()
+                                .label("__name__", "my.metric")
+                                .label("some?label", "label??value")
+                                .build())
+                        .build()
+                )
+                .build();
+        MetricSnapshot got = escapeMetricSnapshot(original, EscapingScheme.VALUE_ENCODING_ESCAPING);
+
+        Assert.assertEquals("U__my_2e_metric", got.getMetadata().getName());
+        Assert.assertEquals("some help text", got.getMetadata().getHelp());
+        Assert.assertEquals(1, got.getDataPoints().size());
+        CounterSnapshot.CounterDataPointSnapshot data = (CounterSnapshot.CounterDataPointSnapshot) got.getDataPoints().get(0);
+        Assert.assertEquals(34.2, data.getValue(), 0.0);
+        Assert.assertEquals(Labels.builder()
+                .label("__name__", "U__my_2e_metric")
+                .label("U__some_3f_label", "label??value")
+                .build(), data.getLabels());
+        Assert.assertEquals("my.metric", original.getMetadata().getName());
+        Assert.assertEquals("some help text", original.getMetadata().getHelp());
+        Assert.assertEquals(1, original.getDataPoints().size());
+        data = (CounterSnapshot.CounterDataPointSnapshot) original.getDataPoints().get(0);
+        Assert.assertEquals(34.2, data.getValue(), 0.0);
+        Assert.assertEquals(Labels.builder()
+                .label("__name__", "my.metric")
+                .label("some?label", "label??value")
+                .build(), data.getLabels());
+
+        nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
+    }
+
+    @Test
+    public void testEscapeMetricSnapshotGaugeEscapingNeeded() {
+        nameValidationScheme = ValidationScheme.UTF_8_VALIDATION;
+        MetricSnapshot original = GaugeSnapshot.builder()
+                .name("unicode.and.dots.花火")
+                .help("some help text")
+                .dataPoint(GaugeSnapshot.GaugeDataPointSnapshot.builder()
+                        .value(34.2)
+                        .labels(Labels.builder()
+                                .label("__name__", "unicode.and.dots.花火")
+                                .label("some_label", "label??value")
+                                .build())
+                        .build()
+                )
+                .build();
+        MetricSnapshot got = escapeMetricSnapshot(original, EscapingScheme.DOTS_ESCAPING);
+
+        Assert.assertEquals("unicode_dot_and_dot_dots_dot___", got.getMetadata().getName());
+        Assert.assertEquals("some help text", got.getMetadata().getHelp());
+        Assert.assertEquals(1, got.getDataPoints().size());
+        GaugeSnapshot.GaugeDataPointSnapshot data = (GaugeSnapshot.GaugeDataPointSnapshot) got.getDataPoints().get(0);
+        Assert.assertEquals(34.2, data.getValue(), 0.0);
+        Assert.assertEquals(Labels.builder()
+                .label("__name__", "unicode_dot_and_dot_dots_dot___")
+                .label("some_label", "label??value")
+                .build(), data.getLabels());
+        Assert.assertEquals("unicode.and.dots.花火", original.getMetadata().getName());
+        Assert.assertEquals("some help text", original.getMetadata().getHelp());
+        Assert.assertEquals(1, original.getDataPoints().size());
+        data = (GaugeSnapshot.GaugeDataPointSnapshot) original.getDataPoints().get(0);
+        Assert.assertEquals(34.2, data.getValue(), 0.0);
+        Assert.assertEquals(Labels.builder()
+                .label("__name__", "unicode.and.dots.花火")
+                .label("some_label", "label??value")
+                .build(), data.getLabels());
+
+        nameValidationScheme = ValidationScheme.LEGACY_VALIDATION;
     }
 }

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
@@ -9,6 +9,7 @@ public class PrometheusNamingTest {
 
     @Test
     public void testSanitizeMetricName() {
+        nameValidationScheme = ValidationScheme.LegacyValidation;
         Assert.assertEquals("_abc_def", prometheusName(sanitizeMetricName("0abc.def")));
         Assert.assertEquals("___ab_:c0", prometheusName(sanitizeMetricName("___ab.:c0")));
         Assert.assertEquals("my_prefix_my_metric", sanitizeMetricName("my_prefix/my_metric"));
@@ -21,6 +22,7 @@ public class PrometheusNamingTest {
 
     @Test
     public void testSanitizeLabelName() {
+        PrometheusNaming.nameValidationScheme = ValidationScheme.LegacyValidation;
         Assert.assertEquals("_abc_def", prometheusName(sanitizeLabelName("0abc.def")));
         Assert.assertEquals("_abc", prometheusName(sanitizeLabelName("_abc")));
         Assert.assertEquals("_abc", prometheusName(sanitizeLabelName("__abc")));

--- a/prometheus-metrics-model/src/test/resources/prometheus.properties
+++ b/prometheus-metrics-model/src/test/resources/prometheus.properties
@@ -1,0 +1,1 @@
+io.prometheus.naming.validationScheme=legacy

--- a/prometheus-metrics-simpleclient-bridge/src/test/java/io/prometheus/metrics/simpleclient/bridge/SimpleclientCollectorTest.java
+++ b/prometheus-metrics-simpleclient-bridge/src/test/java/io/prometheus/metrics/simpleclient/bridge/SimpleclientCollectorTest.java
@@ -10,6 +10,7 @@ import io.prometheus.client.Summary;
 import io.prometheus.client.exporter.common.TextFormat;
 import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import io.prometheus.metrics.model.snapshots.EscapingScheme;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -243,7 +244,7 @@ public class SimpleclientCollectorTest {
     private String newOpenMetrics() throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         OpenMetricsTextFormatWriter writer = new OpenMetricsTextFormatWriter(true, true);
-        writer.write(out, newRegistry.scrape());
+        writer.write(out, newRegistry.scrape(), EscapingScheme.NO_ESCAPING);
         return out.toString(StandardCharsets.UTF_8.name());
     }
 }


### PR DESCRIPTION
Adds UTF-8 support for metric and label names.

These changes are based on the work done on the Prometheus common libraries [here](https://github.com/prometheus/common/pull/537) and [here](https://github.com/prometheus/common/pull/570)

- The `prometheus-metrics-exposition-formats` module will use the new quoting syntax `{"foo"}` iff the metric does not conform to the legacy name format (`foo{}`)
- The `prometheus-metrics-model` has a new flag (`NameValidationScheme`) which determines if validation is done using the legacy or the UTF-8 scheme
- Scrapers can announce via content negotiation that they support UTF-8 names by adding `escaping=allow-utf-8` in the Accept header. In cases where UTF-8 is not available, metric providers can be configured to escape names in a few different ways: values (`U__` UTF value escaping for perfect round-tripping), underscores (all invalid chars become `_`), dots (dots become `_dot_`, `_` becomes `__`, all other values become `___`). Escaping can either be a global default (`PrometheusNaming.nameEscapingScheme`) or can also be specified in Accept header with the `escaping=` term, which can be `allow-utf-8` (for UTF-8-compatible), `underscores`, `dots`, or `values`.
This should still be a noop for existing configurations because scrapers will not be passing the escaping key in the Accept header. Existing functionality is maintained.

Work towards https://github.com/prometheus/common/issues/527