### PR TITLE
Reduce flakyness of testExemplarsClassicHistogram

### DIFF
--- a/prometheus-metrics-core/pom.xml
+++ b/prometheus-metrics-core/pom.xml
@@ -51,11 +51,5 @@
       <version>3.6.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>4.3.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
I've been encountering issues with `io.prometheus.metrics.core.metrics.HistogramTest.testExemplarsClassicHistogram` when running tests locally, lot's of these:

```
[ERROR] Tests run: 28, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.279 s <<< FAILURE! -- in io.prometheus.metrics.core.metrics.HistogramTest
[ERROR] io.prometheus.metrics.core.metrics.HistogramTest.testExemplarsClassicHistogram -- Time elapsed: 0.055 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "io.prometheus.metrics.model.snapshots.Exemplar.getValue()" because "actual" is null
        at io.prometheus.metrics.core.metrics.TestUtil.assertExemplarEquals(TestUtil.java:13)
        at io.prometheus.metrics.core.metrics.HistogramTest.testExemplarsClassicHistogram(HistogramTest.java:1054)
```

attempting to make it a little more reliable with awaitility.

Alternatively we could refactor the ExemplarSampler to take a clock as an argument so we could mock it, but I figured we could start here before we change the production code
