### PR TITLE
chore: use default versioning for release-please

### DIFF
--- a/.github/config/release-please-config.json
+++ b/.github/config/release-please-config.json
@@ -5,7 +5,6 @@
   "packages": {
     ".": {
       "release-type": "java",
-      "versioning": "always-bump-patch",
       "extra-files": [
         "prometheus-metrics-parent/pom.xml",
         "integration-tests/it-spring-boot-smoke-test/pom.xml"


### PR DESCRIPTION
## Summary
- Remove `always-bump-patch` from release-please config so version bumps follow conventional commits (feat → minor, fix → patch)
- This fixes the broken release-please PR #1896 which had an empty diff and generic title due to version mismatch

## Context
The previous `always-bump-patch` setting conflicted with the manual `1.6.0-SNAPSHOT` bump, causing release-please to get stuck. With default versioning, release-please will correctly propose `1.6.0` based on the `feat:` commits since `1.5.0`.

## Test plan
- [ ] After merge, verify release-please creates a new PR with correct version and changelog