### PR TITLE
Add get() method for Counter and Gauge (#920)

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/datapoints/CounterDataPoint.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/datapoints/CounterDataPoint.java
@@ -85,4 +85,14 @@ public interface CounterDataPoint extends DataPoint {
      * Throws an {@link IllegalArgumentException} if {@code amount} is negative.
      */
     void incWithExemplar(double amount, Labels labels);
+
+    /**
+     * Get the current value.
+     */
+    double get();
+
+    /**
+     * Get the current value as a {@code long}. Decimal places will be discarded.
+     */
+    long getLongValue();
 }

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/datapoints/GaugeDataPoint.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/datapoints/GaugeDataPoint.java
@@ -67,6 +67,11 @@ public interface GaugeDataPoint extends DataPoint, TimerApi {
     void set(double value);
 
     /**
+     * Get the current value.
+     */
+    double get();
+
+    /**
      * Set the gauge to {@code value}, and create a custom exemplar with the given labels.
      */
     void setWithExemplar(double value, Labels labels);

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Counter.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Counter.java
@@ -80,6 +80,20 @@ public class Counter extends StatefulMetric<CounterDataPoint, Counter.DataPoint>
     /**
      * {@inheritDoc}
      */
+    public double get() {
+        return getNoLabels().get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public long getLongValue() {
+        return getNoLabels().getLongValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public CounterSnapshot collect() {
         return (CounterSnapshot) super.collect();
@@ -127,6 +141,20 @@ public class Counter extends StatefulMetric<CounterDataPoint, Counter.DataPoint>
 
         private DataPoint(ExemplarSampler exemplarSampler) {
             this.exemplarSampler = exemplarSampler;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public double get() {
+            return longValue.sum() + doubleValue.sum();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public long getLongValue() {
+            return longValue.sum() + (long) doubleValue.sum();
         }
 
         /**
@@ -199,7 +227,7 @@ public class Counter extends StatefulMetric<CounterDataPoint, Counter.DataPoint>
                     }
                 }
             }
-            return new CounterSnapshot.CounterDataPointSnapshot(longValue.sum() + doubleValue.sum(), labels, latestExemplar, createdTimeMillis);
+            return new CounterSnapshot.CounterDataPointSnapshot(get(), labels, latestExemplar, createdTimeMillis);
         }
     }
 

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Gauge.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Gauge.java
@@ -64,6 +64,14 @@ public class Gauge extends StatefulMetric<GaugeDataPoint, Gauge.DataPoint> imple
      * {@inheritDoc}
      */
     @Override
+    public double get() {
+        return getNoLabels().get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void incWithExemplar(double amount, Labels labels) {
         getNoLabels().incWithExemplar(amount, labels);
     }
@@ -162,6 +170,14 @@ public class Gauge extends StatefulMetric<GaugeDataPoint, Gauge.DataPoint> imple
          * {@inheritDoc}
          */
         @Override
+        public double get() {
+            return Double.longBitsToDouble(value.get());
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
         public void setWithExemplar(double value, Labels labels) {
             this.value.set(Double.doubleToRawLongBits(value));
             if (isExemplarsEnabled()) {
@@ -182,7 +198,7 @@ public class Gauge extends StatefulMetric<GaugeDataPoint, Gauge.DataPoint> imple
                     }
                 }
             }
-            return new GaugeSnapshot.GaugeDataPointSnapshot(Double.longBitsToDouble(value.get()), labels, oldest);
+            return new GaugeSnapshot.GaugeDataPointSnapshot(get(), labels, oldest);
         }
     }
 


### PR DESCRIPTION
The old `simpleclient` library had `get()` methods for `Counter` and `Gauge`.

This PR adds these methods for the current 1.x verison.