### PR TITLE
Fix flaky SlidingWindowTest

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/SlidingWindow.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/SlidingWindow.java
@@ -43,7 +43,7 @@ public class SlidingWindow<T> {
             this.ringBuffer[i] = constructor.get();
         }
         this.currentBucket = 0;
-        this.lastRotateTimestampMillis = System.currentTimeMillis();
+        this.lastRotateTimestampMillis = currentTimeMillis.getAsLong();
         this.durationBetweenRotatesMillis = TimeUnit.SECONDS.toMillis(maxAgeSeconds) / ageBuckets;
     }
 

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/SlidingWindowTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/SlidingWindowTest.java
@@ -10,9 +10,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class SlidingWindowTest {
 
-    static class Observer {
+    class Observer {
 
-        List<Double> values = new ArrayList<>();
+        final List<Double> values = new ArrayList<>();
 
         public void observe(double value) {
             values.add(value);
@@ -23,10 +23,11 @@ public class SlidingWindowTest {
             for (double expectedValue : expectedValues) {
                 expectedList.add(expectedValue);
             }
-            Assert.assertEquals(expectedList, values);
+            Assert.assertEquals("Start time: " + startTime + ", current time: " + currentTimeMillis.get() + ", elapsed time: " + (currentTimeMillis.get() - startTime), expectedList, values);
         }
     }
 
+    private long startTime;
     private final AtomicLong currentTimeMillis = new AtomicLong();
     private SlidingWindow<Observer> ringBuffer;
     private final long maxAgeSeconds = 30;
@@ -35,7 +36,8 @@ public class SlidingWindowTest {
 
     @Before
     public void setUp() {
-        currentTimeMillis.set(System.currentTimeMillis());
+        startTime = System.currentTimeMillis();
+        currentTimeMillis.set(startTime);
         ringBuffer = new SlidingWindow<>(Observer.class, Observer::new, Observer::observe, maxAgeSeconds, ageBuckets);
         ringBuffer.currentTimeMillis = currentTimeMillis::get;
     }


### PR DESCRIPTION
Fixes #945.

`SlidingWindow` uses `System.currentTimeMillis()` by default, but allows tests to override this via the `currentTimeMillis` variable.

There was one line of code where `SlidingWindow` called `System.currentTimeMillis()` directly, not the `currentTimeMillis` variable.

I think this is why the test was flaky depending on timing.

The fix is to always use the `currentTimeMillis` variable, never `System.currentTimeMillis()` directly.
