### PR TITLE
Add clear() method into PrometheusRegistry to unregister all collectors

### DIFF
--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/PrometheusRegistry.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/PrometheusRegistry.java
@@ -53,6 +53,12 @@ public class PrometheusRegistry {
 		}
 	}
 
+    public void clear() {
+        collectors.clear();
+        multiCollectors.clear();
+        prometheusNames.clear();
+    }
+
 	public MetricSnapshots scrape() {
 		return scrape((PrometheusScrapeRequest) null);
 	}

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/registry/PrometheusRegistryTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/registry/PrometheusRegistryTest.java
@@ -101,4 +101,18 @@ public class PrometheusRegistryTest {
         snapshots = registry.scrape();
         Assert.assertEquals(3, snapshots.size());
     }
+
+    @Test
+    public void clearOk() {
+        PrometheusRegistry registry = new PrometheusRegistry();
+        registry.register(counterA1);
+        registry.register(counterB);
+        registry.register(gaugeA);
+        MetricSnapshots snapshots = registry.scrape();
+        Assert.assertEquals(3, snapshots.size());
+
+        registry.clear();
+        snapshots = registry.scrape();
+        Assert.assertEquals(0, snapshots.size());
+    }
 }


### PR DESCRIPTION
Add `clear()` method into `PrometheusRegistry` to unregister all collectors

Addresses issue #950

@fstab @dhoard @tomwilkie 