### PR TITLE
Add metricsHandlerPath and registerHealthHandler configuration options to HTTPServer

### DIFF
--- a/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/DefaultHandler.java
+++ b/prometheus-metrics-exporter-httpserver/src/main/java/io/prometheus/metrics/exporter/httpserver/DefaultHandler.java
@@ -11,24 +11,27 @@ public class DefaultHandler implements HttpHandler {
   private final byte[] responseBytes;
   private final String contentType;
 
-  public DefaultHandler() {
+  public DefaultHandler(String metricsPath) {
+    String metrics = metricsPath.startsWith("/") ? metricsPath.substring(1) : metricsPath;
     String responseString =
         "<html>\n"
             + "<head><title>Prometheus Java Client</title></head>\n"
             + "<body>\n"
             + "<h1>Prometheus Java Client</h1>\n"
             + "<h2>Metrics Path</h2>\n"
-            + "The metrics path is <a href=\"metrics\">/metrics</a>.\n"
+            + String.format("The metrics path is <a href=\"%s\">%s</a>.\n", metrics, metricsPath)
             + "<h2>Name Filter</h2>\n"
             + "If you want to scrape only specific metrics, "
             + "use the <tt>name[]</tt> parameter like this:\n"
             + "<ul>\n"
-            + "<li><a href=\"metrics?name[]=my_metric\">/metrics?name[]=my_metric</a></li>\n"
+            + String.format(
+                "<li><a href=\"%s?name[]=my_metric\">%s?name[]=my_metric</a></li>\n",
+                metrics, metricsPath)
             + "</ul>\n"
             + "You can also use multiple <tt>name[]</tt> parameters to query multiple metrics:\n"
             + "<ul>\n"
-            + "<li><a href=\"metrics?name[]=my_metric_a&name=my_metrics_b\">"
-            + "/metrics?name[]=my_metric_a&amp;name=[]=my_metric_b</a></li>\n"
+            + String.format("<li><a href=\"%s?name[]=my_metric_a&name[]=my_metric_b\">", metrics)
+            + String.format("%s?name[]=my_metric_a&amp;name[]=my_metric_b</a></li>\n", metricsPath)
             + "</ul>\n"
             + "The <tt>name[]</tt> parameter can be used by the Prometheus server for scraping. "
             + "Add the following snippet to your scrape job configuration in "
@@ -50,13 +53,17 @@ public class DefaultHandler implements HttpHandler {
             + "The Prometheus Java metrics library supports a <tt>debug</tt> query parameter "
             + "for viewing the different formats in a Web browser:\n"
             + "<ul>\n"
-            + "<li><a href=\"metrics?debug=openmetrics\">/metrics?debug=openmetrics</a>: "
+            + String.format(
+                "<li><a href=\"%s?debug=openmetrics\">%s?debug=openmetrics</a>: ",
+                metrics, metricsPath)
             + "View OpenMetrics text format.</li>\n"
-            + "<li><a href=\"metrics?debug=text\">/metrics?debug=text</a>: "
+            + String.format(
+                "<li><a href=\"%s?debug=text\">%s?debug=text</a>: ", metrics, metricsPath)
             + "View Prometheus text format (this is the default when accessing the "
-            + "<a href=\"metrics\">/metrics</a> endpoint with a Web browser).</li>\n"
-            + "<li><a href=\"metrics?debug=prometheus-protobuf\">"
-            + "/metrics?debug=prometheus-protobuf</a>: "
+            + String.format(
+                "<a href=\"%s\">%s</a> endpoint with a Web browser).</li>\n", metrics, metricsPath)
+            + String.format("<li><a href=\"%s?debug=prometheus-protobuf\">", metrics)
+            + String.format("%s?debug=prometheus-protobuf</a>: ", metricsPath)
             + "View a text representation of the Prometheus protobuf format.</li>\n"
             + "</ul>\n"
             + "Note that the <tt>debug</tt> parameter is only for viewing different formats in a "

--- a/prometheus-metrics-exporter-httpserver/src/test/java/io/prometheus/metrics/exporter/httpserver/HTTPServerTest.java
+++ b/prometheus-metrics-exporter-httpserver/src/test/java/io/prometheus/metrics/exporter/httpserver/HTTPServerTest.java
@@ -106,6 +106,19 @@ public class HTTPServerTest {
   }
 
   @Test
+  void metricsCustomPath() throws IOException {
+    run(
+        HTTPServer.builder()
+            .port(0)
+            .registry(new PrometheusRegistry())
+            .metricsHandlerPath("/my-metrics")
+            .executorService(Executors.newFixedThreadPool(1))
+            .buildAndStart(),
+        "200",
+        "/my-metrics");
+  }
+
+  @Test
   void registryThrows() throws IOException {
     HTTPServer server =
         HTTPServer.builder()
@@ -146,5 +159,31 @@ public class HTTPServerTest {
   @Test
   void health() throws IOException {
     run(HTTPServer.builder().port(0).buildAndStart(), "200", "/-/healthy");
+  }
+
+  @Test
+  void healthEnabled() throws IOException {
+    HttpHandler handler = exchange -> exchange.sendResponseHeaders(204, -1);
+    run(
+        HTTPServer.builder()
+            .port(0)
+            .defaultHandler(handler)
+            .registerHealthHandler(true)
+            .buildAndStart(),
+        "200",
+        "/-/healthy");
+  }
+
+  @Test
+  void healthDisabled() throws IOException {
+    HttpHandler handler = exchange -> exchange.sendResponseHeaders(204, -1);
+    run(
+        HTTPServer.builder()
+            .port(0)
+            .defaultHandler(handler)
+            .registerHealthHandler(false)
+            .buildAndStart(),
+        "204",
+        "/-/healthy");
   }
 }


### PR DESCRIPTION
Hey @fstab, long time no see.

We would like to use this exporter in our project, but need to customize the metrics endpoint and disable the health handler. I hope this small contribution can make into a release.

## Summary

This pull request enhances the configurability of the Prometheus Java HTTP server by allowing customization of the metrics endpoint path and making the health endpoint registration optional. It also updates the default HTML handler to reflect these changes and adds tests to ensure correct behavior.

### Configuration improvements

* Added support for customizing the metrics endpoint via the new `metricsHandlerEndpoint` option in the `HTTPServer.Builder`. The default remains `/metrics`, but it can now be changed as needed. [[1]](diffhunk://#diff-fd57f399229770ac99d7f2b18cee74741a3f70c7c4c0800e17a04cb1b1bc321eL60-R82) [[2]](diffhunk://#diff-fd57f399229770ac99d7f2b18cee74741a3f70c7c4c0800e17a04cb1b1bc321eR187-R191) [[3]](diffhunk://#diff-fd57f399229770ac99d7f2b18cee74741a3f70c7c4c0800e17a04cb1b1bc321eR264-R278) [[4]](diffhunk://#diff-fd57f399229770ac99d7f2b18cee74741a3f70c7c4c0800e17a04cb1b1bc321eL278-R302)
* Introduced a `registerHealthHandler` option in the `HTTPServer.Builder` to control whether the health endpoint (`/-/healthy`) is registered. By default, it is enabled. [[1]](diffhunk://#diff-fd57f399229770ac99d7f2b18cee74741a3f70c7c4c0800e17a04cb1b1bc321eL60-R82) [[2]](diffhunk://#diff-fd57f399229770ac99d7f2b18cee74741a3f70c7c4c0800e17a04cb1b1bc321eR187-R191) [[3]](diffhunk://#diff-fd57f399229770ac99d7f2b18cee74741a3f70c7c4c0800e17a04cb1b1bc321eR264-R278) [[4]](diffhunk://#diff-fd57f399229770ac99d7f2b18cee74741a3f70c7c4c0800e17a04cb1b1bc321eL278-R302)

### Default handler updates

* Updated the `DefaultHandler` to accept the metrics path as a parameter and generate all documentation links and examples based on the configured path, ensuring consistency in the UI and documentation. [[1]](diffhunk://#diff-99311d9bc5b7879fc572852eb8106a440466befcdc072a07632818e6425dbb07L14-R34) [[2]](diffhunk://#diff-99311d9bc5b7879fc572852eb8106a440466befcdc072a07632818e6425dbb07L53-R66)

### Testing

* Added tests to verify that the metrics endpoint can be customized and that the health endpoint can be enabled or disabled as configured. [[1]](diffhunk://#diff-c5c2cdc04572f6033ea66e1b7cd4859178b7da6adea0f8fc46993ae83ce8fa6cR108-R120) [[2]](diffhunk://#diff-c5c2cdc04572f6033ea66e1b7cd4859178b7da6adea0f8fc46993ae83ce8fa6cR163-R188)