### PR TITLE
Added try/finally to close the HttpExchange

### DIFF
--- a/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/DefaultHandler.java
+++ b/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/DefaultHandler.java
@@ -58,10 +58,13 @@ public class DefaultHandler implements HttpHandler {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        exchange.getResponseHeaders().set("Content-Type", contentType);
-        exchange.getResponseHeaders().set("Content-Length", Integer.toString(responseBytes.length));
-        exchange.sendResponseHeaders(200, responseBytes.length);
-        exchange.getResponseBody().write(responseBytes);
-        exchange.close();
+        try {
+            exchange.getResponseHeaders().set("Content-Type", contentType);
+            exchange.getResponseHeaders().set("Content-Length", Integer.toString(responseBytes.length));
+            exchange.sendResponseHeaders(200, responseBytes.length);
+            exchange.getResponseBody().write(responseBytes);
+        } finally {
+            exchange.close();
+        }
     }
 }

--- a/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/HealthyHandler.java
+++ b/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/HealthyHandler.java
@@ -22,10 +22,13 @@ public class HealthyHandler implements HttpHandler {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        exchange.getResponseHeaders().set("Content-Type", contentType);
-        exchange.getResponseHeaders().set("Content-Length", Integer.toString(responseBytes.length));
-        exchange.sendResponseHeaders(200, responseBytes.length);
-        exchange.getResponseBody().write(responseBytes);
-        exchange.close();
+        try {
+            exchange.getResponseHeaders().set("Content-Type", contentType);
+            exchange.getResponseHeaders().set("Content-Length", Integer.toString(responseBytes.length));
+            exchange.sendResponseHeaders(200, responseBytes.length);
+            exchange.getResponseBody().write(responseBytes);
+        } finally {
+            exchange.close();
+        }
     }
 }


### PR DESCRIPTION
In the event of an error reading/writing to a client, the code doesn't correctly close the `HttpExchange`. This will result in sockets not correctly being cleaned up, resulting in sockets in the close `CLOSE_WAIT` state.

I added `try`/`finally` blocks to close the `HttpExchange`.