### PR TITLE
Caffeine instrumentation: add weighted size metric

### DIFF
--- a/prometheus-metrics-instrumentation-caffeine/src/main/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollector.java
+++ b/prometheus-metrics-instrumentation-caffeine/src/main/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollector.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentMap;
  * <pre>{@code
  * // Note that `recordStats()` is required to gather non-zero statistics
  * Cache<String, String> cache = Caffeine.newBuilder().recordStats().build();
- * CacheMetricsCollector cacheMetrics = new CacheMetricsCollector();
+ * CacheMetricsCollector cacheMetrics = CacheMetricsCollector.builder().build();
  * PrometheusRegistry.defaultRegistry.register(cacheMetrics);
  * cacheMetrics.addCache("mycache", cache);
  *
@@ -270,5 +270,15 @@ public class CacheMetricsCollector implements MultiCollector {
   @Override
   public List<String> getPrometheusNames() {
     return ALL_METRIC_NAMES;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    public CacheMetricsCollector build() {
+      return new CacheMetricsCollector();
+    }
   }
 }

--- a/prometheus-metrics-instrumentation-caffeine/src/main/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollector.java
+++ b/prometheus-metrics-instrumentation-caffeine/src/main/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollector.java
@@ -146,10 +146,10 @@ public class CacheMetricsCollector implements MultiCollector {
             .name(METRIC_NAME_CACHE_EVICTION)
             .help("Cache eviction totals, doesn't include manually removed entries");
 
-    final GaugeSnapshot.Builder cacheEvictionWeight =
-        GaugeSnapshot.builder()
+    final CounterSnapshot.Builder cacheEvictionWeight =
+        CounterSnapshot.builder()
             .name(METRIC_NAME_CACHE_EVICTION_WEIGHT)
-            .help("Cache eviction weight");
+            .help("Weight of evicted cache entries, doesn't include manually removed entries");
 
     final CounterSnapshot.Builder cacheLoadFailure =
         CounterSnapshot.builder().name(METRIC_NAME_CACHE_LOAD_FAILURE).help("Cache load failures");
@@ -175,7 +175,7 @@ public class CacheMetricsCollector implements MultiCollector {
 
       try {
         cacheEvictionWeight.dataPoint(
-            GaugeSnapshot.GaugeDataPointSnapshot.builder()
+            CounterSnapshot.CounterDataPointSnapshot.builder()
                 .labels(labels)
                 .value(stats.evictionWeight())
                 .build());

--- a/prometheus-metrics-instrumentation-caffeine/src/test/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollectorTest.java
+++ b/prometheus-metrics-instrumentation-caffeine/src/test/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollectorTest.java
@@ -32,7 +32,7 @@ class CacheMetricsCollectorTest {
     final Cache<String, String> cache =
         Caffeine.newBuilder().maximumSize(2).recordStats().executor(Runnable::run).build();
 
-    final CacheMetricsCollector collector = new CacheMetricsCollector();
+    final CacheMetricsCollector collector = CacheMetricsCollector.builder().build();
     collector.addCache("users", cache);
 
     final PrometheusRegistry registry = new PrometheusRegistry();
@@ -89,7 +89,7 @@ class CacheMetricsCollectorTest {
             .executor(Runnable::run)
             .build();
 
-    final CacheMetricsCollector collector = new CacheMetricsCollector();
+    final CacheMetricsCollector collector = CacheMetricsCollector.builder().build();
     collector.addCache("users", cache);
 
     final PrometheusRegistry registry = new PrometheusRegistry();
@@ -148,7 +148,7 @@ class CacheMetricsCollectorTest {
         .thenReturn("Third User");
 
     final LoadingCache<String, String> cache = Caffeine.newBuilder().recordStats().build(loader);
-    final CacheMetricsCollector collector = new CacheMetricsCollector();
+    final CacheMetricsCollector collector = CacheMetricsCollector.builder().build();
 
     collector.addCache("loadingusers", cache);
 
@@ -180,7 +180,7 @@ class CacheMetricsCollectorTest {
 
   @Test
   public void getPrometheusNamesHasSameSizeAsMetricSizeWhenScraping() {
-    final CacheMetricsCollector collector = new CacheMetricsCollector();
+    final CacheMetricsCollector collector = CacheMetricsCollector.builder().build();
 
     final PrometheusRegistry registry = new PrometheusRegistry();
     registry.register(collector);
@@ -193,7 +193,7 @@ class CacheMetricsCollectorTest {
 
   @Test
   public void collectedMetricNamesAreKnownPrometheusNames() {
-    final CacheMetricsCollector collector = new CacheMetricsCollector();
+    final CacheMetricsCollector collector = CacheMetricsCollector.builder().build();
 
     final PrometheusRegistry registry = new PrometheusRegistry();
     registry.register(collector);

--- a/prometheus-metrics-instrumentation-caffeine/src/test/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollectorTest.java
+++ b/prometheus-metrics-instrumentation-caffeine/src/test/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollectorTest.java
@@ -52,6 +52,7 @@ class CacheMetricsCollectorTest {
     assertCounterMetric(registry, "caffeine_cache_miss", "users", 2.0);
     assertCounterMetric(registry, "caffeine_cache_requests", "users", 3.0);
     assertCounterMetric(registry, "caffeine_cache_eviction", "users", 2.0);
+    assertCounterMetric(registry, "caffeine_cache_eviction_weight", "users", 2.0);
 
     final String expected =
         "# TYPE caffeine_cache_estimated_size gauge\n"
@@ -60,9 +61,9 @@ class CacheMetricsCollectorTest {
             + "# TYPE caffeine_cache_eviction counter\n"
             + "# HELP caffeine_cache_eviction Cache eviction totals, doesn't include manually removed entries\n"
             + "caffeine_cache_eviction_total{cache=\"users\"} 2.0\n"
-            + "# TYPE caffeine_cache_eviction_weight gauge\n"
-            + "# HELP caffeine_cache_eviction_weight Cache eviction weight\n"
-            + "caffeine_cache_eviction_weight{cache=\"users\"} 2.0\n"
+            + "# TYPE caffeine_cache_eviction_weight counter\n"
+            + "# HELP caffeine_cache_eviction_weight Weight of evicted cache entries, doesn't include manually removed entries\n"
+            + "caffeine_cache_eviction_weight_total{cache=\"users\"} 2.0\n"
             + "# TYPE caffeine_cache_hit counter\n"
             + "# HELP caffeine_cache_hit Cache hit totals\n"
             + "caffeine_cache_hit_total{cache=\"users\"} 1.0\n"

--- a/prometheus-metrics-instrumentation-caffeine/src/test/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollectorTest.java
+++ b/prometheus-metrics-instrumentation-caffeine/src/test/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollectorTest.java
@@ -13,6 +13,7 @@ import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
@@ -22,17 +23,34 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 @SuppressWarnings("CheckReturnValue")
 class CacheMetricsCollectorTest {
+  // This enum was added to simplify test parametrization on argument options.
+  public enum Options {
+    LEGACY(false),
+    COLLECT_EVICTION_WEIGHT_AS_COUNTER(true);
 
-  @Test
-  public void cacheExposesMetricsForHitMissAndEviction() {
+    private final boolean collectEvictionWeightAsCounter;
+
+    Options(boolean collectEvictionWeightAsCounter) {
+      this.collectEvictionWeightAsCounter = collectEvictionWeightAsCounter;
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource
+  public void cacheExposesMetricsForHitMissAndEviction(Options options) {
     // Run cleanup in same thread, to remove async behavior with evictions
     final Cache<String, String> cache =
         Caffeine.newBuilder().maximumSize(2).recordStats().executor(Runnable::run).build();
 
-    final CacheMetricsCollector collector = CacheMetricsCollector.builder().build();
+    final CacheMetricsCollector collector =
+        CacheMetricsCollector.builder()
+            .collectEvictionWeightAsCounter(options.collectEvictionWeightAsCounter)
+            .build();
     collector.addCache("users", cache);
 
     final PrometheusRegistry registry = new PrometheusRegistry();
@@ -52,7 +70,20 @@ class CacheMetricsCollectorTest {
     assertCounterMetric(registry, "caffeine_cache_miss", "users", 2.0);
     assertCounterMetric(registry, "caffeine_cache_requests", "users", 3.0);
     assertCounterMetric(registry, "caffeine_cache_eviction", "users", 2.0);
-    assertCounterMetric(registry, "caffeine_cache_eviction_weight", "users", 2.0);
+    String openMetricEvictionWeightExpectedText;
+    if (options.collectEvictionWeightAsCounter) {
+      assertCounterMetric(registry, "caffeine_cache_eviction_weight", "users", 2.0);
+      openMetricEvictionWeightExpectedText =
+          "# TYPE caffeine_cache_eviction_weight counter\n"
+              + "# HELP caffeine_cache_eviction_weight Weight of evicted cache entries, doesn't include manually removed entries\n"
+              + "caffeine_cache_eviction_weight_total{cache=\"users\"} 2.0\n";
+    } else {
+      assertGaugeMetric(registry, "caffeine_cache_eviction_weight", "users", 2.0);
+      openMetricEvictionWeightExpectedText =
+          "# TYPE caffeine_cache_eviction_weight gauge\n"
+              + "# HELP caffeine_cache_eviction_weight Weight of evicted cache entries, doesn't include manually removed entries\n"
+              + "caffeine_cache_eviction_weight{cache=\"users\"} 2.0\n";
+    }
 
     final String expected =
         "# TYPE caffeine_cache_estimated_size gauge\n"
@@ -61,9 +92,7 @@ class CacheMetricsCollectorTest {
             + "# TYPE caffeine_cache_eviction counter\n"
             + "# HELP caffeine_cache_eviction Cache eviction totals, doesn't include manually removed entries\n"
             + "caffeine_cache_eviction_total{cache=\"users\"} 2.0\n"
-            + "# TYPE caffeine_cache_eviction_weight counter\n"
-            + "# HELP caffeine_cache_eviction_weight Weight of evicted cache entries, doesn't include manually removed entries\n"
-            + "caffeine_cache_eviction_weight_total{cache=\"users\"} 2.0\n"
+            + openMetricEvictionWeightExpectedText
             + "# TYPE caffeine_cache_hit counter\n"
             + "# HELP caffeine_cache_hit Cache hit totals\n"
             + "caffeine_cache_hit_total{cache=\"users\"} 1.0\n"
@@ -78,8 +107,9 @@ class CacheMetricsCollectorTest {
     assertThat(convertToOpenMetricsFormat(registry)).isEqualTo(expected);
   }
 
-  @Test
-  public void weightedCacheExposesMetricsForHitMissAndEvictionWeightedSize() {
+  @ParameterizedTest
+  @EnumSource
+  public void weightedCacheExposesMetricsForHitMissAndEvictionWeightedSize(Options options) {
     // Run cleanup in same thread, to remove async behavior with evictions
     final Cache<String, String> cache =
         Caffeine.newBuilder()
@@ -89,7 +119,10 @@ class CacheMetricsCollectorTest {
             .executor(Runnable::run)
             .build();
 
-    final CacheMetricsCollector collector = CacheMetricsCollector.builder().build();
+    final CacheMetricsCollector collector =
+        CacheMetricsCollector.builder()
+            .collectEvictionWeightAsCounter(options.collectEvictionWeightAsCounter)
+            .build();
     collector.addCache("users", cache);
 
     final PrometheusRegistry registry = new PrometheusRegistry();
@@ -109,7 +142,20 @@ class CacheMetricsCollectorTest {
     assertCounterMetric(registry, "caffeine_cache_miss", "users", 2.0);
     assertCounterMetric(registry, "caffeine_cache_requests", "users", 3.0);
     assertCounterMetric(registry, "caffeine_cache_eviction", "users", 2.0);
-    assertCounterMetric(registry, "caffeine_cache_eviction_weight", "users", 31.0);
+    String openMetricEvictionWeightExpectedText;
+    if (options.collectEvictionWeightAsCounter) {
+      assertCounterMetric(registry, "caffeine_cache_eviction_weight", "users", 31.0);
+      openMetricEvictionWeightExpectedText =
+          "# TYPE caffeine_cache_eviction_weight counter\n"
+              + "# HELP caffeine_cache_eviction_weight Weight of evicted cache entries, doesn't include manually removed entries\n"
+              + "caffeine_cache_eviction_weight_total{cache=\"users\"} 31.0\n";
+    } else {
+      assertGaugeMetric(registry, "caffeine_cache_eviction_weight", "users", 31.0);
+      openMetricEvictionWeightExpectedText =
+          "# TYPE caffeine_cache_eviction_weight gauge\n"
+              + "# HELP caffeine_cache_eviction_weight Weight of evicted cache entries, doesn't include manually removed entries\n"
+              + "caffeine_cache_eviction_weight{cache=\"users\"} 31.0\n";
+    }
 
     final String expected =
         "# TYPE caffeine_cache_estimated_size gauge\n"
@@ -118,9 +164,7 @@ class CacheMetricsCollectorTest {
             + "# TYPE caffeine_cache_eviction counter\n"
             + "# HELP caffeine_cache_eviction Cache eviction totals, doesn't include manually removed entries\n"
             + "caffeine_cache_eviction_total{cache=\"users\"} 2.0\n"
-            + "# TYPE caffeine_cache_eviction_weight counter\n"
-            + "# HELP caffeine_cache_eviction_weight Weight of evicted cache entries, doesn't include manually removed entries\n"
-            + "caffeine_cache_eviction_weight_total{cache=\"users\"} 31.0\n"
+            + openMetricEvictionWeightExpectedText
             + "# TYPE caffeine_cache_hit counter\n"
             + "# HELP caffeine_cache_hit Cache hit totals\n"
             + "caffeine_cache_hit_total{cache=\"users\"} 1.0\n"
@@ -178,9 +222,13 @@ class CacheMetricsCollectorTest {
     assertThat(loadDuration.getSum()).isGreaterThan(0);
   }
 
-  @Test
-  public void getPrometheusNamesHasSameSizeAsMetricSizeWhenScraping() {
-    final CacheMetricsCollector collector = CacheMetricsCollector.builder().build();
+  @ParameterizedTest
+  @EnumSource
+  public void getPrometheusNamesHasSameSizeAsMetricSizeWhenScraping(Options options) {
+    final CacheMetricsCollector collector =
+        CacheMetricsCollector.builder()
+            .collectEvictionWeightAsCounter(options.collectEvictionWeightAsCounter)
+            .build();
 
     final PrometheusRegistry registry = new PrometheusRegistry();
     registry.register(collector);
@@ -191,9 +239,13 @@ class CacheMetricsCollectorTest {
     assertThat(prometheusNames).hasSize(metricSnapshots.size());
   }
 
-  @Test
-  public void collectedMetricNamesAreKnownPrometheusNames() {
-    final CacheMetricsCollector collector = CacheMetricsCollector.builder().build();
+  @ParameterizedTest
+  @EnumSource
+  public void collectedMetricNamesAreKnownPrometheusNames(Options options) {
+    final CacheMetricsCollector collector =
+        CacheMetricsCollector.builder()
+            .collectEvictionWeightAsCounter(options.collectEvictionWeightAsCounter)
+            .build();
 
     final PrometheusRegistry registry = new PrometheusRegistry();
     registry.register(collector);
@@ -210,6 +262,14 @@ class CacheMetricsCollectorTest {
       PrometheusRegistry registry, String name, String cacheName, double value) {
     final CounterSnapshot.CounterDataPointSnapshot dataPointSnapshot =
         (CounterSnapshot.CounterDataPointSnapshot) getDataPointSnapshot(registry, name, cacheName);
+
+    assertThat(dataPointSnapshot.getValue()).isEqualTo(value);
+  }
+
+  private void assertGaugeMetric(
+      PrometheusRegistry registry, String name, String cacheName, double value) {
+    final GaugeSnapshot.GaugeDataPointSnapshot dataPointSnapshot =
+        (GaugeSnapshot.GaugeDataPointSnapshot) getDataPointSnapshot(registry, name, cacheName);
 
     assertThat(dataPointSnapshot.getValue()).isEqualTo(value);
   }


### PR DESCRIPTION
There are two modifications in this PR:

 * `caffeine_cache_eviction_weight` has been changed from a `gauge` to a `counter` - that seems semantically more pertinent to me, as that statistic can only increase (though there is a debate on that point - see #1246);
 * `caffeine_cache_weighted_size` has been added;

There are at least two backwards compatibility concerns that should be given a thought:

 1. If the change of type of `caffeine_cache_eviction_weight` is accepted, users would have to migrate to using the `_total` suffix;
 2. If someone already uses `caffeine-instrumentation`, and has defined their own `caffeine_cache_weighted_size` metric, upgrading to a version that includes this PR would break their application;

Point 1 obviously depends on whether the type change is accepted, both from a theoretical point of view (how it should be modelled as a metric), and from a practical point of view (is the change worth a migration for current users).
For point 2, I guess my main point would be to understand the project's policy on backward compatibility when adding metric names in instrumentation libraries. I would be happy to add documentation pertaining to:

 * Guava and Caffeine instrumentation, and backwards compatibility policy as it pertains to new metric added by these instrumentation libraries in the future;
 * Backwards compatibility policy around adding new metrics to JVM instrumentation;