### PR TITLE
Fix NPE when label value is null

### DIFF
--- a/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
+++ b/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
@@ -35,6 +35,9 @@ public class TextFormatUtil {
   }
 
   static void writeEscapedLabelValue(Writer writer, String s) throws IOException {
+    if (s == null) {
+      return;
+    }
     for (int i = 0; i < s.length(); i++) {
       char c = s.charAt(i);
       switch (c) {


### PR DESCRIPTION
Hi, we faced an NPE in metrics exporter in [cassandra-management-api](https://github.com/k8ssandra/management-api-for-apache-cassandra).

```
WARN  [epollEventLoopGroup-6-1] 2025-01-17 07:37:13,527 DefaultChannelPipeline.java:1152 - An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in th
e pipeline did not handle the exception.
java.lang.NullPointerException: null
        at io.prometheus.client.exporter.common.TextFormat.writeEscapedLabelValue(TextFormat.java:156)
        at io.prometheus.client.exporter.common.TextFormat.write004(TextFormat.java:119)
        at io.prometheus.client.exporter.common.TextFormat.writeFormat(TextFormat.java:53)
at io.k8ssandra.metrics.http.NettyServerHandler.channelRead0(NettyServerHandler.java:76)
        at io.k8ssandra.metrics.http.NettyServerHandler.channelRead0(NettyServerHandler.java:31)
```

It exports a lot of metrics and prometheus client doesn't add information about the particular metric that causes the exception, so it's hard to identify and fix a particular metric definition. Adding information about metric and label for all possible exceptions will require much more effort, so I think rendering nulls as empty values should be a good option instead of not rendering anything at all.