### PR TITLE
chore: update benchmark results

### DIFF
--- a/.mise/tasks/update_benchmarks.py
+++ b/.mise/tasks/update_benchmarks.py
@@ -53,7 +53,7 @@ def run_cmd(cmd: List[str], cwd: Optional[str] = None) -> str:
         # Stream lines as they appear and capture them for returning
         for line in proc.stdout:
             # Print immediately so callers (and CI) can observe progress
-            print(line, end="")
+            print(line, end="", flush=True)
             output_lines.append(line)
         proc.wait()
     except KeyboardInterrupt:

--- a/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/CounterBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/CounterBenchmark.java
@@ -22,16 +22,16 @@ import org.openjdk.jmh.annotations.Threads;
  *
  * <pre>
  * Benchmark                                             Mode  Cnt       Score       Error  Units
- * CounterBenchmark.codahaleIncNoLabels                 thrpt   25  144632.191 ±  2778.333  ops/s
- * CounterBenchmark.openTelemetryAdd                    thrpt   25    2165.775 ±   168.554  ops/s
- * CounterBenchmark.openTelemetryInc                    thrpt   25    1940.143 ±    86.223  ops/s
- * CounterBenchmark.openTelemetryIncNoLabels            thrpt   25    1880.089 ±   192.395  ops/s
- * CounterBenchmark.prometheusAdd                       thrpt   25  122427.789 ±  1377.485  ops/s
- * CounterBenchmark.prometheusInc                       thrpt   25  183603.131 ±  2812.874  ops/s
- * CounterBenchmark.prometheusNoLabelsInc               thrpt   25  169733.499 ±   670.495  ops/s
- * CounterBenchmark.simpleclientAdd                     thrpt   25   13771.151 ±    77.473  ops/s
- * CounterBenchmark.simpleclientInc                     thrpt   25   14255.342 ±   117.339  ops/s
- * CounterBenchmark.simpleclientNoLabelsInc             thrpt   25   14175.465 ±    56.575  ops/s
+ * CounterBenchmark.codahaleIncNoLabels                 thrpt   25  141585.607 ±  4512.937  ops/s
+ * CounterBenchmark.openTelemetryAdd                    thrpt   25    1734.254 ±    93.992  ops/s
+ * CounterBenchmark.openTelemetryInc                    thrpt   25    1824.626 ±   119.822  ops/s
+ * CounterBenchmark.openTelemetryIncNoLabels            thrpt   25    1875.878 ±   130.215  ops/s
+ * CounterBenchmark.prometheusAdd                       thrpt   25  121522.492 ±  1724.943  ops/s
+ * CounterBenchmark.prometheusInc                       thrpt   25  180139.585 ±  3367.156  ops/s
+ * CounterBenchmark.prometheusNoLabelsInc               thrpt   25  166823.346 ±  2915.374  ops/s
+ * CounterBenchmark.simpleclientAdd                     thrpt   25   13040.009 ±   217.831  ops/s
+ * CounterBenchmark.simpleclientInc                     thrpt   25   14268.840 ±   127.324  ops/s
+ * CounterBenchmark.simpleclientNoLabelsInc             thrpt   25   13804.127 ±   163.815  ops/s
  * </pre>
  *
  * Prometheus counters are faster than counters of other libraries. For example, incrementing a

--- a/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/HistogramBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/HistogramBenchmark.java
@@ -21,11 +21,11 @@ import org.openjdk.jmh.annotations.Threads;
  *
  * <pre>
  * Benchmark                                             Mode  Cnt       Score       Error  Units
- * HistogramBenchmark.openTelemetryClassic              thrpt   25     968.178 ±    28.582  ops/s
- * HistogramBenchmark.openTelemetryExponential          thrpt   25     836.000 ±    17.709  ops/s
- * HistogramBenchmark.prometheusClassic                 thrpt   25    7010.393 ±   683.782  ops/s
- * HistogramBenchmark.prometheusNative                  thrpt   25    5040.572 ±   284.433  ops/s
- * HistogramBenchmark.simpleclient                      thrpt   25   10485.462 ±    41.265  ops/s
+ * HistogramBenchmark.openTelemetryClassic              thrpt   25     966.937 ±    46.984  ops/s
+ * HistogramBenchmark.openTelemetryExponential          thrpt   25     816.254 ±    28.033  ops/s
+ * HistogramBenchmark.prometheusClassic                 thrpt   25   15468.490 ±   828.441  ops/s
+ * HistogramBenchmark.prometheusNative                  thrpt   25    7452.050 ±   282.636  ops/s
+ * HistogramBenchmark.simpleclient                      thrpt   25   10082.382 ±   245.428  ops/s
  * </pre>
  *
  * The simpleclient (i.e. client_java version 0.16.0 and older) histograms perform about the same as

--- a/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
@@ -24,10 +24,10 @@ import org.openjdk.jmh.annotations.State;
  *
  * <pre>
  * Benchmark                                             Mode  Cnt       Score       Error  Units
- * TextFormatUtilBenchmark.openMetricsWriteToByteArray  thrpt   25  826847.708 ± 10941.611  ops/s
- * TextFormatUtilBenchmark.openMetricsWriteToNull       thrpt   25  847756.101 ±  5299.128  ops/s
- * TextFormatUtilBenchmark.prometheusWriteToByteArray   thrpt   25  874804.601 ±  9730.060  ops/s
- * TextFormatUtilBenchmark.prometheusWriteToNull        thrpt   25  910782.719 ± 17617.167  ops/s
+ * TextFormatUtilBenchmark.openMetricsWriteToByteArray  thrpt   25  748557.302 ± 22925.735  ops/s
+ * TextFormatUtilBenchmark.openMetricsWriteToNull       thrpt   25  727876.401 ± 31520.283  ops/s
+ * TextFormatUtilBenchmark.prometheusWriteToByteArray   thrpt   25  768419.214 ± 22785.134  ops/s
+ * TextFormatUtilBenchmark.prometheusWriteToNull        thrpt   25  796486.637 ± 11456.297  ops/s
  * </pre>
  */
 public class TextFormatUtilBenchmark {


### PR DESCRIPTION
## Summary
- Updated benchmark numbers after latest run
- Notable: `prometheusClassic` histogram throughput doubled from ~7k to ~15.4k ops/s, `prometheusNative` improved from ~5k to ~7.4k ops/s
- Added `flush=True` to benchmark script print for real-time output during runs

## Test plan
- [ ] CI passes (no functional code changes)