### PR TITLE
Prevent illegal metric names

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/MetricWithFixedMetadata.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/MetricWithFixedMetadata.java
@@ -32,8 +32,8 @@ public abstract class MetricWithFixedMetadata extends Metric {
 
     private String makeName(String name, Unit unit) {
         if (unit != null) {
-            if (!name.endsWith(unit.toString())) {
-                name = name + "_" + unit;
+            if (!name.endsWith("_" + unit) && !name.endsWith("." + unit)) {
+                name += "_" + unit;
             }
         }
         return name;

--- a/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
+++ b/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
@@ -1,26 +1,11 @@
 package io.prometheus.metrics.expositionformats;
 
+import io.prometheus.metrics.model.snapshots.*;
 import io.prometheus.metrics.shaded.com_google_protobuf_3_25_3.TextFormat;
 import io.prometheus.metrics.expositionformats.generated.com_google_protobuf_3_25_3.Metrics;
-import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot.CounterDataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.Exemplar;
-import io.prometheus.metrics.model.snapshots.Exemplars;
-import io.prometheus.metrics.model.snapshots.ClassicHistogramBuckets;
-import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot.GaugeDataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
-import io.prometheus.metrics.model.snapshots.InfoSnapshot;
-import io.prometheus.metrics.model.snapshots.Labels;
-import io.prometheus.metrics.model.snapshots.MetricSnapshot;
-import io.prometheus.metrics.model.snapshots.MetricSnapshots;
-import io.prometheus.metrics.model.snapshots.NativeHistogramBuckets;
-import io.prometheus.metrics.model.snapshots.Quantiles;
-import io.prometheus.metrics.model.snapshots.StateSetSnapshot;
-import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.Unit;
-import io.prometheus.metrics.model.snapshots.UnknownSnapshot;
 import io.prometheus.metrics.model.snapshots.UnknownSnapshot.UnknownDataPointSnapshot;
 import org.junit.Assert;
 import org.junit.Test;
@@ -1825,24 +1810,24 @@ public class ExpositionFormatsTest {
     @Test
     public void testUnknownWithDots() throws IOException {
         String openMetrics = "" +
-                "# TYPE some_unknown_metric unknown\n" +
-                "# UNIT some_unknown_metric bytes\n" +
-                "# HELP some_unknown_metric help message\n" +
-                "some_unknown_metric{test_env=\"7\"} 0.7\n" +
+                "# TYPE some_unknown_metric_bytes unknown\n" +
+                "# UNIT some_unknown_metric_bytes bytes\n" +
+                "# HELP some_unknown_metric_bytes help message\n" +
+                "some_unknown_metric_bytes{test_env=\"7\"} 0.7\n" +
                 "# EOF\n";
         String openMetricsWithExemplarsOnAllTimeSeries = "" +
-                "# TYPE some_unknown_metric unknown\n" +
-                "# UNIT some_unknown_metric bytes\n" +
-                "# HELP some_unknown_metric help message\n" +
-                "some_unknown_metric{test_env=\"7\"} 0.7 # " + exemplarWithDotsString + "\n" +
+                "# TYPE some_unknown_metric_bytes unknown\n" +
+                "# UNIT some_unknown_metric_bytes bytes\n" +
+                "# HELP some_unknown_metric_bytes help message\n" +
+                "some_unknown_metric_bytes{test_env=\"7\"} 0.7 # " + exemplarWithDotsString + "\n" +
                 "# EOF\n";
         String prometheus = "" +
-                "# HELP some_unknown_metric help message\n" +
-                "# TYPE some_unknown_metric untyped\n" +
-                "some_unknown_metric{test_env=\"7\"} 0.7\n";
+                "# HELP some_unknown_metric_bytes help message\n" +
+                "# TYPE some_unknown_metric_bytes untyped\n" +
+                "some_unknown_metric_bytes{test_env=\"7\"} 0.7\n";
         String prometheusProtobuf = "" +
                 //@formatter:off
-                "name: \"some_unknown_metric\" " +
+                "name: \"some_unknown_metric_bytes\" " +
                 "help: \"help message\" " +
                 "type: UNTYPED " +
                 "metric { " +
@@ -1851,7 +1836,7 @@ public class ExpositionFormatsTest {
                 "}";
                 //@formatter:on
         UnknownSnapshot unknown = UnknownSnapshot.builder()
-                .name("some.unknown.metric")
+                .name(PrometheusNaming.sanitizeMetricName("some.unknown.metric", Unit.BYTES))
                 .help("help message")
                 .unit(Unit.BYTES)
                 .dataPoint(UnknownDataPointSnapshot.builder()

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
@@ -105,5 +105,11 @@ public final class MetricMetadata {
             throw new IllegalArgumentException("'" + name + "': Illegal metric name. " + error
                     + " Call " + PrometheusNaming.class.getSimpleName() + ".sanitizeMetricName(name) to avoid this error.");
         }
+        if (hasUnit()) {
+            if (!name.endsWith("_" + unit) && !name.endsWith("." + unit)) {
+                throw new IllegalArgumentException("'" + name + "': Illegal metric name. The name must end with _" + unit + "."
+                        + " Call " + PrometheusNaming.class.getSimpleName() + ".sanitizeMetricName(name, unit) to avoid this error.");
+            }
+        }
     }
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
@@ -122,6 +122,20 @@ public class PrometheusNaming {
     }
 
     /**
+     * Like {@link #sanitizeMetricName(String)}, but also makes sure that the unit is appended
+     * as a suffix if the unit is not {@code null}.
+     */
+    public static String sanitizeMetricName(String metricName, Unit unit) {
+        String result = sanitizeLabelName(metricName);
+        if (unit != null) {
+            if (!result.endsWith("_" + unit) && !result.endsWith("." + unit)) {
+                result += "_" + unit;
+            }
+        }
+        return result;
+    }
+
+    /**
      * Convert an arbitrary string to a name where {@link #isValidLabelName(String) isValidLabelName(name)} is true.
      */
     public static String sanitizeLabelName(String labelName) {

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
@@ -25,9 +25,9 @@ public class MetricMetadataTest {
 
     @Test
     public void testSanitizationIllegalCharacters() {
-        MetricMetadata metadata = new MetricMetadata(sanitizeMetricName("my_namespace/http.server.duration"), "help string", Unit.SECONDS);
-        Assert.assertEquals("my_namespace_http.server.duration", metadata.getName());
-        Assert.assertEquals("my_namespace_http_server_duration", metadata.getPrometheusName());
+        MetricMetadata metadata = new MetricMetadata(sanitizeMetricName("my_namespace/http.server.duration", Unit.SECONDS), "help string", Unit.SECONDS);
+        Assert.assertEquals("my_namespace_http.server.duration_seconds", metadata.getName());
+        Assert.assertEquals("my_namespace_http_server_duration_seconds", metadata.getPrometheusName());
         Assert.assertEquals("help string", metadata.getHelp());
         Assert.assertEquals("seconds", metadata.getUnit().toString());
     }


### PR DESCRIPTION
If a Prometheus scrape finds a metric that has `UNIT` metadata but a name that does not end with the unit, the entire scrape fails.

https://github.com/prometheus/prometheus/blob/2e30f1231b6686e69afe1abb199c57dfe98fba07/model/textparse/openmetricsparse.go#L321-L323

With this PR we prevent these illegal metric names by throwing an `IllegalArgumentException`. The goal is to make it impossible to create illegal metric names with `prometheus-metrics-model`.