### PR TITLE
chore(deps): update flint to v0.5.0 and use slim super-linter

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ protoc = "33.5"
 [env]
 RENOVATE_TRACKED_DEPS_EXCLUDE="github-actions,github-runners"
 # renovate: datasource=docker depName=ghcr.io/super-linter/super-linter
-SUPER_LINTER_VERSION="v8.5.0@sha256:6831c0a801d353b510e4e468a3209a8a48bf0102e193d5c7e94e57667fdf64eb"
+SUPER_LINTER_VERSION="slim-v8.5.0@sha256:857dcc3f0bf5dd065fdeed1ace63394bb2004238a5ef02910ea23d9bcd8fd2b8"
 
 [tasks.ci]
 description = "CI Build"
@@ -53,15 +53,15 @@ run = "./mvnw install -DskipTests -Dcoverage.skip=true"
 # Shared lint tasks from flint (https://github.com/grafana/flint)
 [tasks."lint:super-linter"]
 description = "Run Super-Linter on the repository"
-file = "https://raw.githubusercontent.com/grafana/flint/986a4ca33894e67ac54363fe9c814432ffd6dd9b/tasks/lint/super-linter.sh" # v0.4.0
+file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/super-linter.sh" # v0.5.0
 
 [tasks."lint:links"]
 description = "Lint links"
-file = "https://raw.githubusercontent.com/grafana/flint/986a4ca33894e67ac54363fe9c814432ffd6dd9b/tasks/lint/links.sh" # v0.4.0
+file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/links.sh" # v0.5.0
 
 [tasks."lint:renovate-deps"]
 description = "Verify renovate-tracked-deps.json is up to date"
-file = "https://raw.githubusercontent.com/grafana/flint/986a4ca33894e67ac54363fe9c814432ffd6dd9b/tasks/lint/renovate-deps.py" # v0.4.0
+file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/renovate-deps.py" # v0.5.0
 
 [tasks."lint"]
 description = "Run all lints"


### PR DESCRIPTION
## Summary

- Update flint from v0.4.0 to v0.5.0
- Switch from full Super-Linter image to the slim variant (~2 GB smaller), which excludes Rust, .NET/C#, PowerShell, and ARM template linters that this project doesn't use

## Test plan

- [x] `mise run lint` passes locally