### PR TITLE
Use bulk string writes for text formats

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -42,20 +42,13 @@
             <version>${jmh.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <version>${jmh.version}</version>
-        </dependency>
-        <!--
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
-        </dependency>
-        -->
-        <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-exposition-textformats</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
@@ -1,0 +1,122 @@
+package io.prometheus.metrics.benchmarks;
+
+import io.prometheus.metrics.expositionformats.ExpositionFormatWriter;
+import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
+import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot.GaugeDataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.Labels;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.model.snapshots.SummarySnapshot;
+import io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.Unit;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+public class TextFormatUtilBenchmark {
+
+  private static final MetricSnapshots SNAPSHOTS;
+
+  static {
+    MetricSnapshot gaugeSnapshot =
+        GaugeSnapshot.builder()
+            .name("gauge_snapshot_name")
+            .dataPoint(
+                GaugeDataPointSnapshot.builder()
+                    .labels(Labels.of("name", "value"))
+                    .scrapeTimestampMillis(1000L)
+                    .value(123.45d)
+                    .build())
+            .build();
+
+    MetricSnapshot summaryDataPointSnapshot =
+        SummarySnapshot.builder()
+            .name("summary_snapshot_name_bytes")
+            .dataPoint(
+                SummaryDataPointSnapshot.builder()
+                    .count(5)
+                    .labels(Labels.of("name", "value"))
+                    .sum(123456d)
+                    .build())
+            .unit(Unit.BYTES)
+            .build();
+
+    SNAPSHOTS = MetricSnapshots.of(gaugeSnapshot, summaryDataPointSnapshot);
+  }
+
+  private static final ExpositionFormatWriter OPEN_METRICS_TEXT_FORMAT_WRITER =
+      new OpenMetricsTextFormatWriter(false, false);
+  private static final ExpositionFormatWriter PROMETHEUS_TEXT_FORMAT_WRITER =
+      new PrometheusTextFormatWriter(false);
+
+  @State(Scope.Benchmark)
+  public static class WriterState {
+
+    final ByteArrayOutputStream byteArrayOutputStream;
+
+    public WriterState() {
+      this.byteArrayOutputStream = new ByteArrayOutputStream();
+    }
+  }
+
+  @Benchmark
+  public OutputStream openMetricsWriteToByteArray(WriterState writerState) throws IOException {
+    // avoid growing the array
+    ByteArrayOutputStream byteArrayOutputStream = writerState.byteArrayOutputStream;
+    byteArrayOutputStream.reset();
+    OPEN_METRICS_TEXT_FORMAT_WRITER.write(byteArrayOutputStream, SNAPSHOTS);
+    return byteArrayOutputStream;
+  }
+
+  @Benchmark
+  public OutputStream openMetricsWriteToNull() throws IOException {
+    OutputStream nullOutputStream = NullOutputStream.INSTANCE;
+    OPEN_METRICS_TEXT_FORMAT_WRITER.write(nullOutputStream, SNAPSHOTS);
+    return nullOutputStream;
+  }
+
+  @Benchmark
+  public OutputStream prometheusWriteToByteArray(WriterState writerState) throws IOException {
+    // avoid growing the array
+    ByteArrayOutputStream byteArrayOutputStream = writerState.byteArrayOutputStream;
+    byteArrayOutputStream.reset();
+    PROMETHEUS_TEXT_FORMAT_WRITER.write(byteArrayOutputStream, SNAPSHOTS);
+    return byteArrayOutputStream;
+  }
+
+  @Benchmark
+  public OutputStream prometheusWriteToNull() throws IOException {
+    OutputStream nullOutputStream = NullOutputStream.INSTANCE;
+    PROMETHEUS_TEXT_FORMAT_WRITER.write(nullOutputStream, SNAPSHOTS);
+    return nullOutputStream;
+  }
+
+  static final class NullOutputStream extends OutputStream {
+
+    static final OutputStream INSTANCE = new NullOutputStream();
+
+    private NullOutputStream() {
+      super();
+    }
+
+    @Override
+    public void write(int b) {}
+
+    @Override
+    public void write(byte[] b) {}
+
+    @Override
+    public void write(byte[] b, int off, int len) {}
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
+  }
+}

--- a/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/TextFormatUtilTest.java
+++ b/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/TextFormatUtilTest.java
@@ -1,0 +1,24 @@
+package io.prometheus.metrics.expositionformats;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+
+class TextFormatUtilTest {
+
+  @Test
+  void writeEscapedLabelValue() throws IOException {
+    assertEquals("aa\\\\bb\\\"cc\\ndd\\nee\\\\ff\\\"gg", escape("aa\\bb\"cc\ndd\nee\\ff\"gg"));
+    assertEquals("\\\\", escape("\\"));
+    assertEquals("\\\\\\\\", escape("\\\\"));
+    assertEquals("text", escape("text"));
+  }
+
+  private static String escape(String s) throws IOException {
+    StringWriter writer = new StringWriter();
+    TextFormatUtil.writeEscapedLabelValue(writer, s);
+    return writer.toString();
+  }
+}


### PR DESCRIPTION
Further optimize `TextFormatUtil#writeEscapedLabelValue`. We're seeing `TextFormatUtil#writeEscapedLabelValue` show up in our production traces due to the single `char` writes to `OutputStreamWriter`. We're using `OpenMetricsTextFormatWriter`. #1241 and #1248 should take care of most of these issues but there still remains some optimization potential left. `BufferedWriter#write(int)` has some minimal overhead in terms of locking. If we assume that rarely any characters need to be escaped and instead optimize to write as large of a part of the String as possible in one method call.

Before
---------
```
Benchmark                                             Mode  Cnt       Score      Error  Units
TextFormatUtilBenchmark.openMetricsWriteToByteArray  thrpt   25  438485.372 ± 4270.355  ops/s
TextFormatUtilBenchmark.openMetricsWriteToNull       thrpt   25  440105.281 ± 2891.572  ops/s
TextFormatUtilBenchmark.prometheusWriteToByteArray   thrpt   25  467213.001 ±  878.780  ops/s
TextFormatUtilBenchmark.prometheusWriteToNull        thrpt   25  472931.759 ±  976.028  ops/s
```

After
-------

```
Benchmark                                             Mode  Cnt       Score      Error  Units
TextFormatUtilBenchmark.openMetricsWriteToByteArray  thrpt   25  462852.243 ± 5071.696  ops/s
TextFormatUtilBenchmark.openMetricsWriteToNull       thrpt   25  469910.681 ± 1670.430  ops/s
TextFormatUtilBenchmark.prometheusWriteToByteArray   thrpt   25  482362.506 ± 2051.684  ops/s
TextFormatUtilBenchmark.prometheusWriteToNull        thrpt   25  487707.557 ± 3344.881  ops/s
```

About a 5% to 6% gain for `OpenMetricsTextFormatWriter` and around 3% for `PrometheusTextFormatWriter`.

Note that this benchmark is actually for `OpenMetricsTextFormatWriter` and `PrometheusTextFormatWriter` since `TextFormatUtil` is not public and can therefore not be benchmarked directly. The relative gains in `#writeEscapedLabelValue` are higher because the benchmark runs the full text format writers.

I also added a test for `TextFormatUtil#writeEscapedLabelValue` since the code is now more complicated.
