### PR TITLE
public StatefulMetric

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
@@ -28,7 +28,8 @@ import java.util.function.Function;
  * because in Java <i>synchronous</i> and <i>asynchronous</i> usually refers to multi-threading, but
  * this has nothing to do with multi-threading.
  */
-public abstract class StatefulMetric<D extends DataPoint, T extends D> extends MetricWithFixedMetadata {
+public abstract class StatefulMetric<D extends DataPoint, T extends D>
+    extends MetricWithFixedMetadata {
 
   /** Map label values to data points. */
   private final ConcurrentHashMap<List<String>, T> data = new ConcurrentHashMap<>();


### PR DESCRIPTION
All the other classes in the hierarchy are public too, this is probably just an oversight.