### PR TITLE
Add abstract build method to MetricSnapshot.Builder

### DIFF
--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/CounterSnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/CounterSnapshot.java
@@ -139,6 +139,7 @@ public class CounterSnapshot extends MetricSnapshot {
             return this;
         }
 
+        @Override
         public CounterSnapshot build() {
             return new CounterSnapshot(buildMetadata(), dataPoints);
         }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/GaugeSnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/GaugeSnapshot.java
@@ -118,13 +118,14 @@ public final class GaugeSnapshot extends MetricSnapshot {
         }
 
         /**
-         * Add a data point. This can be alled multiple times to add multiple data points.
+         * Add a data point. This can be called multiple times to add multiple data points.
          */
         public Builder dataPoint(GaugeDataPointSnapshot dataPoint) {
             dataPoints.add(dataPoint);
             return this;
         }
 
+        @Override
         public GaugeSnapshot build() {
             return new GaugeSnapshot(buildMetadata(), dataPoints);
         }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/HistogramSnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/HistogramSnapshot.java
@@ -389,6 +389,7 @@ public final class HistogramSnapshot extends MetricSnapshot {
             return this;
         }
 
+        @Override
         public HistogramSnapshot build() {
             return new HistogramSnapshot(isGaugeHistogram, buildMetadata(), dataPoints);
         }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/InfoSnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/InfoSnapshot.java
@@ -95,6 +95,7 @@ public final class InfoSnapshot extends MetricSnapshot {
             throw new IllegalArgumentException("Info metric cannot have a unit.");
         }
 
+        @Override
         public InfoSnapshot build() {
             return new InfoSnapshot(buildMetadata(), dataPoints);
         }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricSnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricSnapshot.java
@@ -76,6 +76,8 @@ public abstract class MetricSnapshot {
             return self();
         }
 
+        public abstract MetricSnapshot build();
+
         protected MetricMetadata buildMetadata() {
             return new MetricMetadata(name, help, unit);
         }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/StateSetSnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/StateSetSnapshot.java
@@ -219,6 +219,7 @@ public final class StateSetSnapshot extends MetricSnapshot {
             throw new IllegalArgumentException("StateSet metric cannot have a unit.");
         }
 
+        @Override
         public StateSetSnapshot build() {
             return new StateSetSnapshot(buildMetadata(), dataPoints);
         }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/SummarySnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/SummarySnapshot.java
@@ -127,6 +127,7 @@ public final class SummarySnapshot extends MetricSnapshot {
             return this;
         }
 
+        @Override
         public SummarySnapshot build() {
             return new SummarySnapshot(buildMetadata(), dataPoints);
         }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/UnknownSnapshot.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/UnknownSnapshot.java
@@ -126,6 +126,7 @@ public final class UnknownSnapshot extends MetricSnapshot {
             return this;
         }
 
+        @Override
         public UnknownSnapshot build() {
             return new UnknownSnapshot(buildMetadata(), dataPoints);
         }


### PR DESCRIPTION
Having an abstract `build()` method allows writing generic code for the different builders.

For context, I'm currently updating a library from `simpleclient` to the new 1.X version. The library converts metrics from Apache Kafka where we can have multiple metric objects with the same metric name but different labels. 

With `simpleclient`, we could also have multiple `MetricFamilySamples` with the same name, but that's not the case anymore with `MetricSnapshots` where each `MetricSnapshot` must have a unique name.

So when converting metrics from Kafka, we need to keep un-built `MetricSnapshot.Builder` and add datapoints when we find metrics with the same names. In this example being able to store various `MetricSnapshot.Builder` objects in a collection is useful and allows building them all easily.