### PR TITLE
Add method for sanitizing Unit names

### DIFF
--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/Unit.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/Unit.java
@@ -28,10 +28,12 @@ public class Unit {
         if (name == null) {
             throw new NullPointerException("Unit name cannot be null.");
         }
-        if (name.trim().isEmpty()) {
-            throw new IllegalArgumentException("Unit name cannot be empty.");
+        name = name.trim();
+        String error = PrometheusNaming.validateUnitName(name);
+        if (error != null) {
+            throw new IllegalArgumentException(name + ": Illegal unit name: " + error);
         }
-        this.name = name.trim();
+        this.name = name;
     }
 
     @Override

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
@@ -3,9 +3,7 @@ package io.prometheus.metrics.model.snapshots;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
-import static io.prometheus.metrics.model.snapshots.PrometheusNaming.sanitizeLabelName;
-import static io.prometheus.metrics.model.snapshots.PrometheusNaming.sanitizeMetricName;
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.*;
 
 public class PrometheusNamingTest {
 
@@ -19,6 +17,8 @@ public class PrometheusNamingTest {
         Assert.assertEquals("jvm", sanitizeMetricName("jvm_info"));
         Assert.assertEquals("jvm", sanitizeMetricName("jvm.info"));
         Assert.assertEquals("a.b", sanitizeMetricName("a.b"));
+        Assert.assertEquals("total", sanitizeMetricName("_total"));
+        Assert.assertEquals("total", sanitizeMetricName("total"));
     }
 
     @Test
@@ -30,5 +30,47 @@ public class PrometheusNamingTest {
         Assert.assertEquals("_abc", prometheusName(sanitizeLabelName("_.abc")));
         Assert.assertEquals("abc.def", sanitizeLabelName("abc.def"));
         Assert.assertEquals("abc.def2", sanitizeLabelName("abc.def2"));
+    }
+
+    @Test
+    public void testValidateUnitName() {
+        Assert.assertNotNull(validateUnitName("secondstotal"));
+        Assert.assertNotNull(validateUnitName("total"));
+        Assert.assertNotNull(validateUnitName("seconds_total"));
+        Assert.assertNotNull(validateUnitName("_total"));
+        Assert.assertNotNull(validateUnitName(""));
+
+        Assert.assertNull(validateUnitName("seconds"));
+        Assert.assertNull(validateUnitName("2"));
+    }
+
+    @Test
+    public void testSanitizeUnitName() {
+        Assert.assertEquals("seconds", sanitizeUnitName("seconds"));
+        Assert.assertEquals("seconds", sanitizeUnitName("seconds_total"));
+        Assert.assertEquals("seconds", sanitizeUnitName("seconds_total_total"));
+        Assert.assertEquals("m_s", sanitizeUnitName("m/s"));
+        Assert.assertEquals("seconds", sanitizeUnitName("secondstotal"));
+        Assert.assertEquals("2", sanitizeUnitName("2"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidUnitName1() {
+        sanitizeUnitName("total");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidUnitName2() {
+        sanitizeUnitName("_total");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidUnitName3() {
+        sanitizeUnitName("%");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyUnitName() {
+        sanitizeUnitName("");
     }
 }


### PR DESCRIPTION
This PR fixes a corner case where invalid Unit names could be produced.

For example, previously it was possible to create a Unit named `total` and use it for a `Gauge`, which would have resulted in an illegal `_total` suffix on a `Gauge` metric.

This PR adds stricter validation for Unit names, and a convenience method `PrometheusNaming.sanitizeUnitName(name)` for converting arbitrary strings into valid Unit names.