### PR TITLE
Nullify noLabels in StatefulMetric during clear() to prevent no-label inc to stop working

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
@@ -114,6 +114,7 @@ abstract class StatefulMetric<D extends DataPoint, T extends D> extends MetricWi
      */
     public void clear() {
         data.clear();
+        noLabels = null;
     }
 
     protected abstract T newDataPoint();

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/StatefulMetricTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/StatefulMetricTest.java
@@ -60,5 +60,10 @@ public class StatefulMetricTest {
         // No labels is always present, but as no value has been observed after clear() the value should be 0.0
         Assert.assertEquals(1, counter.collect().getDataPoints().size());
         Assert.assertEquals(0.0, counter.collect().getDataPoints().get(0).getValue(), 0.0);
+
+        // Making inc() works correctly after clear()
+        counter.inc();
+        Assert.assertEquals(1, counter.collect().getDataPoints().size());
+        Assert.assertEquals(1.0, counter.collect().getDataPoints().get(0).getValue(), 0.0);
     }
 }


### PR DESCRIPTION
Fixes #971

- nullified volatile `noLabels` variable on `clear()`
- enhanced `testClearNoLabels`

@fstab @dhoard @tomwilkie 