### PR TITLE
Start Prometheus HTTP server on the provided executor

### DIFF
--- a/integration-tests/it-exporter/it-exporter-httpserver-sample/src/main/java/io/prometheus/metrics/it/exporter/httpserver/HTTPServerSample.java
+++ b/integration-tests/it-exporter/it-exporter-httpserver-sample/src/main/java/io/prometheus/metrics/it/exporter/httpserver/HTTPServerSample.java
@@ -65,6 +65,7 @@ public class HTTPServerSample {
                 .buildAndStart();
 
         System.out.println("HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
+        Thread.sleep(10_000);
     }
 
     private static int parsePortOrExit(String port) {

--- a/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/HTTPServer.java
+++ b/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/HTTPServer.java
@@ -6,7 +6,6 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
-import io.prometheus.metrics.config.ExporterHttpServerProperties;
 import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 
@@ -14,6 +13,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.SynchronousQueue;
@@ -55,7 +55,13 @@ public class HTTPServer implements Closeable {
         registerHandler("/", defaultHandler == null ? new DefaultHandler() : defaultHandler, authenticator);
         registerHandler("/metrics", new MetricsHandler(config, registry), authenticator);
         registerHandler("/-/healthy", new HealthyHandler(), authenticator);
-        this.server.start();
+        try {
+            executorService.submit(() -> this.server.start()).get();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
     }
 
     private void registerHandler(String path, HttpHandler handler, Authenticator authenticator) {

--- a/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/HTTPServer.java
+++ b/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/HTTPServer.java
@@ -57,6 +57,7 @@ public class HTTPServer implements Closeable {
         registerHandler("/-/healthy", new HealthyHandler(), authenticator);
         try {
             executorService.submit(() -> this.server.start()).get();
+            // calling .get() on the Future here to avoid silently discarding errors
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (ExecutionException e) {

--- a/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/HTTPServer.java
+++ b/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/HTTPServer.java
@@ -60,7 +60,7 @@ public class HTTPServer implements Closeable {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
The metrics HTTP server should run on a daemon JVM
thread so as to not keep the JVM running even
though all relevant threads have already exited.
Unfortunately, the OpenJDK builtin HTTP server
likes to spawn its own HTTP Dispatcher thread on
startup.
https://github.com/openjdk/jdk/blob/02c95a6d7eb77ed17ae64d0f585197e87a67cc4a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java#L190
This new thread inherits the daemon flag from the
thread that started it, therefore we need to call
the start method from the executor service,
because those threads are daemon threads.