### PR TITLE
Fix broken link to "Exclude protobuf exposition format" section

### DIFF
--- a/docs/content/getting-started/quickstart.md
+++ b/docs/content/getting-started/quickstart.md
@@ -55,7 +55,7 @@ standalone HTTP server.
 {{< hint type=note >}}
 
 If you do not use the protobuf exposition format, you can
-[exclude]({{< relref "quickstart.md#exclude-protobuf-exposition-format" >}})
+[exclude]({{< relref "../exporters/formats.md#exclude-protobuf-exposition-format" >}})
 it from the dependencies.
 
 {{< /hint >}}


### PR DESCRIPTION
This PR fixes a broken link to the "Exclude protobuf exposition format" section in the `quickstart.md`.