### PR TITLE
feat: OM2 writer outputs names as provided, no suffix appending

### DIFF
--- a/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriter.java
+++ b/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriter.java
@@ -296,10 +296,10 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
   private void writeInfo(Writer writer, InfoSnapshot snapshot, EscapingScheme scheme)
       throws IOException {
     MetricMetadata metadata = snapshot.getMetadata();
-    // OM2 spec: Info MetricFamily name MUST end in _info
+    // OM2 spec: Info MetricFamily name MUST end in _info.
+    // In OM2, TYPE/HELP use the same name as the data lines.
     String infoName = ensureSuffix(getExpositionBaseMetadataName(metadata, scheme), "_info");
-    String baseName = removeSuffix(infoName, "_info");
-    writeMetadataWithName(writer, baseName, "info", metadata);
+    writeMetadataWithName(writer, infoName, "info", metadata);
     for (InfoSnapshot.InfoDataPointSnapshot data : snapshot.getDataPoints()) {
       writeNameAndLabels(writer, infoName, null, data.getLabels(), scheme);
       writer.write("1");
@@ -487,12 +487,5 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
       return name;
     }
     return name + suffix;
-  }
-
-  private static String removeSuffix(String name, String suffix) {
-    if (name.endsWith(suffix)) {
-      return name.substring(0, name.length() - suffix.length());
-    }
-    return name;
   }
 }

--- a/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriterTest.java
+++ b/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriterTest.java
@@ -207,7 +207,7 @@ class OpenMetrics2TextFormatWriterTest {
   }
 
   @Test
-  void testOutputIdenticalToOM1ForInfo() throws IOException {
+  void testInfoHelpNameMatchesMeterName() throws IOException {
     MetricSnapshots snapshots =
         MetricSnapshots.of(
             InfoSnapshot.builder()
@@ -219,10 +219,15 @@ class OpenMetrics2TextFormatWriterTest {
                         .build())
                 .build());
 
-    String om1Output = writeWithOM1(snapshots);
     String om2Output = writeWithOM2(snapshots);
 
-    assertThat(om2Output).isEqualTo(om1Output);
+    // OM2: TYPE/HELP use the full name including _info (help name == meter name)
+    assertThat(om2Output)
+        .isEqualTo(
+            "# TYPE my_info info\n"
+                + "# HELP my_info Test info\n"
+                + "my_info{platform=\"linux\",version=\"1.0\"} 1\n"
+                + "# EOF\n");
   }
 
   @Test


### PR DESCRIPTION
## Summary

The OM2 writer now uses `expositionBaseName` directly instead of
appending `_total` (counters) or unit suffixes. The `_info` suffix
is enforced per the OM2 spec (MUST). Part of #1942.

### Key table

| User provides | OM1 | OM2 |
|---|---|---|
| `Counter("events")` | `events_total` | `events` |
| `Counter("events_total")` | `events_total` | `events_total` |
| `Counter("req").unit(BYTES)` | `req_bytes_total` | `req_bytes` |
| `Counter("req_bytes").unit(BYTES)` | `req_bytes_total` | `req_bytes` |
| `Gauge("events_total")` | `events_total` | `events_total` |
| `Info("target")` | `target_info` | `target_info` |

### PR stack

1. Core model + OM1/protobuf writers (#1955)
2. OTel `preserve_names` (independent)
3. **This PR** — OM2 writer no-suffix

## Test plan

- [x] `mise run compile` passes
- [x] OM2-specific tests verify no `_total`/unit suffix appending
- [x] `_info` suffix enforcement tested

Part of #1912.

