### PR TITLE
Fix flaky protobuf debug format test when nanos is zero

### DIFF
--- a/integration-tests/it-exporter/it-exporter-test/src/test/java/io/prometheus/metrics/it/exporter/test/ExporterIT.java
+++ b/integration-tests/it-exporter/it-exporter-test/src/test/java/io/prometheus/metrics/it/exporter/test/ExporterIT.java
@@ -113,8 +113,7 @@ abstract class ExporterIT extends ExporterTest {
       // Protobuf text format omits fields with value 0, so nanos may be absent.
       // Replace the nanos placeholder with a regex-friendly marker before quoting.
       String withOptionalNanos =
-          expectedResponse.replace(
-              "\n      nanos: <CREATED_TIMESTAMP_NANOS>", "<OPTIONAL_NANOS>");
+          expectedResponse.replace("\n      nanos: <CREATED_TIMESTAMP_NANOS>", "<OPTIONAL_NANOS>");
       String pattern =
           Pattern.quote(withOptionalNanos)
               .replace("<CREATED_TIMESTAMP_SECONDS>", "\\E\\d+\\Q")


### PR DESCRIPTION
## Summary
- Protobuf3 text format omits fields with default (zero) values
- When `created_timestamp` lands on an exact second boundary, the `nanos` field is absent
- The test pattern now makes the `nanos` line optional

## Test plan
- [ ] CI passes (specifically Java 25 integration tests)