### PR TITLE
Bump flint to v0.7.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -53,15 +53,15 @@ run = "./mvnw install -DskipTests -Dcoverage.skip=true"
 # Shared lint tasks from flint (https://github.com/grafana/flint)
 [tasks."lint:super-linter"]
 description = "Run Super-Linter on the repository"
-file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/super-linter.sh" # v0.6.0
+file = "https://raw.githubusercontent.com/grafana/flint/8822bdc543f28f2c7dd1f697af4df6d89768c507/tasks/lint/super-linter.sh" # v0.7.0
 
 [tasks."lint:links"]
 description = "Lint links"
-file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/links.sh" # v0.6.0
+file = "https://raw.githubusercontent.com/grafana/flint/8822bdc543f28f2c7dd1f697af4df6d89768c507/tasks/lint/links.sh" # v0.7.0
 
 [tasks."lint:renovate-deps"]
 description = "Verify renovate-tracked-deps.json is up to date"
-file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/renovate-deps.py" # v0.6.0
+file = "https://raw.githubusercontent.com/grafana/flint/8822bdc543f28f2c7dd1f697af4df6d89768c507/tasks/lint/renovate-deps.py" # v0.7.0
 
 [tasks."lint"]
 description = "Run all lints"


### PR DESCRIPTION
## Summary
- Bump flint from v0.6.0 to v0.7.0

New in v0.7.0: global handling of GitHub line-number anchors (`#L123`, `#L10-L20`) and issue comment fragments (`#issuecomment-*`) in link checks — these no longer need exclusions in `lychee.toml`.

## Test plan
- [ ] CI lint passes