### PR TITLE
additional improve MetricSnapshots.Builder performance

### DIFF
--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricSnapshots.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricSnapshots.java
@@ -3,8 +3,10 @@ package io.prometheus.metrics.model.snapshots;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
@@ -74,6 +76,7 @@ public class MetricSnapshots implements Iterable<MetricSnapshot> {
     public static class Builder {
 
         private final List<MetricSnapshot> snapshots = new ArrayList<>();
+        private final Set<String> prometheusNames = new HashSet<>();
 
         private Builder() {
         }
@@ -83,12 +86,7 @@ public class MetricSnapshots implements Iterable<MetricSnapshot> {
                 return false;
             }
             String prometheusName = prometheusName(name);
-            for (MetricSnapshot snapshot : snapshots) {
-                if (snapshot.getMetadata().getPrometheusName().equals(prometheusName)) {
-                    return true;
-                }
-            }
-            return false;
+            return prometheusNames.contains(prometheusName);
         }
 
         /**
@@ -96,6 +94,7 @@ public class MetricSnapshots implements Iterable<MetricSnapshot> {
          */
         public Builder metricSnapshot(MetricSnapshot snapshot) {
             snapshots.add(snapshot);
+            prometheusNames.add(snapshot.getMetadata().getPrometheusName());
             return this;
         }
 


### PR DESCRIPTION
The function `io.prometheus.metrics.model.registry.PrometheusRegistry.scrape` has O(n^2) complexity: higher size of the list `multiCollectors` generates higher amount of `snapshots` in the `io.prometheus.metrics.model.snapshots.MetricSnapshots.Builder` class on each loop iteration.

Because of this we have x100 times slower metrics scrape in our project on production.

This PR gave us good performance improvement: https://github.com/prometheus/client_java/pull/963
But it's not enough, because the complexity is still O(n^2). The current PR resolves the performance issue.