### PR TITLE
Let clients of DropwizardExports handle validation errors

### DIFF
--- a/prometheus-metrics-instrumentation-dropwizard/src/main/java/io/prometheus/metrics/instrumentation/dropwizard/DropwizardExports.java
+++ b/prometheus-metrics-instrumentation-dropwizard/src/main/java/io/prometheus/metrics/instrumentation/dropwizard/DropwizardExports.java
@@ -9,6 +9,7 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
+import io.prometheus.metrics.instrumentation.dropwizard5.InvalidMetricHandler;
 import io.prometheus.metrics.instrumentation.dropwizard5.labels.CustomLabelMapper;
 import io.prometheus.metrics.model.registry.MultiCollector;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
@@ -21,8 +22,10 @@ import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import io.prometheus.metrics.model.snapshots.Quantiles;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -32,6 +35,7 @@ public class DropwizardExports implements MultiCollector {
   private final MetricRegistry registry;
   private final MetricFilter metricFilter;
   private final Optional<CustomLabelMapper> labelMapper;
+  private final InvalidMetricHandler invalidMetricHandler;
 
   /**
    * Creates a new DropwizardExports and {@link MetricFilter#ALL}.
@@ -43,6 +47,7 @@ public class DropwizardExports implements MultiCollector {
     this.registry = registry;
     this.metricFilter = MetricFilter.ALL;
     this.labelMapper = Optional.empty();
+    this.invalidMetricHandler = InvalidMetricHandler.ALWAYS_THROW;
   }
 
   /**
@@ -55,6 +60,7 @@ public class DropwizardExports implements MultiCollector {
     this.registry = registry;
     this.metricFilter = metricFilter;
     this.labelMapper = Optional.empty();
+    this.invalidMetricHandler = InvalidMetricHandler.ALWAYS_THROW;
   }
 
   /**
@@ -67,6 +73,23 @@ public class DropwizardExports implements MultiCollector {
     this.registry = registry;
     this.metricFilter = metricFilter;
     this.labelMapper = Optional.ofNullable(labelMapper);
+    this.invalidMetricHandler = InvalidMetricHandler.ALWAYS_THROW;
+  }
+
+  /**
+   * @param registry a metric registry to export in prometheus.
+   * @param metricFilter a custom metric filter.
+   * @param labelMapper a labelMapper to use to map labels.
+   */
+  private DropwizardExports(
+      MetricRegistry registry,
+      MetricFilter metricFilter,
+      CustomLabelMapper labelMapper,
+      InvalidMetricHandler invalidMetricHandler) {
+    this.registry = registry;
+    this.metricFilter = metricFilter;
+    this.labelMapper = Optional.ofNullable(labelMapper);
+    this.invalidMetricHandler = invalidMetricHandler;
   }
 
   private static String getHelpMessage(String metricName, Metric metric) {
@@ -194,32 +217,31 @@ public class DropwizardExports implements MultiCollector {
   @Override
   public MetricSnapshots collect() {
     MetricSnapshots.Builder metricSnapshots = MetricSnapshots.builder();
-
-    registry
-        .getGauges(metricFilter)
-        .forEach(
-            (name, gauge) -> {
-              MetricSnapshot snapshot = fromGauge(name, gauge);
-              if (snapshot != null) {
-                metricSnapshots.metricSnapshot(snapshot);
-              }
-            });
-
-    registry
-        .getCounters(metricFilter)
-        .forEach((name, counter) -> metricSnapshots.metricSnapshot(fromCounter(name, counter)));
-    registry
-        .getHistograms(metricFilter)
-        .forEach(
-            (name, histogram) -> metricSnapshots.metricSnapshot(fromHistogram(name, histogram)));
-    registry
-        .getTimers(metricFilter)
-        .forEach((name, timer) -> metricSnapshots.metricSnapshot(fromTimer(name, timer)));
-    registry
-        .getMeters(metricFilter)
-        .forEach((name, meter) -> metricSnapshots.metricSnapshot(fromMeter(name, meter)));
-
+    collectMetricKind(metricSnapshots, registry.getGauges(metricFilter), this::fromGauge);
+    collectMetricKind(metricSnapshots, registry.getCounters(metricFilter), this::fromCounter);
+    collectMetricKind(metricSnapshots, registry.getHistograms(metricFilter), this::fromHistogram);
+    collectMetricKind(metricSnapshots, registry.getTimers(metricFilter), this::fromTimer);
+    collectMetricKind(metricSnapshots, registry.getMeters(metricFilter), this::fromMeter);
     return metricSnapshots.build();
+  }
+
+  private <T> void collectMetricKind(
+      MetricSnapshots.Builder builder,
+      Map<String, T> metric,
+      BiFunction<String, T, MetricSnapshot> toSnapshot) {
+    for (Map.Entry<String, T> entry : metric.entrySet()) {
+      String metricName = entry.getKey();
+      try {
+        MetricSnapshot snapshot = toSnapshot.apply(metricName, entry.getValue());
+        if (snapshot != null) {
+          builder.metricSnapshot(snapshot);
+        }
+      } catch (Exception e) {
+        if (!invalidMetricHandler.suppressException(metricName, e)) {
+          throw e;
+        }
+      }
+    }
   }
 
   public static Builder builder() {
@@ -231,9 +253,11 @@ public class DropwizardExports implements MultiCollector {
     private MetricRegistry registry;
     private MetricFilter metricFilter;
     private CustomLabelMapper labelMapper;
+    private InvalidMetricHandler invalidMetricHandler;
 
     private Builder() {
       this.metricFilter = MetricFilter.ALL;
+      this.invalidMetricHandler = InvalidMetricHandler.ALWAYS_THROW;
     }
 
     public Builder dropwizardRegistry(MetricRegistry registry) {
@@ -251,15 +275,16 @@ public class DropwizardExports implements MultiCollector {
       return this;
     }
 
+    public Builder invalidMetricHandler(InvalidMetricHandler invalidMetricHandler) {
+      this.invalidMetricHandler = invalidMetricHandler;
+      return this;
+    }
+
     DropwizardExports build() {
       if (registry == null) {
         throw new IllegalArgumentException("MetricRegistry must be set");
       }
-      if (labelMapper == null) {
-        return new DropwizardExports(registry, metricFilter);
-      } else {
-        return new DropwizardExports(registry, metricFilter, labelMapper);
-      }
+      return new DropwizardExports(registry, metricFilter, labelMapper, invalidMetricHandler);
     }
 
     public void register() {

--- a/prometheus-metrics-instrumentation-dropwizard/src/test/java/io/prometheus/metrics/instrumentation/dropwizard/DropwizardExportsTest.java
+++ b/prometheus-metrics-instrumentation-dropwizard/src/test/java/io/prometheus/metrics/instrumentation/dropwizard/DropwizardExportsTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.codahale.metrics.*;
 import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
+import io.prometheus.metrics.instrumentation.dropwizard5.InvalidMetricHandler;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 import java.io.ByteArrayOutputStream;
@@ -276,6 +277,56 @@ my_application_namedTimer1_count 0
 # EOF
 """;
     assertThat(convertToOpenMetricsFormat()).isEqualTo(expected);
+  }
+
+  @Test
+  void responseWhenRegistryIsEmpty() {
+    var registry = new PrometheusRegistry();
+    registry.register(DropwizardExports.builder().dropwizardRegistry(metricRegistry).build());
+    assertThat(convertToOpenMetricsFormat(registry))
+        .isEqualTo(
+            """
+# EOF
+""");
+  }
+
+  @Test
+  void collectInvalidMetricFails() {
+    metricRegistry.counter("my.application.namedCounter1").inc(-10);
+    metricRegistry.counter("my.application.namedCounter2").inc(10);
+    var registry = new PrometheusRegistry();
+    DropwizardExports.builder().dropwizardRegistry(metricRegistry).register(registry);
+    assertThatThrownBy(() -> convertToOpenMetricsFormat(registry))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void collectInvalidMetricPassesWhenExceptionIsIgnored() {
+    metricRegistry.counter("my.application.namedCounter1").inc(-10);
+    metricRegistry.counter("my.application.namedCounter2").inc(10);
+    var registry = new PrometheusRegistry();
+
+    final StringBuilder buf = new StringBuilder();
+    InvalidMetricHandler invalidMetricHandler =
+        (name, exc) -> {
+          buf.append("%s: %s%n".formatted(name, exc.getMessage()));
+          return true;
+        };
+
+    DropwizardExports.builder()
+        .dropwizardRegistry(metricRegistry)
+        .invalidMetricHandler(invalidMetricHandler)
+        .register(registry);
+    assertThat(convertToOpenMetricsFormat(registry))
+        .isEqualTo(
+            """
+# TYPE my_application_namedCounter2 counter
+# HELP my_application_namedCounter2 Generated from Dropwizard metric import (metric=my.application.namedCounter2, type=com.codahale.metrics.Counter)
+my_application_namedCounter2_total 10.0
+# EOF
+""");
+    assertThat(buf.toString())
+        .contains("my.application.namedCounter1: -10.0: counters cannot have a negative value");
   }
 
   private static class ExampleDoubleGauge implements Gauge<Double> {

--- a/prometheus-metrics-instrumentation-dropwizard5/src/main/java/io/prometheus/metrics/instrumentation/dropwizard5/DropwizardExports.java
+++ b/prometheus-metrics-instrumentation-dropwizard5/src/main/java/io/prometheus/metrics/instrumentation/dropwizard5/DropwizardExports.java
@@ -24,8 +24,8 @@ import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -35,6 +35,7 @@ public class DropwizardExports implements MultiCollector {
   private final MetricRegistry registry;
   private final MetricFilter metricFilter;
   private final Optional<CustomLabelMapper> labelMapper;
+  private final InvalidMetricHandler invalidMetricHandler;
 
   /**
    * Creates a new DropwizardExports and {@link MetricFilter#ALL}.
@@ -46,6 +47,7 @@ public class DropwizardExports implements MultiCollector {
     this.registry = registry;
     this.metricFilter = MetricFilter.ALL;
     this.labelMapper = Optional.empty();
+    this.invalidMetricHandler = InvalidMetricHandler.ALWAYS_THROW;
   }
 
   /**
@@ -58,6 +60,7 @@ public class DropwizardExports implements MultiCollector {
     this.registry = registry;
     this.metricFilter = metricFilter;
     this.labelMapper = Optional.empty();
+    this.invalidMetricHandler = InvalidMetricHandler.ALWAYS_THROW;
   }
 
   /**
@@ -70,6 +73,23 @@ public class DropwizardExports implements MultiCollector {
     this.registry = registry;
     this.metricFilter = metricFilter;
     this.labelMapper = Optional.ofNullable(labelMapper);
+    this.invalidMetricHandler = InvalidMetricHandler.ALWAYS_THROW;
+  }
+
+  /**
+   * @param registry a metric registry to export in prometheus.
+   * @param metricFilter a custom metric filter.
+   * @param labelMapper a labelMapper to use to map labels.
+   */
+  private DropwizardExports(
+      MetricRegistry registry,
+      MetricFilter metricFilter,
+      CustomLabelMapper labelMapper,
+      InvalidMetricHandler invalidMetricHandler) {
+    this.registry = registry;
+    this.metricFilter = metricFilter;
+    this.labelMapper = Optional.ofNullable(labelMapper);
+    this.invalidMetricHandler = invalidMetricHandler;
   }
 
   private static String getHelpMessage(String metricName, Metric metric) {
@@ -197,25 +217,31 @@ public class DropwizardExports implements MultiCollector {
   @Override
   public MetricSnapshots collect() {
     MetricSnapshots.Builder metricSnapshots = MetricSnapshots.builder();
-    @SuppressWarnings("rawtypes")
-    Set<Map.Entry<MetricName, Gauge>> entries = registry.getGauges(metricFilter).entrySet();
-    for (@SuppressWarnings("rawtypes") Map.Entry<MetricName, Gauge> entry : entries) {
-      Optional.ofNullable(fromGauge(entry.getKey().getKey(), entry.getValue()))
-          .ifPresent(metricSnapshots::metricSnapshot);
-    }
-    for (Map.Entry<MetricName, Counter> entry : registry.getCounters(metricFilter).entrySet()) {
-      metricSnapshots.metricSnapshot(fromCounter(entry.getKey().getKey(), entry.getValue()));
-    }
-    for (Map.Entry<MetricName, Histogram> entry : registry.getHistograms(metricFilter).entrySet()) {
-      metricSnapshots.metricSnapshot(fromHistogram(entry.getKey().getKey(), entry.getValue()));
-    }
-    for (Map.Entry<MetricName, Timer> entry : registry.getTimers(metricFilter).entrySet()) {
-      metricSnapshots.metricSnapshot(fromTimer(entry.getKey().getKey(), entry.getValue()));
-    }
-    for (Map.Entry<MetricName, Meter> entry : registry.getMeters(metricFilter).entrySet()) {
-      metricSnapshots.metricSnapshot(fromMeter(entry.getKey().getKey(), entry.getValue()));
-    }
+    collectMetricKind(metricSnapshots, registry.getGauges(metricFilter), this::fromGauge);
+    collectMetricKind(metricSnapshots, registry.getCounters(metricFilter), this::fromCounter);
+    collectMetricKind(metricSnapshots, registry.getHistograms(metricFilter), this::fromHistogram);
+    collectMetricKind(metricSnapshots, registry.getTimers(metricFilter), this::fromTimer);
+    collectMetricKind(metricSnapshots, registry.getMeters(metricFilter), this::fromMeter);
     return metricSnapshots.build();
+  }
+
+  private <T> void collectMetricKind(
+      MetricSnapshots.Builder builder,
+      Map<MetricName, T> metric,
+      BiFunction<String, T, MetricSnapshot> toSnapshot) {
+    for (Map.Entry<MetricName, T> entry : metric.entrySet()) {
+      String metricName = entry.getKey().getKey();
+      try {
+        MetricSnapshot snapshot = toSnapshot.apply(metricName, entry.getValue());
+        if (snapshot != null) {
+          builder.metricSnapshot(snapshot);
+        }
+      } catch (Exception e) {
+        if (!invalidMetricHandler.suppressException(metricName, e)) {
+          throw e;
+        }
+      }
+    }
   }
 
   public static Builder builder() {
@@ -227,9 +253,11 @@ public class DropwizardExports implements MultiCollector {
     private MetricRegistry registry;
     private MetricFilter metricFilter;
     private CustomLabelMapper labelMapper;
+    private InvalidMetricHandler invalidMetricHandler;
 
     private Builder() {
       this.metricFilter = MetricFilter.ALL;
+      this.invalidMetricHandler = InvalidMetricHandler.ALWAYS_THROW;
     }
 
     public Builder dropwizardRegistry(MetricRegistry registry) {
@@ -247,15 +275,16 @@ public class DropwizardExports implements MultiCollector {
       return this;
     }
 
+    public Builder invalidMetricHandler(InvalidMetricHandler invalidMetricHandler) {
+      this.invalidMetricHandler = invalidMetricHandler;
+      return this;
+    }
+
     DropwizardExports build() {
       if (registry == null) {
         throw new IllegalArgumentException("MetricRegistry must be set");
       }
-      if (labelMapper == null) {
-        return new DropwizardExports(registry, metricFilter);
-      } else {
-        return new DropwizardExports(registry, metricFilter, labelMapper);
-      }
+      return new DropwizardExports(registry, metricFilter, labelMapper, invalidMetricHandler);
     }
 
     public void register() {

--- a/prometheus-metrics-instrumentation-dropwizard5/src/main/java/io/prometheus/metrics/instrumentation/dropwizard5/InvalidMetricHandler.java
+++ b/prometheus-metrics-instrumentation-dropwizard5/src/main/java/io/prometheus/metrics/instrumentation/dropwizard5/InvalidMetricHandler.java
@@ -1,0 +1,13 @@
+package io.prometheus.metrics.instrumentation.dropwizard5;
+
+@FunctionalInterface
+public interface InvalidMetricHandler {
+  InvalidMetricHandler ALWAYS_THROW = (metricName, exc) -> false;
+
+  /**
+   * @param metricName the name of the metric that was collected.
+   * @param exc The exception that was thrown when producing the metric snapshot.
+   * @return true if the exception should be suppressed.
+   */
+  boolean suppressException(String metricName, Exception exc);
+}


### PR DESCRIPTION
A possible solution for #1353.

In the current form, if e.g. a Counter contains invalid data the entire `collect` calls fails with InvalidArgumentException.

In large applications, it may be preferable to gracefully degrade the available metrics and report the failure via e.g. logging. This change allows just that - by changing the access modifiers to the `fromXYZ` methods subclasses can now handle the errors.

Finally, to allow for skipping of invalid metrics, we follow the example in `fromGauge` to interpret the meaning of a returned null to be that the metric should be skipped.