### PR TITLE
Discussion, improve CounterDataPoint.inc() critical path

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Counter.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Counter.java
@@ -38,7 +38,11 @@ public class Counter extends StatefulMetric<CounterDataPoint, Counter.DataPoint>
     super(builder);
     MetricsProperties[] properties = getMetricProperties(builder, prometheusProperties);
     boolean exemplarsEnabled = getConfigProperty(properties, MetricsProperties::getExemplarsEnabled);
-    if (exemplarsEnabled) {
+    // exemplars might be enabled specifically for a metric, however, if the code
+    // says withoutExemplars they should stay disabled.
+    boolean notTurnedOffWithinCode =
+      builder == null || builder.exemplarsEnabled == null || builder.exemplarsEnabled;
+    if (exemplarsEnabled && notTurnedOffWithinCode) {
       exemplarSamplerConfig =
           new ExemplarSamplerConfig(prometheusProperties.getExemplarProperties(), 1);
     } else {

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/CounterTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/CounterTest.java
@@ -319,8 +319,6 @@ class CounterTest {
   public void testExemplarSamplerDisabled() {
     Counter counter =
         Counter.builder()
-            // .withExemplarSampler((inc, prev) -> {throw new RuntimeException("unexpected call to
-            // exemplar sampler");})
             .name("count_total")
             .withoutExemplars()
             .build();
@@ -328,6 +326,21 @@ class CounterTest {
     assertThat(getData(counter).getExemplar()).isNull();
     counter.inc(2.0);
     assertThat(getData(counter).getExemplar()).isNull();
+  }
+
+  @Test
+  public void testExemplarSamplerDisabledReturnsFastCounter() {
+    Counter counter =
+      Counter.builder()
+        .name("count_total")
+        .withoutExemplars()
+        .build();
+    Counter.DataPointIgnoringExemplars fasterCounter = (Counter.DataPointIgnoringExemplars)
+      counter.labelValues();
+    assertThat(getData(counter).getValue()).isEqualTo(0);
+    fasterCounter.inc(1);
+    assertThat(getData(counter).getValue()).isEqualTo(1);
+    assertThat(fasterCounter.isExemplarsEnabled()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
@fstab, @dhoard, @tomwilkie, @zeitlinger

Thanks for the cool library. Its a pleasure to work with!

I was using it for a new project and started with placing own `LongAdder` in the code and expose via the `collect()` method. This way, I would I could manipulate it directly in the class implementing the service resulting in maximum performance. The code started to be come repetitive and add some point I realised that I am starting to implement something like `CounterDataPoint` again. To avoid this, I started digging into the code to see what the overhead would be.

With a code like `counter.labelValues().inc(1)` there is a bit of indirection until we hit `LongAdder`. However, there is already a faster path as the documentation in `CounterDataPoint` describes:

````
CounterDataPoint pendingTasks = counter.labelValues("pending");
pendingTasks.inc();
````

Looking deeper into the code there is a tiny bit more indirection, which could be avoided.

This patch is returning a specialised class in case the exemplars support is not enabled. The intended usage is:

````
    Counter counter =
      Counter.builder()
        .name("count_total")
        .withoutExemplars()
        .build();
    Counter.DataPointIgnoringExemplars fasterCounter = (Counter.DataPointIgnoringExemplars)
      counter.labelValues();
    fasterCounter.inc(1);
````

The unit test run successfully, however I realise that its breaking with the concept that the configuration can override what is configured in the code. I am not sure whether this would be tolerable for that special case. If an SRE enables exemplars for further diagnosis, the application would crash completely. Not good. However, probably 

The patch is still worth discussion and worth applying without propagating to use `Counter.DataPointIgnoringExemplars` class directly. This class can be private to avoid wrong usage. Which brings me to the class visibility of `Counter.DataPoint`.

My IDE marks code with:

<img width="628" height="221" alt="Screenshot_20250721_135228" src="https://github.com/user-attachments/assets/6df32e86-68c0-45ad-805d-ef988b4b8abf" />

The problem is that it's used as type parameter in the main `Counter` class and therefor becomes visible. My recommendation would be to make this public, deprecate the interface `CounterDataPoint` and mandate to use `Counter.DataPoint` instead. That is painful and probably will not happen fast, however, it is a mismatch, since `Counter` is a class that is not open for extension and the only one that will ever provide a `CounterDataPoint`.

The patch also removes two unnecessary boolean fields. If that makes sense, I can also extract that as a housekeeping PR.

Thoughts?