### PR TITLE
ci: add native linting tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -50,22 +50,21 @@ description = "build all modules without tests"
 run = "./mvnw install -DskipTests -Dcoverage.skip=true"
 
 # Shared lint tasks from flint (https://github.com/grafana/flint)
-# TODO: update SHA after grafana/flint#107 and grafana/flint#112 merge
 [tasks."lint:super-linter"]
 description = "Run Super-Linter on the repository"
-file = "https://raw.githubusercontent.com/grafana/flint/84e2d760286dead4e503315f9483a44fe872ee85/tasks/lint/super-linter.sh" # v0.8.0
+file = "https://raw.githubusercontent.com/grafana/flint/8a39d96e17327c54974623b252eb5260d67ed68a/tasks/lint/super-linter.sh" # v0.9.1
 
 [tasks."lint:links"]
 description = "Lint links"
-file = "https://raw.githubusercontent.com/grafana/flint/84e2d760286dead4e503315f9483a44fe872ee85/tasks/lint/links.sh" # v0.8.0
+file = "https://raw.githubusercontent.com/grafana/flint/8a39d96e17327c54974623b252eb5260d67ed68a/tasks/lint/links.sh" # v0.9.1
 
 [tasks."lint:renovate-deps"]
 description = "Verify renovate-tracked-deps.json is up to date"
-file = "https://raw.githubusercontent.com/grafana/flint/84e2d760286dead4e503315f9483a44fe872ee85/tasks/lint/renovate-deps.py" # v0.8.0
+file = "https://raw.githubusercontent.com/grafana/flint/8a39d96e17327c54974623b252eb5260d67ed68a/tasks/lint/renovate-deps.py" # v0.9.1
 
 [tasks."setup:native-lint-tools"]
 description = "Install native lint tools matching the pinned super-linter version"
-file = "https://raw.githubusercontent.com/grafana/flint/84e2d760286dead4e503315f9483a44fe872ee85/tasks/setup/native-lint-tools.sh" # v0.8.0
+file = "https://raw.githubusercontent.com/grafana/flint/8a39d96e17327c54974623b252eb5260d67ed68a/tasks/setup/native-lint-tools.sh" # v0.9.1
 
 [tasks."lint:spotless"]
 description = "Check Java formatting with Spotless"


### PR DESCRIPTION
## Summary

- Add `lint:spotless` task for Java format checking
- Add `lint:fast` grouping task (super-linter + links + bom + example-poms + spotless)
- Add `native-lint` meta-task (`NATIVE=true`, no container needed)
- Switch `pre-commit` to `NATIVE=true mise run lint:fast`

## Blocked on

- https://github.com/grafana/flint/pull/107 — `NATIVE` env var support for `lint:super-linter`
- https://github.com/grafana/flint/pull/112 — v8.5.0 version mapping for `setup:native-lint-tools`

After those merge, update the flint SHA in `mise.toml`.

## Test plan

- [ ] `mise run native-lint` passes after flint update
- [ ] `mise run lint` still works in CI (container mode)
- [ ] Pre-commit hook works with native linting