### PR TITLE
fix: remove version manipulation from build-release.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Build release version
         run: mise run build-release
-        env:
-          TAG: ${{ github.ref_name }}
 
       - name: Set up Apache Maven Central
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/test-release-build.yml
+++ b/.github/workflows/test-release-build.yml
@@ -32,6 +32,3 @@ jobs:
           BASE_URL: "/client_java"
       - name: Build release version
         run: mise run build-release
-        env:
-          # don't use the current snapshot version, to test a more realistic release
-          TAG: ${{ github.run_number }}

--- a/.mise/tasks/build-release.sh
+++ b/.mise/tasks/build-release.sh
@@ -1,22 +1,8 @@
 #!/usr/bin/env bash
 
 #MISE description="Build release package"
-#USAGE arg "[tag]" env="TAG"
 
 set -euo pipefail
 
-PARENT_POM="prometheus-metrics-parent/pom.xml"
-CURRENT_VERSION=$(sed -n 's/.*<version>\(.*-SNAPSHOT\)<\/version>.*/\1/p' "$PARENT_POM" | head -1)
-
-if [[ -z "$CURRENT_VERSION" ]]; then
-	echo "ERROR: could not find SNAPSHOT version in $PARENT_POM" >&2
-	exit 1
-fi
-
-# shellcheck disable=SC2154 # is set by mise
-VERSION=${usage_tag:-$CURRENT_VERSION}
-VERSION=${VERSION#v}
-
-find . -name 'pom.xml' -exec \
-	sed -i "s/<version>${CURRENT_VERSION}<\/version>/<version>${VERSION}<\/version>/g" {} +
-mvn -B package -P 'release,!default,!examples-and-integration-tests' -Dmaven.test.skip=true -Dgpg.skip=true
+mvn -B package -P 'release,!default,!examples-and-integration-tests' \
+	-Dmaven.test.skip=true -Dgpg.skip=true


### PR DESCRIPTION
## Summary

- Remove redundant sed-based SNAPSHOT version replacement from `build-release.sh` — release-please already sets the correct versions in pom.xml at the tagged commit
- Remove `TAG` env var from `release.yml` and `test-release-build.yml` workflows

## Test plan

- [x] `mise run build-release` succeeds locally
- [x] `mise run lint` passes
- [ ] CI passes on PR