### PR TITLE
fix: use /tree/ instead of /blob/ for directory URL

### DIFF
--- a/docs/content/otel/tracing.md
+++ b/docs/content/otel/tracing.md
@@ -56,7 +56,7 @@ Exemplars are only selected every
 [`minRetentionPeriodSeconds`]({{< relref "../config/config.md#exemplar-properties" >}}) seconds.
 
 Here's an example of how to configure OpenTelemetry's
-[tail sampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/tailsamplingprocessor/) <!-- editorconfig-checker-disable-line -->
+[tail sampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor/) <!-- editorconfig-checker-disable-line -->
 to sample all Spans marked with `exemplar="true"`, and then discard 90% of the traces:
 
 ```yaml


### PR DESCRIPTION
## Summary
- Fix tail sampling processor link in `docs/content/otel/tracing.md` to use `/tree/` instead of `/blob/`
- The link points to a directory, not a file. GitHub redirects `/blob/` → `/tree/` (301), but link checkers that remap to `raw.githubusercontent.com` get 400 for directories

## Test plan
- [ ] Link checker passes