### PR TITLE
Add optional SpanContext parameter to ExemplarSampler

### DIFF
--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/ExemplarsProperties.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/ExemplarsProperties.java
@@ -107,7 +107,7 @@ public class ExemplarsProperties {
             return this;
         }
 
-        public ExemplarsProperties builder() {
+        public ExemplarsProperties build() {
             return new ExemplarsProperties(minRetentionPeriodSeconds, maxRetentionPeriodSeconds, sampleIntervalMilliseconds);
         }
     }

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/exemplars/ExemplarSamplerTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/exemplars/ExemplarSamplerTest.java
@@ -76,8 +76,7 @@ public class ExemplarSamplerTest {
     public void testIsSampled() throws Exception {
         SpanContext context = new SpanContext();
         context.isSampled = false;
-        SpanContextSupplier.setSpanContext(context);
-        ExemplarSampler sampler = new ExemplarSampler(makeConfig());
+        ExemplarSampler sampler = new ExemplarSampler(makeConfig(), context);
         Thread.sleep(tick); // t = 1 tick
         sampler.observe(0.3); // no sampled, because isSampled() returns false
         assertExemplars(sampler); // empty
@@ -85,9 +84,7 @@ public class ExemplarSamplerTest {
 
     @Test
     public void testDefaultConfigHasFourExemplars() throws Exception {
-        SpanContext context = new SpanContext();
-        SpanContextSupplier.setSpanContext(context);
-        ExemplarSampler sampler = new ExemplarSampler(makeConfig());
+        ExemplarSampler sampler = new ExemplarSampler(makeConfig(), new SpanContext());
         Thread.sleep(tick); // t = 1 tick
         sampler.observe(0.3);
         Thread.sleep(sampleInterval + tick); // t = 12 tick
@@ -104,9 +101,7 @@ public class ExemplarSamplerTest {
 
     @Test
     public void testEmptyBuckets() throws Exception {
-        SpanContext context = new SpanContext();
-        SpanContextSupplier.setSpanContext(context);
-        ExemplarSampler sampler = new ExemplarSampler(makeConfig(Double.POSITIVE_INFINITY));
+        ExemplarSampler sampler = new ExemplarSampler(makeConfig(Double.POSITIVE_INFINITY), new SpanContext());
         Thread.sleep(tick); // t = 1 tick
         sampler.observe(0.8); // observed in the +Inf bucket
         Thread.sleep(sampleInterval + tick); // t = 12 tick
@@ -117,9 +112,7 @@ public class ExemplarSamplerTest {
 
     @Test
     public void testDefaultExemplarsBuckets() throws Exception {
-        SpanContext context = new SpanContext();
-        SpanContextSupplier.setSpanContext(context);
-        ExemplarSampler sampler = new ExemplarSampler(makeConfig(0.2, 0.4, 0.6, 0.8, 1.0, Double.POSITIVE_INFINITY));
+        ExemplarSampler sampler = new ExemplarSampler(makeConfig(0.2, 0.4, 0.6, 0.8, 1.0, Double.POSITIVE_INFINITY), new SpanContext());
         Scheduler.awaitInitialization();
         Thread.sleep(tick); // t = 1 tick
         sampler.observe(0.3);
@@ -150,9 +143,7 @@ public class ExemplarSamplerTest {
 
     @Test
     public void testDefaultExemplarsNoBuckets() throws Exception {
-        SpanContext context = new SpanContext();
-        SpanContextSupplier.setSpanContext(context);
-        ExemplarSampler sampler = new ExemplarSampler(makeConfig());
+        ExemplarSampler sampler = new ExemplarSampler(makeConfig(), new SpanContext());
         Scheduler.awaitInitialization();
         Thread.sleep(tick);           // t = 1 tick
         sampler.observe(1);    // observed

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/exemplars/SpanContextSupplierTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/exemplars/SpanContextSupplierTest.java
@@ -1,0 +1,103 @@
+package io.prometheus.metrics.core.exemplars;
+
+import io.prometheus.metrics.config.ExemplarsProperties;
+import io.prometheus.metrics.model.snapshots.Exemplar;
+import io.prometheus.metrics.model.snapshots.Exemplars;
+import io.prometheus.metrics.tracer.common.SpanContext;
+import io.prometheus.metrics.tracer.initializer.SpanContextSupplier;
+import org.junit.*;
+
+import static io.prometheus.metrics.model.snapshots.Exemplar.TRACE_ID;
+
+public class SpanContextSupplierTest {
+
+    public SpanContext makeSpanContext(String traceId, String spanId) {
+
+        return new SpanContext() {
+            @Override
+            public String getCurrentTraceId() {
+                return traceId;
+            }
+
+            @Override
+            public String getCurrentSpanId() {
+                return spanId;
+            }
+
+            @Override
+            public boolean isCurrentSpanSampled() {
+                return true;
+            }
+
+            @Override
+            public void markCurrentSpanAsExemplar() {
+            }
+        };
+    }
+
+    SpanContext spanContextA = makeSpanContext("A", "a");
+    SpanContext spanContextB = makeSpanContext("B", "b");
+    SpanContext origSpanContext;
+
+    ExemplarSamplerConfig config = new ExemplarSamplerConfig(
+            10, // min retention period in milliseconds
+            20, // max retention period in milliseconds
+            5, // sample interval in millisecnods
+            1, // number of exemplars
+            null // histogram upper bounds
+    );
+
+    @Before
+    public void setUp() {
+        origSpanContext = SpanContextSupplier.getSpanContext();
+    }
+
+    @After
+    public void tearDown() {
+        SpanContextSupplier.setSpanContext(origSpanContext);
+    }
+
+    /**
+     * Test: When a {@link SpanContext} is provided as a constructor argument to the {@link ExemplarSampler},
+     * then that {@link SpanContext} is used, not the one from the {@link SpanContextSupplier}.
+     */
+    @Test
+    public void testConstructorInjection() {
+        ExemplarsProperties properties = ExemplarsProperties.builder().build();
+        ExemplarSamplerConfig config = new ExemplarSamplerConfig(properties, 1);
+        ExemplarSampler exemplarSampler = new ExemplarSampler(config, spanContextA);
+
+        SpanContextSupplier.setSpanContext(spanContextB);
+        exemplarSampler.observe(1.0);
+        Exemplars exemplars = exemplarSampler.collect();
+        Assert.assertEquals(1, exemplars.size());
+        Exemplar exemplar = exemplars.get(0);
+        Assert.assertEquals("A", exemplar.getLabels().get(TRACE_ID));
+    }
+
+    /**
+     * When the global {@link SpanContext} is updated via {@link SpanContextSupplier#setSpanContext(SpanContext)},
+     * the {@link ExemplarSampler} recognizes the update (unless a {@link ExemplarSampler} was provided as
+     * constructor argument to {@link ExemplarSampler}).
+     */
+    @Test
+    public void testUpdateSpanContext() throws InterruptedException {
+        ExemplarSampler exemplarSampler = new ExemplarSampler(config);
+
+        SpanContextSupplier.setSpanContext(spanContextB);
+        exemplarSampler.observe(1.0);
+        Exemplars exemplars = exemplarSampler.collect();
+        Assert.assertEquals(1, exemplars.size());
+        Exemplar exemplar = exemplars.get(0);
+        Assert.assertEquals("B", exemplar.getLabels().get(TRACE_ID));
+
+        Thread.sleep(15); // more than the minimum retention period defined in config above.
+
+        SpanContextSupplier.setSpanContext(spanContextA);
+        exemplarSampler.observe(1.0);
+        exemplars = exemplarSampler.collect();
+        Assert.assertEquals(1, exemplars.size());
+        exemplar = exemplars.get(0);
+        Assert.assertEquals("A", exemplar.getLabels().get(TRACE_ID));
+    }
+}

--- a/prometheus-metrics-tracer/prometheus-metrics-tracer-common/src/main/java/io/prometheus/metrics/tracer/common/SpanContext.java
+++ b/prometheus-metrics-tracer/prometheus-metrics-tracer-common/src/main/java/io/prometheus/metrics/tracer/common/SpanContext.java
@@ -2,8 +2,8 @@ package io.prometheus.metrics.tracer.common;
 
 public interface SpanContext {
 
-  public static final String EXEMPLAR_ATTRIBUTE_NAME = "exemplar";
-  public static final String EXEMPLAR_ATTRIBUTE_VALUE = "true";
+  String EXEMPLAR_ATTRIBUTE_NAME = "exemplar";
+  String EXEMPLAR_ATTRIBUTE_VALUE = "true";
 
   /**
    * @return the current trace id, or {@code null} if this call is not happening within a span context.


### PR DESCRIPTION
Add an optional `SpanContext` constructor parameter to the `ExemplarSampler`.

When a `SpanContext` is provided, that `SpanContext` is used and the `ExemplarSampler` does not use the `SpanContextSupplier`.

If `SpanContext` is `null`, the `ExemplarSampler` uses the global `SpanContextSupplier` to find a `SpanContext` at runtime.

---

Note that with this PR we also renamed `ExemplarProperties.Builder.builder()` to `ExemplarProperties.Builder.build()`. The previous method name was a typo. Obviously a `Builder` should have a `build()` method, not a `builder()` method.