### PR TITLE
docs(theme): fix gdoc-md overflow

### DIFF
--- a/docs/static/custom.css
+++ b/docs/static/custom.css
@@ -37,3 +37,7 @@
     --footer-link-color-visited: #ffffff;
   }
 }
+
+.gdoc-markdown pre,.gdoc-markdown code {
+  overflow: auto;
+}


### PR DESCRIPTION
Alternative fix to #925

Current:

![Screenshot_1](https://github.com/prometheus/client_java/assets/59066707/efb1029e-06f1-4b46-a4a3-8a56def273a0)

New:

![Screenshot_4](https://github.com/prometheus/client_java/assets/59066707/ca190500-7d77-4e93-ac3f-a09253f516c4)

