### PR TITLE
Various cleanups in instrumentation-jvm

### DIFF
--- a/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/JvmMemoryPoolAllocationMetrics.java
+++ b/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/JvmMemoryPoolAllocationMetrics.java
@@ -49,13 +49,11 @@ public class JvmMemoryPoolAllocationMetrics {
   private static final String JVM_MEMORY_POOL_ALLOCATED_BYTES_TOTAL =
       "jvm_memory_pool_allocated_bytes_total";
 
-  private final PrometheusProperties config;
   private final List<GarbageCollectorMXBean> garbageCollectorBeans;
 
   private JvmMemoryPoolAllocationMetrics(
       List<GarbageCollectorMXBean> garbageCollectorBeans, PrometheusProperties config) {
     this.garbageCollectorBeans = garbageCollectorBeans;
-    this.config = config;
   }
 
   private void register(PrometheusRegistry registry) {
@@ -80,7 +78,7 @@ public class JvmMemoryPoolAllocationMetrics {
 
   static class AllocationCountingNotificationListener implements NotificationListener {
 
-    private final Map<String, Long> lastMemoryUsage = new HashMap<String, Long>();
+    private final Map<String, Long> lastMemoryUsage = new HashMap<>();
     private final Counter counter;
 
     AllocationCountingNotificationListener(Counter counter) {

--- a/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/JvmNativeMemoryMetrics.java
+++ b/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/JvmNativeMemoryMetrics.java
@@ -134,12 +134,8 @@ public class JvmNativeMemoryMetrics {
         Matcher matcher = pattern.matcher(summary);
         while (matcher.find()) {
           String category = matcher.group(1);
-          long value;
-          if (reserved) {
-            value = Long.parseLong(matcher.group(2));
-          } else {
-            value = Long.parseLong(matcher.group(3));
-          }
+          long value =
+              reserved ? Long.parseLong(matcher.group(2)) : Long.parseLong(matcher.group(3));
           callback.call(value, category);
         }
       }

--- a/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/JvmThreadsMetrics.java
+++ b/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/JvmThreadsMetrics.java
@@ -155,7 +155,7 @@ public class JvmThreadsMetrics {
     ThreadInfo[] allThreads = threadBean.getThreadInfo(threadIds, 0);
 
     // Initialize the map with all thread states
-    HashMap<String, Integer> threadCounts = new HashMap<String, Integer>();
+    Map<String, Integer> threadCounts = new HashMap<>();
     for (Thread.State state : Thread.State.values()) {
       threadCounts.put(state.name(), 0);
     }

--- a/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/ProcessMetrics.java
+++ b/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/ProcessMetrics.java
@@ -72,7 +72,7 @@ public class ProcessMetrics {
   private static final String PROCESS_VIRTUAL_MEMORY_BYTES = "process_virtual_memory_bytes";
   private static final String PROCESS_RESIDENT_MEMORY_BYTES = "process_resident_memory_bytes";
 
-  private static final File PROC_SELF_STATUS = new File("/proc/self/status");
+  static final File PROC_SELF_STATUS = new File("/proc/self/status");
 
   private final PrometheusProperties config;
   private final OperatingSystemMXBean osBean;

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmBufferPoolMetricsTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmBufferPoolMetricsTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import static io.prometheus.metrics.instrumentation.jvm.TestUtil.convertToOpenMetricsFormat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,7 +12,6 @@ import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import java.io.IOException;
 import java.lang.management.BufferPoolMXBean;
 import java.util.Arrays;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -59,7 +59,7 @@ public class JvmBufferPoolMetricsTest {
             + "jvm_buffer_pool_used_bytes{pool=\"mapped\"} 2345.0\n"
             + "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmClassLoadingMetricsTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmClassLoadingMetricsTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import static io.prometheus.metrics.instrumentation.jvm.TestUtil.convertToOpenMetricsFormat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -10,14 +11,13 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import java.io.IOException;
 import java.lang.management.ClassLoadingMXBean;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class JvmClassLoadingMetricsTest {
 
-  private ClassLoadingMXBean mockClassLoadingBean = Mockito.mock(ClassLoadingMXBean.class);
+  private final ClassLoadingMXBean mockClassLoadingBean = Mockito.mock(ClassLoadingMXBean.class);
 
   @Before
   public void setUp() {
@@ -45,7 +45,7 @@ public class JvmClassLoadingMetricsTest {
             + "jvm_classes_unloaded_total 500.0\n"
             + "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmCompilationMetricsTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmCompilationMetricsTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import static io.prometheus.metrics.instrumentation.jvm.TestUtil.convertToOpenMetricsFormat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
@@ -10,18 +11,17 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import java.io.IOException;
 import java.lang.management.CompilationMXBean;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class JvmCompilationMetricsTest {
 
-  private CompilationMXBean mockCompilationBean = Mockito.mock(CompilationMXBean.class);
+  private final CompilationMXBean mockCompilationBean = Mockito.mock(CompilationMXBean.class);
 
   @Before
   public void setUp() {
-    when(mockCompilationBean.getTotalCompilationTime()).thenReturn(10000l);
+    when(mockCompilationBean.getTotalCompilationTime()).thenReturn(10000L);
     when(mockCompilationBean.isCompilationTimeMonitoringSupported()).thenReturn(true);
   }
 
@@ -39,7 +39,7 @@ public class JvmCompilationMetricsTest {
             + "jvm_compilation_time_seconds_total 10.0\n"
             + "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test
@@ -54,6 +54,6 @@ public class JvmCompilationMetricsTest {
     MetricSnapshots snapshots = registry.scrape(filter);
 
     verify(mockCompilationBean, times(0)).getTotalCompilationTime();
-    Assert.assertEquals(0, snapshots.size());
+    assertEquals(0, snapshots.size());
   }
 }

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmGarbageCollectorMetricsTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmGarbageCollectorMetricsTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import static io.prometheus.metrics.instrumentation.jvm.TestUtil.convertToOpenMetricsFormat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,15 +13,14 @@ import java.io.IOException;
 import java.lang.management.GarbageCollectorMXBean;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class JvmGarbageCollectorMetricsTest {
 
-  private GarbageCollectorMXBean mockGcBean1 = Mockito.mock(GarbageCollectorMXBean.class);
-  private GarbageCollectorMXBean mockGcBean2 = Mockito.mock(GarbageCollectorMXBean.class);
+  private final GarbageCollectorMXBean mockGcBean1 = Mockito.mock(GarbageCollectorMXBean.class);
+  private final GarbageCollectorMXBean mockGcBean2 = Mockito.mock(GarbageCollectorMXBean.class);
 
   @Before
   public void setUp() {
@@ -51,7 +51,7 @@ public class JvmGarbageCollectorMetricsTest {
             + "jvm_gc_collection_seconds_sum{gc=\"MyGC2\"} 20.0\n"
             + "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test
@@ -67,6 +67,6 @@ public class JvmGarbageCollectorMetricsTest {
 
     verify(mockGcBean1, times(0)).getCollectionTime();
     verify(mockGcBean1, times(0)).getCollectionCount();
-    Assert.assertEquals(0, snapshots.size());
+    assertEquals(0, snapshots.size());
   }
 }

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmMemoryMetricsTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmMemoryMetricsTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import static io.prometheus.metrics.instrumentation.jvm.TestUtil.convertToOpenMetricsFormat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,22 +14,21 @@ import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
 import java.util.Arrays;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class JvmMemoryMetricsTest {
 
-  private MemoryMXBean mockMemoryBean = Mockito.mock(MemoryMXBean.class);
-  private MemoryPoolMXBean mockPoolsBeanEdenSpace = Mockito.mock(MemoryPoolMXBean.class);
-  private MemoryPoolMXBean mockPoolsBeanOldGen = Mockito.mock(MemoryPoolMXBean.class);
-  private MemoryUsage memoryUsageHeap = Mockito.mock(MemoryUsage.class);
-  private MemoryUsage memoryUsageNonHeap = Mockito.mock(MemoryUsage.class);
-  private MemoryUsage memoryUsagePoolEdenSpace = Mockito.mock(MemoryUsage.class);
-  private MemoryUsage memoryUsagePoolOldGen = Mockito.mock(MemoryUsage.class);
-  private MemoryUsage memoryUsagePoolCollectionEdenSpace = Mockito.mock(MemoryUsage.class);
-  private MemoryUsage memoryUsagePoolCollectionOldGen = Mockito.mock(MemoryUsage.class);
+  private final MemoryMXBean mockMemoryBean = Mockito.mock(MemoryMXBean.class);
+  private final MemoryPoolMXBean mockPoolsBeanEdenSpace = Mockito.mock(MemoryPoolMXBean.class);
+  private final MemoryPoolMXBean mockPoolsBeanOldGen = Mockito.mock(MemoryPoolMXBean.class);
+  private final MemoryUsage memoryUsageHeap = Mockito.mock(MemoryUsage.class);
+  private final MemoryUsage memoryUsageNonHeap = Mockito.mock(MemoryUsage.class);
+  private final MemoryUsage memoryUsagePoolEdenSpace = Mockito.mock(MemoryUsage.class);
+  private final MemoryUsage memoryUsagePoolOldGen = Mockito.mock(MemoryUsage.class);
+  private final MemoryUsage memoryUsagePoolCollectionEdenSpace = Mockito.mock(MemoryUsage.class);
+  private final MemoryUsage memoryUsagePoolCollectionOldGen = Mockito.mock(MemoryUsage.class);
 
   @Before
   public void setUp() {
@@ -154,7 +154,7 @@ public class JvmMemoryMetricsTest {
             + "jvm_memory_used_bytes{area=\"nonheap\"} 6.0\n"
             + "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmMemoryPoolAllocationMetricsTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmMemoryPoolAllocationMetricsTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import io.prometheus.metrics.core.metrics.Counter;
 import io.prometheus.metrics.instrumentation.jvm.JvmMemoryPoolAllocationMetrics.AllocationCountingNotificationListener;
@@ -8,7 +9,6 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class JvmMemoryPoolAllocationMetricsTest {
@@ -60,7 +60,7 @@ public class JvmMemoryPoolAllocationMetricsTest {
         }
       }
     }
-    Assert.fail("pool " + poolName + " not found.");
+    fail("pool " + poolName + " not found.");
     return 0.0;
   }
 }

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmNativeMemoryMetricsTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmNativeMemoryMetricsTest.java
@@ -1,18 +1,17 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import static io.prometheus.metrics.instrumentation.jvm.TestUtil.convertToOpenMetricsFormat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import java.io.IOException;
-import junit.framework.TestCase;
-import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class JvmNativeMemoryMetricsTest extends TestCase {
+public class JvmNativeMemoryMetricsTest {
 
   @Test
   public void testNativeMemoryTrackingFail() throws IOException {
@@ -28,7 +27,7 @@ public class JvmNativeMemoryMetricsTest extends TestCase {
 
     String expected = "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test
@@ -45,7 +44,7 @@ public class JvmNativeMemoryMetricsTest extends TestCase {
 
     String expected = "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test
@@ -63,7 +62,7 @@ public class JvmNativeMemoryMetricsTest extends TestCase {
 
     String expected = "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test
@@ -226,6 +225,6 @@ public class JvmNativeMemoryMetricsTest extends TestCase {
             + "jvm_native_memory_reserved_bytes{pool=\"Tracing\"} 33097.0\n"
             + "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 }

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmRuntimeInfoMetricTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmRuntimeInfoMetricTest.java
@@ -1,11 +1,11 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import static io.prometheus.metrics.instrumentation.jvm.TestUtil.convertToOpenMetricsFormat;
+import static org.junit.Assert.assertEquals;
 
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class JvmRuntimeInfoMetricTest {
@@ -27,6 +27,6 @@ public class JvmRuntimeInfoMetricTest {
             + "jvm_runtime_info{runtime=\"OpenJDK Runtime Environment\",vendor=\"Oracle Corporation\",version=\"1.8.0_382-b05\"} 1\n"
             + "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 }

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmThreadsMetricsTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/JvmThreadsMetricsTest.java
@@ -1,6 +1,8 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import static io.prometheus.metrics.instrumentation.jvm.TestUtil.convertToOpenMetricsFormat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,17 +18,16 @@ import java.lang.management.ThreadMXBean;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class JvmThreadsMetricsTest {
 
-  private ThreadMXBean mockThreadsBean = Mockito.mock(ThreadMXBean.class);
-  private ThreadInfo mockThreadInfoBlocked = Mockito.mock(ThreadInfo.class);
-  private ThreadInfo mockThreadInfoRunnable1 = Mockito.mock(ThreadInfo.class);
-  private ThreadInfo mockThreadInfoRunnable2 = Mockito.mock(ThreadInfo.class);
+  private final ThreadMXBean mockThreadsBean = Mockito.mock(ThreadMXBean.class);
+  private final ThreadInfo mockThreadInfoBlocked = Mockito.mock(ThreadInfo.class);
+  private final ThreadInfo mockThreadInfoRunnable1 = Mockito.mock(ThreadInfo.class);
+  private final ThreadInfo mockThreadInfoRunnable2 = Mockito.mock(ThreadInfo.class);
 
   @Before
   public void setUp() {
@@ -84,7 +85,7 @@ public class JvmThreadsMetricsTest {
             + "jvm_threads_state{state=\"WAITING\"} 0.0\n"
             + "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test
@@ -133,9 +134,9 @@ public class JvmThreadsMetricsTest {
 
       Map<String, Double> actual = getCountByState(registry.scrape());
 
-      Assert.assertEquals(expected.size(), actual.size());
+      assertEquals(expected.size(), actual.size());
       for (String threadState : expected.keySet()) {
-        Assert.assertEquals(expected.get(threadState), actual.get(threadState), 0.0);
+        assertEquals(expected.get(threadState), actual.get(threadState), 0.0);
       }
     } finally {
       for (int i = 0; i < numberOfInvalidThreadIds; i++) {
@@ -151,7 +152,7 @@ public class JvmThreadsMetricsTest {
         for (GaugeSnapshot.GaugeDataPointSnapshot data :
             ((GaugeSnapshot) snapshot).getDataPoints()) {
           String state = data.getLabels().get("state");
-          Assert.assertNotNull(state);
+          assertNotNull(state);
           result.put(state, data.getValue());
         }
       }

--- a/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/ProcessMetricsTest.java
+++ b/prometheus-metrics-instrumentation-jvm/src/test/java/io/prometheus/metrics/instrumentation/jvm/ProcessMetricsTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.metrics.instrumentation.jvm;
 
 import static io.prometheus.metrics.instrumentation.jvm.TestUtil.convertToOpenMetricsFormat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -14,20 +15,19 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.management.RuntimeMXBean;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class ProcessMetricsTest {
 
-  private com.sun.management.UnixOperatingSystemMXBean sunOsBean =
+  private final com.sun.management.UnixOperatingSystemMXBean sunOsBean =
       Mockito.mock(com.sun.management.UnixOperatingSystemMXBean.class);
-  private java.lang.management.OperatingSystemMXBean javaOsBean =
+  private final java.lang.management.OperatingSystemMXBean javaOsBean =
       Mockito.mock(java.lang.management.OperatingSystemMXBean.class);
-  private ProcessMetrics.Grepper linuxGrepper = Mockito.mock(ProcessMetrics.Grepper.class);
-  private ProcessMetrics.Grepper windowsGrepper = Mockito.mock(ProcessMetrics.Grepper.class);
-  private RuntimeMXBean runtimeBean = Mockito.mock(RuntimeMXBean.class);
+  private final ProcessMetrics.Grepper linuxGrepper = Mockito.mock(ProcessMetrics.Grepper.class);
+  private final ProcessMetrics.Grepper windowsGrepper = Mockito.mock(ProcessMetrics.Grepper.class);
+  private final RuntimeMXBean runtimeBean = Mockito.mock(RuntimeMXBean.class);
 
   @Before
   public void setUp() throws IOException {
@@ -62,22 +62,32 @@ public class ProcessMetricsTest {
             + "process_max_fds 244.0\n"
             + "# TYPE process_open_fds gauge\n"
             + "# HELP process_open_fds Number of open file descriptors.\n"
-            + "process_open_fds 127.0\n"
-            + "# TYPE process_resident_memory_bytes gauge\n"
-            + "# UNIT process_resident_memory_bytes bytes\n"
-            + "# HELP process_resident_memory_bytes Resident memory size in bytes.\n"
-            + "process_resident_memory_bytes 1036288.0\n"
+            + "process_open_fds 127.0\n";
+    if (ProcessMetrics.PROC_SELF_STATUS.canRead()) {
+      expected +=
+          ""
+              + "# TYPE process_resident_memory_bytes gauge\n"
+              + "# UNIT process_resident_memory_bytes bytes\n"
+              + "# HELP process_resident_memory_bytes Resident memory size in bytes.\n"
+              + "process_resident_memory_bytes 1036288.0\n";
+    }
+    expected +=
+        ""
             + "# TYPE process_start_time_seconds gauge\n"
             + "# UNIT process_start_time_seconds seconds\n"
             + "# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.\n"
-            + "process_start_time_seconds 37.1\n"
-            + "# TYPE process_virtual_memory_bytes gauge\n"
-            + "# UNIT process_virtual_memory_bytes bytes\n"
-            + "# HELP process_virtual_memory_bytes Virtual memory size in bytes.\n"
-            + "process_virtual_memory_bytes 6180864.0\n"
-            + "# EOF\n";
+            + "process_start_time_seconds 37.1\n";
+    if (ProcessMetrics.PROC_SELF_STATUS.canRead()) {
+      expected +=
+          ""
+              + "# TYPE process_virtual_memory_bytes gauge\n"
+              + "# UNIT process_virtual_memory_bytes bytes\n"
+              + "# HELP process_virtual_memory_bytes Virtual memory size in bytes.\n"
+              + "process_virtual_memory_bytes 6180864.0\n";
+    }
+    expected += "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test
@@ -98,7 +108,7 @@ public class ProcessMetricsTest {
             + "process_start_time_seconds 37.1\n"
             + "# EOF\n";
 
-    Assert.assertEquals(expected, convertToOpenMetricsFormat(snapshots));
+    assertEquals(expected, convertToOpenMetricsFormat(snapshots));
   }
 
   @Test


### PR DESCRIPTION
The first commit contains cleanups and refactorings. The second commit was generated using `mvn spotless:apply` so spotless does not fail the build. I can separate them in 2 PRs if you'd prefer that, the spotless changes are pretty large.