### PR TITLE
Set a name to threads created by Scheduler Threadfactory

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/util/Scheduler.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/util/Scheduler.java
@@ -14,9 +14,13 @@ import java.util.concurrent.TimeUnit;
 public class Scheduler {
 
   private static class DaemonThreadFactory implements ThreadFactory {
+    private static int threadNum;
+    private static synchronized int nextThreadNum() {
+      return threadNum++;
+    }
     @Override
     public Thread newThread(Runnable runnable) {
-      Thread thread = new Thread(runnable);
+      Thread thread = new Thread(runnable, "prometheus-metrics-scheduler-" + nextThreadNum());
       thread.setDaemon(true);
       return thread;
     }

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/util/Scheduler.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/util/Scheduler.java
@@ -15,9 +15,11 @@ public class Scheduler {
 
   private static class DaemonThreadFactory implements ThreadFactory {
     private static int threadNum;
+
     private static synchronized int nextThreadNum() {
       return threadNum++;
     }
+
     @Override
     public Thread newThread(Runnable runnable) {
       Thread thread = new Thread(runnable, "prometheus-metrics-scheduler-" + nextThreadNum());


### PR DESCRIPTION
Use prefix "prometheus-metrics-scheduler-" plus counter.

Used in conjunction with https://issues.apache.org/jira/browse/KAFKA-18982