### PR TITLE
fix: reduce lychee retries to avoid compounding GitHub 429s

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -2,8 +2,8 @@
 # See https://lychee.cli.rs/config/
 
 timeout = 30
-retry_wait_time = 5
-max_retries = 6
+retry_wait_time = 10
+max_retries = 2
 max_concurrency = 4
 
 # Check link anchors


### PR DESCRIPTION
## Summary

- Reduce `max_retries` from 6 to 2 and increase `retry_wait_time` from 5s to 10s
- 6 retries with 5s wait compounds 429 rate limiting from GitHub — many rapid retries keep triggering rate limits
- Fewer retries with longer wait between them is more effective at recovering from 429s

## Test plan

- [ ] Link check CI workflow passes without hitting sustained 429 errors