### PR TITLE
chore(deps): update dependency grafana/flint to v0.6.0

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -12,11 +12,6 @@ include_fragments = true
 base_url = "https://prometheus.github.io"
 exclude_path = ["docs/themes"]
 
-remap = [
-  # workaround for https://github.com/lycheeverse/lychee/issues/1729
-  "https://github.com/(.*?)/(.*?)/blob/(.*?)/(.*#.*)$ https://raw.githubusercontent.com/$1/$2/$3/$4"
-]
-
 exclude = [
   # excluding links to pull requests and issues is done for performance
   "^https://github.com/prometheus/client_java/(issues|pull)/\\d+$",

--- a/mise.toml
+++ b/mise.toml
@@ -53,15 +53,15 @@ run = "./mvnw install -DskipTests -Dcoverage.skip=true"
 # Shared lint tasks from flint (https://github.com/grafana/flint)
 [tasks."lint:super-linter"]
 description = "Run Super-Linter on the repository"
-file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/super-linter.sh" # v0.5.0
+file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/super-linter.sh" # v0.6.0
 
 [tasks."lint:links"]
 description = "Lint links"
-file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/links.sh" # v0.5.0
+file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/links.sh" # v0.6.0
 
 [tasks."lint:renovate-deps"]
 description = "Verify renovate-tracked-deps.json is up to date"
-file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/renovate-deps.py" # v0.5.0
+file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/renovate-deps.py" # v0.6.0
 
 [tasks."lint"]
 description = "Run all lints"


### PR DESCRIPTION
## Summary
- Update flint from v0.5.0 to v0.6.0
- Remove lychee `remap` workaround for [lychee#1729](https://github.com/lycheeverse/lychee/issues/1729) — flint v0.6.0 now handles GitHub fragment URL remaps natively in `links.sh`

## Test plan
- [ ] CI lint checks pass with updated flint tasks
- [ ] Link checking works correctly without the local remap rule