### PR TITLE
docs: Update classicBuckets() to classicUpperBounds()

### DIFF
--- a/docs/content/getting-started/metric-types.md
+++ b/docs/content/getting-started/metric-types.md
@@ -109,9 +109,9 @@ most cases you don't need them, defaults are good. The following is an incomplet
 most important options:
 
 - `nativeOnly()` / `classicOnly()`: Create a histogram with one representation only.
-- `classicBuckets(...)`: Set the classic bucket boundaries. Default buckets are `.005`, `.01`,
-  `.025`, `.05`, `.1`, `.25`, `.5`, `1`, `2.5`, `5`, `and 10`. The default bucket boundaries are
-  designed for measuring request durations in seconds.
+- `classicUpperBounds(...)`: Set the classic bucket upper boundaries. Default bucket upper
+  boundaries are `.005`, `.01`, `.025`, `.05`, `.1`, `.25`, `.5`, `1`, `2.5`, `5`, `and 10`. The
+  default bucket boundaries are designed for measuring request durations in seconds.
 - `nativeMaxNumberOfBuckets()`: Upper limit for the number of native histogram buckets.
   Default is 160. When the maximum is reached, the native histogram automatically
   reduces resolution to stay below the limit.

--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/MetricsProperties.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/MetricsProperties.java
@@ -263,7 +263,7 @@ public class MetricsProperties {
     return histogramClassicOnly;
   }
 
-  /** See {@code Histogram.Builder.classicBuckets()} */
+  /** See {@code Histogram.Builder.classicUpperBounds()} */
   @Nullable
   public List<Double> getHistogramClassicUpperBounds() {
     return histogramClassicUpperBounds;


### PR DESCRIPTION
Commit c57e49cab206 (2023-09-23, "Rename buckets to upperBounds in histogram builder") renamed method `classicBuckets()` to `classicUpperBounds()` but missed renames in `docs/` and in one javadoc link.

Fix the documentation to the new name.