### PR TITLE
Add clear() method to StatefulMetric (#917)

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
@@ -109,8 +109,12 @@ abstract class StatefulMetric<D extends DataPoint, T extends D> extends MetricWi
         data.remove(Arrays.asList(labelValues));
     }
 
-    // TODO: Write a clear() method that resets the metric (removes all data points),
-    // see https://prometheus.io/docs/instrumenting/writing_clientlibs/#labels
+    /**
+     * Reset the metric (remove all data points).
+     */
+    public void clear() {
+        data.clear();
+    }
 
     protected abstract T newDataPoint();
 

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/StatefulMetricTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/StatefulMetricTest.java
@@ -33,4 +33,32 @@ public class StatefulMetricTest {
             Assert.assertNotNull(entry.getValue());
         }
     }
+
+    @Test
+    public void testClear() {
+        Counter counter = Counter.builder().name("test").labelNames("label1", "label2").build();
+        counter.labelValues("a", "b").inc(3.0);
+        counter.labelValues("c", "d").inc(3.0);
+        counter.labelValues("a", "b").inc();
+        Assert.assertEquals(2, counter.collect().getDataPoints().size());
+
+        counter.clear();
+        Assert.assertEquals(0, counter.collect().getDataPoints().size());
+
+        counter.labelValues("a", "b").inc();
+        Assert.assertEquals(1, counter.collect().getDataPoints().size());
+    }
+
+    @Test
+    public void testClearNoLabels() {
+        Counter counter = Counter.builder().name("test").build();
+        counter.inc();
+        Assert.assertEquals(1, counter.collect().getDataPoints().size());
+        Assert.assertEquals(1.0, counter.collect().getDataPoints().get(0).getValue(), 0.0);
+
+        counter.clear();
+        // No labels is always present, but as no value has been observed after clear() the value should be 0.0
+        Assert.assertEquals(1, counter.collect().getDataPoints().size());
+        Assert.assertEquals(0.0, counter.collect().getDataPoints().get(0).getValue(), 0.0);
+    }
 }


### PR DESCRIPTION
Add a `clear()` method to `StatefulMetric` that resets the metric (removes all data points).

See https://prometheus.io/docs/instrumenting/writing_clientlibs/#labels