### PR TITLE
Eagerly reject null label values

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
@@ -112,7 +112,20 @@ abstract class StatefulMetric<D extends DataPoint, T extends D> extends MetricWi
             "Expected " + labelNames.length + " label values, but got " + labelValues.length + ".");
       }
     }
-    return data.computeIfAbsent(Arrays.asList(labelValues), l -> newDataPoint());
+    return data.computeIfAbsent(
+        Arrays.asList(labelValues),
+        l -> {
+          for (int i = 0; i < l.size(); i++) {
+            if (l.get(i) == null) {
+              throw new IllegalArgumentException(
+                  "null label value for metric "
+                      + getMetadata().getName()
+                      + " and label "
+                      + labelNames[i]);
+            }
+          }
+          return newDataPoint();
+        });
   }
 
   /**

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/StatefulMetricTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/StatefulMetricTest.java
@@ -1,6 +1,7 @@
 package io.prometheus.metrics.core.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -66,5 +67,13 @@ class StatefulMetricTest {
     counter.inc();
     assertThat(counter.collect().getDataPoints()).hasSize(1);
     assertThat(counter.collect().getDataPoints().get(0).getValue()).isEqualTo(1.0);
+  }
+
+  @Test
+  public void testNullLabel() {
+    Counter counter = Counter.builder().name("test").labelNames("l1", "l2").build();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> counter.labelValues("l1", null))
+        .withMessage("null label value for metric test and label l2");
   }
 }


### PR DESCRIPTION
Scraping generally doesn't support null label values and can throw NPEs at various points. It's easiest to debug such problems at the point null is introduced.

Signed-off-by: Benjamin Peterson <benjamin@engflow.com>
