### PR TITLE
Add `prometheus-metrics-exposition-textformats` to BOM

### DIFF
--- a/prometheus-metrics-bom/pom.xml
+++ b/prometheus-metrics-bom/pom.xml
@@ -81,6 +81,11 @@
       </dependency>
       <dependency>
         <groupId>io.prometheus</groupId>
+        <artifactId>prometheus-metrics-exposition-textformats</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.prometheus</groupId>
         <artifactId>prometheus-metrics-instrumentation-dropwizard</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Hi all, I noticed a reference to `prometheus-metrics-exposition-textformats` on https://prometheus.github.io/client_java/exporters/formats/, but I didn't see the dependency in the BOM, so I'm adding it now.

@fstab @zeitlinger @dhoard @tomwilkie Please take a look. Thanks!