### PR TITLE
[Performance]Use threadGroup to compute threads state rather than ThreadMXBean

### DIFF
--- a/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/JvmThreadsMetrics.java
+++ b/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/JvmThreadsMetrics.java
@@ -138,43 +138,6 @@ public class JvmThreadsMetrics {
     }
   }
 
-  private Map<String, Integer> getThreadStateCountMap(ThreadMXBean threadBean) {
-    long[] threadIds = threadBean.getAllThreadIds();
-
-    // Code to remove any thread id values <= 0
-    int writePos = 0;
-    for (int i = 0; i < threadIds.length; i++) {
-      if (threadIds[i] > 0) {
-        threadIds[writePos++] = threadIds[i];
-      }
-    }
-
-    final int numberOfInvalidThreadIds = threadIds.length - writePos;
-    threadIds = Arrays.copyOf(threadIds, writePos);
-
-    // Get thread information without computing any stack traces
-    ThreadInfo[] allThreads = threadBean.getThreadInfo(threadIds, 0);
-
-    // Initialize the map with all thread states
-    Map<String, Integer> threadCounts = new HashMap<>();
-    for (Thread.State state : Thread.State.values()) {
-      threadCounts.put(state.name(), 0);
-    }
-
-    // Collect the actual thread counts
-    for (ThreadInfo curThread : allThreads) {
-      if (curThread != null) {
-        Thread.State threadState = curThread.getThreadState();
-        threadCounts.put(threadState.name(), threadCounts.get(threadState.name()) + 1);
-      }
-    }
-
-    // Add the thread count for invalid thread ids
-    threadCounts.put(UNKNOWN, numberOfInvalidThreadIds);
-
-    return threadCounts;
-  }
-
   private Map<String, Integer> getThreadStateCountMapFromThreadGroup() {
     int threadsNew = 0;
     int threadsRunnable = 0;


### PR DESCRIPTION
Environment: jdk-1.8
We encountered performance issue caused by jmx-exporter agent when the thread counts of HDFS Router becoming high.
We have found that it because exporter agent uses ThreadMXBean to compute threads state. It has big performance problem when thread count is high.

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/deb28ad2-528b-420b-b8cd-8068d5967f48" />


More detailes, please refer to https://issues.apache.org/jira/browse/HADOOP-16850

![image](https://github.com/user-attachments/assets/e110e2ba-2b3d-4970-897f-b410ccb78de6)
