### PR TITLE
Fix flaky `SlidingWindowTest`

### DIFF
--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/SlidingWindowTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/SlidingWindowTest.java
@@ -48,8 +48,12 @@ class SlidingWindowTest {
     currentTimeMillis.set(startTime);
     ringBuffer =
         new SlidingWindow<>(
-            Observer.class, Observer::new, Observer::observe, maxAgeSeconds, ageBuckets);
-    ringBuffer.currentTimeMillis = currentTimeMillis::get;
+            Observer.class,
+            Observer::new,
+            Observer::observe,
+            maxAgeSeconds,
+            ageBuckets,
+            currentTimeMillis::get);
   }
 
   @Test


### PR DESCRIPTION
Observed in the context of PicnicSupermarket/error-prone-support#1468, this PR aims to resolve the following transient test failure:
```
[ERROR] io.prometheus.metrics.core.metrics.SlidingWindowTest.rotate -- Time elapsed: 0.023 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
[Start time: 1734782202868, current time: 1734782232878, elapsed time: 30010]
expected: [1.0, 1.0, 1.0, 1.0, 1.0]
 but was: [1.0, 1.0, 1.0, 1.0]
    at io.prometheus.metrics.core.metrics.SlidingWindowTest$Observer.assertValues(SlidingWindowTest.java:30)
    at io.prometheus.metrics.core.metrics.SlidingWindowTest.rotate(SlidingWindowTest.java:57)
    at java.base/java.lang.reflect.Method.invoke(Method.java:569)
    at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
    at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

This fix likely also resolves #956.

How to reproduce:
```
mvn install -DskipTests -pl prometheus-metrics-core -am
while mvn test -Dtest='SlidingWindowTest' -pl prometheus-metrics-core; do echo Again...; done
```

Prior to this fix the loop exists after a few minutes (or even significantly faster), while with this change the loop does not appear to terminate.