### PR TITLE
Change links on front page to be relative

### DIFF
--- a/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/DefaultHandler.java
+++ b/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/DefaultHandler.java
@@ -21,15 +21,15 @@ public class DefaultHandler implements HttpHandler {
                 "<body>\n" +
                 "<h1>Prometheus Java Client</h1>\n" +
                 "<h2>Metrics Path</h2>\n" +
-                "The metrics path is <a href=\"/metrics\">/metrics</a>.\n" +
+                "The metrics path is <a href=\"metrics\">/metrics</a>.\n" +
                 "<h2>Name Filter</h2>\n" +
                 "If you want to scrape only specific metrics, use the <tt>name[]</tt> parameter like this:\n" +
                 "<ul>\n" +
-                "<li><a href=\"/metrics?name[]=my_metric\">/metrics?name[]=my_metric</a></li>\n" +
+                "<li><a href=\"metrics?name[]=my_metric\">/metrics?name[]=my_metric</a></li>\n" +
                 "</ul>\n" +
                 "You can also use multiple <tt>name[]</tt> parameters to query multiple metrics:\n" +
                 "<ul>\n" +
-                "<li><a href=\"/metrics?name[]=my_metric_a&name=my_metrics_b\">/metrics?name[]=my_metric_a&amp;name=[]=my_metric_b</a></li>\n" +
+                "<li><a href=\"metrics?name[]=my_metric_a&name=my_metrics_b\">/metrics?name[]=my_metric_a&amp;name=[]=my_metric_b</a></li>\n" +
                 "</ul>\n" +
                 "The <tt>name[]</tt> parameter can be used by the Prometheus server for scraping. Add the following snippet to your scrape job configuration in <tt>prometheus.yaml</tt>:\n" +
                 "<pre>\n" +
@@ -45,9 +45,9 @@ public class DefaultHandler implements HttpHandler {
                 "in which case the default is Prometheus protobuf.\n" +
                 "The Prometheus Java metrics library supports a <tt>debug</tt> query parameter for viewing the different formats in a Web browser:\n" +
                 "<ul>\n" +
-                "<li><a href=\"/metrics?debug=openmetrics\">/metrics?debug=openmetrics</a>: View OpenMetrics text format.</li>\n" +
-                "<li><a href=\"/metrics?debug=text\">/metrics?debug=text</a>: View Prometheus text format (this is the default when accessing the <a href=\"/metrics\">/metrics</a> endpoint with a Web browser).</li>\n" +
-                "<li><a href=\"/metrics?debug=prometheus-protobuf\">/metrics?debug=prometheus-protobuf</a>: View a text representation of the Prometheus protobuf format.</li>\n" +
+                "<li><a href=\"metrics?debug=openmetrics\">/metrics?debug=openmetrics</a>: View OpenMetrics text format.</li>\n" +
+                "<li><a href=\"metrics?debug=text\">/metrics?debug=text</a>: View Prometheus text format (this is the default when accessing the <a href=\"metrics\">/metrics</a> endpoint with a Web browser).</li>\n" +
+                "<li><a href=\"metrics?debug=prometheus-protobuf\">/metrics?debug=prometheus-protobuf</a>: View a text representation of the Prometheus protobuf format.</li>\n" +
                 "</ul>\n" +
                 "Note that the <tt>debug</tt> parameter is only for viewing different formats in a Web browser, it should not be used by the Prometheus server for scraping. The Prometheus server uses the <tt>Accept</tt> header for indicating which format it accepts.\n" +
                 "</body>\n" +


### PR DESCRIPTION
@fstab , @dhoard , @tomwilkie

On the machines running JMX_Exporter, we are using a reverse proxy to perform TLS termination. 
When mapping the JMX_Exporter to a subpath with the reverse proxy (e.g. https://myhostname/jmx/ ), the links on the frontpage of JMX_Exporter will break, as they are currently absolute links pointing to pagesin the root.

This PR changes them to be relative, so they will continue to work on a subpath.