### PR TITLE
Simple MetricsSnapshot performance change

### DIFF
--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricSnapshots.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricSnapshots.java
@@ -79,8 +79,12 @@ public class MetricSnapshots implements Iterable<MetricSnapshot> {
         }
 
         public boolean containsMetricName(String name) {
+            if (name == null) {
+                return false;
+            }
+            String prometheusName = prometheusName(name);
             for (MetricSnapshot snapshot : snapshots) {
-                if (snapshot.getMetadata().getPrometheusName().equals(prometheusName(name))) {
+                if (snapshot.getMetadata().getPrometheusName().equals(prometheusName)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Simple MetricsSnapshot performance change to prevent calling `prometheusName(name)` in a loop.