### PR TITLE
Add stable Metrics class to decouple consumers from protobuf version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,10 +58,23 @@ mise run compile
 
 ## Updating the Protobuf Java Classes
 
+The generated protobuf `Metrics.java` lives in a versioned package
+(e.g., `...generated.com_google_protobuf_4_33_5`) that changes with each
+protobuf release. A stable extending class at
+`...generated/Metrics.java` reexports all types so that consumer code
+only imports from the version-free package. On protobuf upgrades only
+the `extends` clause in the stable class changes.
+
 In the failing PR from renovate, run:
 
 ```shell
 mise run generate
 ```
 
-Add the new `Metrics.java` to Git and commit it.
+The script will:
+
+1. Re-generate the protobuf sources with the new version.
+2. Update the versioned package name in all Java files
+   (including the stable `Metrics.java` extends clause).
+
+Add the updated files to Git and commit them.

--- a/prometheus-metrics-exposition-formats/generate-protobuf.sh
+++ b/prometheus-metrics-exposition-formats/generate-protobuf.sh
@@ -18,7 +18,7 @@ mkdir -p "$TARGET_DIR"
 rm -rf $PROTO_DIR || true
 mkdir -p $PROTO_DIR
 
-OLD_PACKAGE=$(sed -nE 's/import (io.prometheus.metrics.expositionformats.generated.*).Metrics;/\1/p' src/main/java/io/prometheus/metrics/expositionformats/internal/PrometheusProtobufWriterImpl.java)
+OLD_PACKAGE=$(sed -nE 's/.*extends (io\.prometheus\.metrics\.expositionformats\.generated\.[^ ]*?)\.Metrics.*/\1/p' src/main/java/io/prometheus/metrics/expositionformats/generated/Metrics.java)
 PACKAGE="io.prometheus.metrics.expositionformats.generated.com_google_protobuf_${PROTOBUF_VERSION_STRING}"
 
 if [[ $OLD_PACKAGE != "$PACKAGE" ]]; then
@@ -32,6 +32,10 @@ sed -i "s/java_package = \"io.prometheus.client\"/java_package = \"$PACKAGE\"/" 
 protoc --java_out "$TARGET_DIR" $PROTO_DIR/metrics.proto
 sed -i '1 i\//CHECKSTYLE:OFF: checkstyle' "$(find src/main/generated/io -type f)"
 sed -i -e $'$a\\\n//CHECKSTYLE:ON: checkstyle' "$(find src/main/generated/io -type f)"
+
+GENERATED_FILE="$TARGET_DIR/${PACKAGE//\.//}/Metrics.java"
+sed -i 's/public final class Metrics/public class Metrics/' "$GENERATED_FILE"
+sed -i 's/private Metrics() {}/protected Metrics() {}/' "$GENERATED_FILE"
 
 GENERATED_WITH=$(grep -oP '\/\/ Protobuf Java Version: \K.*' "$TARGET_DIR/${PACKAGE//\.//}"/Metrics.java)
 

--- a/prometheus-metrics-exposition-formats/src/main/generated/io/prometheus/metrics/expositionformats/generated/com_google_protobuf_4_33_5/Metrics.java
+++ b/prometheus-metrics-exposition-formats/src/main/generated/io/prometheus/metrics/expositionformats/generated/com_google_protobuf_4_33_5/Metrics.java
@@ -7,8 +7,8 @@
 package io.prometheus.metrics.expositionformats.generated.com_google_protobuf_4_33_5;
 
 @com.google.protobuf.Generated
-public final class Metrics extends com.google.protobuf.GeneratedFile {
-  private Metrics() {}
+public class Metrics extends com.google.protobuf.GeneratedFile {
+  protected Metrics() {}
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/generated/Metrics.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/generated/Metrics.java
@@ -1,0 +1,6 @@
+package io.prometheus.metrics.expositionformats.generated;
+
+public final class Metrics
+    extends io.prometheus.metrics.expositionformats.generated.com_google_protobuf_4_33_5.Metrics {
+  private Metrics() {}
+}

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/internal/PrometheusProtobufWriterImpl.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/internal/PrometheusProtobufWriterImpl.java
@@ -7,7 +7,7 @@ import com.google.protobuf.TextFormat;
 import io.prometheus.metrics.config.EscapingScheme;
 import io.prometheus.metrics.expositionformats.ExpositionFormatWriter;
 import io.prometheus.metrics.expositionformats.TextFormatUtil;
-import io.prometheus.metrics.expositionformats.generated.com_google_protobuf_4_33_5.Metrics;
+import io.prometheus.metrics.expositionformats.generated.Metrics;
 import io.prometheus.metrics.model.snapshots.ClassicHistogramBuckets;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot.CounterDataPointSnapshot;
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import javax.annotation.Nullable;
 
+@SuppressWarnings("NonCanonicalType")
 public class PrometheusProtobufWriterImpl implements ExpositionFormatWriter {
 
   @Override

--- a/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/DuplicateNamesProtobufTest.java
+++ b/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/DuplicateNamesProtobufTest.java
@@ -3,7 +3,7 @@ package io.prometheus.metrics.expositionformats;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.prometheus.metrics.config.EscapingScheme;
-import io.prometheus.metrics.expositionformats.generated.com_google_protobuf_4_33_5.Metrics;
+import io.prometheus.metrics.expositionformats.generated.Metrics;
 import io.prometheus.metrics.expositionformats.internal.PrometheusProtobufWriterImpl;
 import io.prometheus.metrics.model.registry.Collector;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("NonCanonicalType")
 class DuplicateNamesProtobufTest {
 
   private static PrometheusRegistry getPrometheusRegistry() {

--- a/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/ProtobufExpositionFormatsTest.java
+++ b/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/ProtobufExpositionFormatsTest.java
@@ -3,11 +3,12 @@ package io.prometheus.metrics.expositionformats;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.prometheus.metrics.config.EscapingScheme;
-import io.prometheus.metrics.expositionformats.generated.com_google_protobuf_4_33_5.Metrics;
+import io.prometheus.metrics.expositionformats.generated.Metrics;
 import io.prometheus.metrics.expositionformats.internal.PrometheusProtobufWriterImpl;
 import io.prometheus.metrics.expositionformats.internal.ProtobufUtil;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 
+@SuppressWarnings("NonCanonicalType")
 class ProtobufExpositionFormatsTest extends ExpositionFormatsTest {
 
   @Override


### PR DESCRIPTION
## Summary

- Introduce a stable `Metrics.java` in the version-free `...generated` package that extends the versioned generated class, so consumer code no longer needs import updates on protobuf upgrades.
- Update `generate-protobuf.sh` to make the generated class extensible (`final` removed, constructor `protected`) and read the old package from the stable class's `extends` clause.
- Update all consumer imports to use the stable package, with `@SuppressWarnings("NonCanonicalType")` for Error Prone compatibility.

## Test plan

- [x] `mise run build` passes (all 54 modules)
- [x] `mise run test -pl prometheus-metrics-exposition-formats` passes (47 tests)
- [x] `mise run lint:super-linter` passes