### PR TITLE
Allow metric names with only a single character

### DIFF
--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
@@ -13,7 +13,7 @@ public class PrometheusNaming {
     /**
      * Legal characters for metric names, including dot.
      */
-    private static final Pattern METRIC_NAME_PATTERN = Pattern.compile("^[a-zA-Z_.:][a-zA-Z0-9_.:]+$");
+    private static final Pattern METRIC_NAME_PATTERN = Pattern.compile("^[a-zA-Z_.:][a-zA-Z0-9_.:]*$");
 
     /**
      * Legal characters for label names, including dot.


### PR DESCRIPTION
Due to a typo in `METRIC_NAME_PATTERN` the library rejects metric names with only a single character.

However, these metrics should be allowed, see the pattern in the official Prometheus docs here: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

This PR fixes the typo and makes single characters legal metric names.