### PR TITLE
Builder.withoutExemplars() setting cannot be overridden via properties

### DIFF
--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusProperties.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusProperties.java
@@ -36,6 +36,10 @@ public class PrometheusProperties {
     return instance;
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   public PrometheusProperties(
       MetricsProperties defaultMetricsProperties,
       Map<String, MetricsProperties> metricProperties,
@@ -94,5 +98,78 @@ public class PrometheusProperties {
 
   public ExporterOpenTelemetryProperties getExporterOpenTelemetryProperties() {
     return exporterOpenTelemetryProperties;
+  }
+
+  public static class Builder {
+    private MetricsProperties defaultMetricsProperties;
+    private Map<String, MetricsProperties> metricProperties = new HashMap<>();
+    private ExemplarsProperties exemplarProperties;
+    private ExporterProperties exporterProperties;
+    private ExporterFilterProperties exporterFilterProperties;
+    private ExporterHttpServerProperties exporterHttpServerProperties;
+    private ExporterPushgatewayProperties pushgatewayProperties;
+    private ExporterOpenTelemetryProperties otelConfig;
+
+    private Builder() {}
+
+    public Builder defaultMetricsProperties(MetricsProperties defaultMetricsProperties) {
+      this.defaultMetricsProperties = defaultMetricsProperties;
+      return this;
+    }
+
+    public Builder metricProperties(Map<String, MetricsProperties> metricProperties) {
+      this.metricProperties = metricProperties;
+      return this;
+    }
+
+    /** Convenience for adding a single named MetricsProperties */
+    public Builder putMetricProperty(String name, MetricsProperties props) {
+      this.metricProperties.put(name, props);
+      return this;
+    }
+
+    public Builder exemplarProperties(ExemplarsProperties exemplarProperties) {
+      this.exemplarProperties = exemplarProperties;
+      return this;
+    }
+
+    public Builder exporterProperties(ExporterProperties exporterProperties) {
+      this.exporterProperties = exporterProperties;
+      return this;
+    }
+
+    public Builder exporterFilterProperties(ExporterFilterProperties exporterFilterProperties) {
+      this.exporterFilterProperties = exporterFilterProperties;
+      return this;
+    }
+
+    public Builder exporterHttpServerProperties(
+        ExporterHttpServerProperties exporterHttpServerProperties) {
+      this.exporterHttpServerProperties = exporterHttpServerProperties;
+      return this;
+    }
+
+    public Builder pushgatewayProperties(ExporterPushgatewayProperties pushgatewayProperties) {
+      this.pushgatewayProperties = pushgatewayProperties;
+      return this;
+    }
+
+    public Builder exporterOpenTelemetryProperties(
+        ExporterOpenTelemetryProperties exporterOpenTelemetryProperties) {
+      this.otelConfig = exporterOpenTelemetryProperties;
+      return this;
+    }
+
+    public PrometheusProperties build() {
+      return new PrometheusProperties(
+          defaultMetricsProperties,
+          metricProperties,
+          exemplarProperties,
+          exporterProperties,
+          exporterFilterProperties,
+          exporterHttpServerProperties,
+          pushgatewayProperties,
+          otelConfig);
+    }
   }
 }

--- a/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/PrometheusPropertiesTest.java
+++ b/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/PrometheusPropertiesTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
@@ -29,5 +30,30 @@ class PrometheusPropertiesTest {
     assertThat(properties).hasSize(1);
     MetricsProperties.load("io.prometheus.metrics", properties);
     assertThat(properties).isEmpty();
+  }
+
+  @Test
+  public void testBuilder() {
+    PrometheusProperties defaults = PrometheusPropertiesLoader.load(new HashMap<>());
+    PrometheusProperties.Builder builder = PrometheusProperties.builder();
+    builder.defaultMetricsProperties(defaults.getDefaultMetricProperties());
+    builder.exemplarProperties(defaults.getExemplarProperties());
+    builder.defaultMetricsProperties(defaults.getDefaultMetricProperties());
+    builder.exporterFilterProperties(defaults.getExporterFilterProperties());
+    builder.exporterHttpServerProperties(defaults.getExporterHttpServerProperties());
+    builder.exporterOpenTelemetryProperties(defaults.getExporterOpenTelemetryProperties());
+    builder.pushgatewayProperties(defaults.getExporterPushgatewayProperties());
+    PrometheusProperties result = builder.build();
+    assertThat(result.getDefaultMetricProperties()).isSameAs(defaults.getDefaultMetricProperties());
+    assertThat(result.getDefaultMetricProperties()).isSameAs(defaults.getDefaultMetricProperties());
+    assertThat(result.getExemplarProperties()).isSameAs(defaults.getExemplarProperties());
+    assertThat(result.getExporterFilterProperties())
+        .isSameAs(defaults.getExporterFilterProperties());
+    assertThat(result.getExporterHttpServerProperties())
+        .isSameAs(defaults.getExporterHttpServerProperties());
+    assertThat(result.getExporterOpenTelemetryProperties())
+        .isSameAs(defaults.getExporterOpenTelemetryProperties());
+    assertThat(result.getExporterPushgatewayProperties())
+        .isSameAs(defaults.getExporterPushgatewayProperties());
   }
 }

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Gauge.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Gauge.java
@@ -39,13 +39,13 @@ import java.util.concurrent.atomic.AtomicLong;
 public class Gauge extends StatefulMetric<GaugeDataPoint, Gauge.DataPoint>
     implements GaugeDataPoint {
 
-  private final boolean exemplarsEnabled;
   private final ExemplarSamplerConfig exemplarSamplerConfig;
 
   private Gauge(Builder builder, PrometheusProperties prometheusProperties) {
     super(builder);
     MetricsProperties[] properties = getMetricProperties(builder, prometheusProperties);
-    exemplarsEnabled = getConfigProperty(properties, MetricsProperties::getExemplarsEnabled);
+    boolean exemplarsEnabled =
+        getConfigProperty(properties, MetricsProperties::getExemplarsEnabled);
     if (exemplarsEnabled) {
       exemplarSamplerConfig =
           new ExemplarSamplerConfig(prometheusProperties.getExemplarProperties(), 1);
@@ -104,10 +104,10 @@ public class Gauge extends StatefulMetric<GaugeDataPoint, Gauge.DataPoint>
 
   @Override
   protected boolean isExemplarsEnabled() {
-    return exemplarsEnabled;
+    return exemplarSamplerConfig != null;
   }
 
-  class DataPoint implements GaugeDataPoint {
+  static class DataPoint implements GaugeDataPoint {
 
     private final ExemplarSampler exemplarSampler; // null if isExemplarsEnabled() is false
 
@@ -170,6 +170,10 @@ public class Gauge extends StatefulMetric<GaugeDataPoint, Gauge.DataPoint>
         }
       }
       return new GaugeSnapshot.GaugeDataPointSnapshot(get(), labels, oldest);
+    }
+
+    private boolean isExemplarsEnabled() {
+      return exemplarSampler != null;
     }
   }
 

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/StatefulMetric.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -157,23 +158,26 @@ public abstract class StatefulMetric<D extends DataPoint, T extends D>
     return noLabels;
   }
 
+  /**
+   * Metric properties in effect by order of precedence with the highest precedence first. If a
+   * {@code MetricProperties} is configured for the metric name it has higher precedence than the
+   * builder configuration. A special case is the setting {@link Builder#withoutExemplars()} via the
+   * builder, which cannot be overridden by any configuration.
+   */
   protected MetricsProperties[] getMetricProperties(
       Builder<?, ?> builder, PrometheusProperties prometheusProperties) {
+    List<MetricsProperties> properties = new ArrayList<>();
+    if (Objects.equals(builder.exemplarsEnabled, false)) {
+      properties.add(MetricsProperties.builder().exemplarsEnabled(false).build());
+    }
     String metricName = getMetadata().getName();
     if (prometheusProperties.getMetricProperties(metricName) != null) {
-      return new MetricsProperties[] {
-        prometheusProperties.getMetricProperties(metricName), // highest precedence
-        builder.toProperties(), // second-highest precedence
-        prometheusProperties.getDefaultMetricProperties(), // third-highest precedence
-        builder.getDefaultProperties() // fallback
-      };
-    } else {
-      return new MetricsProperties[] {
-        builder.toProperties(), // highest precedence
-        prometheusProperties.getDefaultMetricProperties(), // second-highest precedence
-        builder.getDefaultProperties() // fallback
-      };
+      properties.add(prometheusProperties.getMetricProperties(metricName));
     }
+    properties.add(builder.toProperties());
+    properties.add(prometheusProperties.getDefaultMetricProperties());
+    properties.add(builder.getDefaultProperties()); // fallback
+    return properties.toArray(new MetricsProperties[0]);
   }
 
   protected <P> P getConfigProperty(

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/GaugeTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/GaugeTest.java
@@ -4,6 +4,8 @@ import static io.prometheus.metrics.core.metrics.TestUtil.assertExemplarEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 
+import io.prometheus.metrics.config.MetricsProperties;
+import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.core.datapoints.Timer;
 import io.prometheus.metrics.core.exemplars.ExemplarSamplerConfigTestUtil;
 import io.prometheus.metrics.model.snapshots.Exemplar;
@@ -222,6 +224,19 @@ class GaugeTest {
   @Test
   public void testExemplarSamplerDisabled() {
     Gauge gauge = Gauge.builder().name("test").withoutExemplars().build();
+    gauge.setWithExemplar(3.0, Labels.of("a", "b"));
+    assertThat(getData(gauge).getExemplar()).isNull();
+    gauge.inc(2.0);
+    assertThat(getData(gauge).getExemplar()).isNull();
+  }
+
+  @Test
+  public void testExemplarSamplerDisabledByBuilder_enabledByPropertiesOnMetric() {
+    PrometheusProperties properties =
+        PrometheusProperties.builder()
+            .putMetricProperty("test", MetricsProperties.builder().exemplarsEnabled(true).build())
+            .build();
+    Gauge gauge = Gauge.builder(properties).name("test").withoutExemplars().build();
     gauge.setWithExemplar(3.0, Labels.of("a", "b"));
     assertThat(getData(gauge).getExemplar()).isNull();
     gauge.inc(2.0);

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/HistogramTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/HistogramTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.Offset.offset;
 
+import io.prometheus.metrics.config.MetricsProperties;
+import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.core.datapoints.DistributionDataPoint;
 import io.prometheus.metrics.core.exemplars.ExemplarSamplerConfigTestUtil;
 import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
@@ -1426,6 +1428,25 @@ class HistogramTest {
     assertThat(getBucket(histogram, 5).getCount()).isZero();
     assertThat(getBucket(histogram, 10).getCount()).isZero();
     assertThat(getBucket(histogram, Double.POSITIVE_INFINITY).getCount()).isOne();
+  }
+
+  @Test
+  public void testExemplarsDisabledInBuilder() {
+    Histogram histogram = Histogram.builder().withoutExemplars().name("test").build();
+    histogram.observeWithExemplar(2.5, Labels.EMPTY);
+    assertThat(getData(histogram).getExemplars().size()).isZero();
+  }
+
+  @Test
+  public void testExemplarsDisabledInBuilder_enabledByPropertiesOnMetric() {
+    PrometheusProperties properties =
+        PrometheusProperties.builder()
+            .putMetricProperty("test", MetricsProperties.builder().exemplarsEnabled(true).build())
+            .defaultMetricsProperties(MetricsProperties.builder().build())
+            .build();
+    Histogram histogram = Histogram.builder(properties).withoutExemplars().name("test").build();
+    histogram.observeWithExemplar(2.5, Labels.EMPTY);
+    assertThat(getData(histogram).getExemplars().size()).isZero();
   }
 
   @Test


### PR DESCRIPTION
The PR will fix the behaviour that exemplar support can be switched on via the properties, although it was disabled explicitly in the code definition by `withoutExemplars`. Currently this would enable exemplars:

````
    PrometheusProperties properties = PrometheusProperties.builder()
      .putMetricProperty("count", MetricsProperties.builder()
        .exemplarsEnabled(true)
        .build())
      .build();
    Counter counter =
      Counter.builder(properties)
        .name("count_total")
        .withoutExemplars()
        .build();
````

In TDD fashion I will add failing tests first.
