### PR TITLE
ci: exclude CHANGELOG.md from linting

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -10,7 +10,7 @@ max_concurrency = 4
 include_fragments = true
 
 base_url = "https://prometheus.github.io"
-exclude_path = ["docs/themes"]
+exclude_path = ["docs/themes", "CHANGELOG.md"]
 
 exclude = [
   # excluding links to pull requests and issues is done for performance

--- a/.github/config/super-linter.env
+++ b/.github/config/super-linter.env
@@ -1,4 +1,4 @@
-FILTER_REGEX_EXCLUDE=mvnw|src/main/generated/.*|docs/themes/.*|keystore.pkcs12|.*.java|prometheus-metrics-exporter-opentelemetry-shaded/pom.xml|CODE_OF_CONDUCT.md|CLAUDE.md
+FILTER_REGEX_EXCLUDE=mvnw|src/main/generated/.*|docs/themes/.*|keystore.pkcs12|.*.java|prometheus-metrics-exporter-opentelemetry-shaded/pom.xml|CODE_OF_CONDUCT.md|CLAUDE.md|CHANGELOG.md
 IGNORE_GITIGNORED_FILES=true
 JAVA_FILE_NAME=google_checks.xml
 LOG_LEVEL=ERROR


### PR DESCRIPTION
## Summary

- Exclude `CHANGELOG.md` from super-linter (editorconfig + prettier)
- Exclude `CHANGELOG.md` from lychee link checker

`CHANGELOG.md` is generated by release-please and contains long lines
and compare URLs that 404 until the release tag is published.

Fixes lint on [#1962](https://github.com/prometheus/client_java/pull/1962).

## Test plan

- [ ] Lint CI passes on this PR
- [ ] Re-run lint on #1962 after this merges