### PR TITLE
ci(release-please): fix footer not appearing on release PRs

### DIFF
--- a/.github/config/release-please-config.json
+++ b/.github/config/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": false,
   "pull-request-footer": "> [!IMPORTANT]\n> Close and reopen this PR to trigger CI checks.",
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary
- `pull-request-footer` was not being applied to release PRs because
  release-please defaults `separatePullRequests` to `true` for
  single-package configs, which skips the Merge plugin responsible for
  applying the footer
- Setting `separate-pull-requests: false` forces the Merge plugin to run

## Context
- This is a workaround for an upstream bug in release-please where
  `pull-request-footer` is silently ignored for single-package repos
- Affects both regular release PRs and Java SNAPSHOT PRs
- Same issue exists in grafana/flint and likely any single-package repo
  using `pull-request-footer`

## Test plan
- [ ] After merging, verify PR #1896 gets updated with the footer on
  the next release-please run