### PR TITLE
fix: Relax metric name validation in Dropwizard5

### DIFF
--- a/prometheus-metrics-instrumentation-dropwizard5/src/main/java/io/prometheus/metrics/instrumentation/dropwizard5/labels/GraphiteNamePattern.java
+++ b/prometheus-metrics-instrumentation-dropwizard5/src/main/java/io/prometheus/metrics/instrumentation/dropwizard5/labels/GraphiteNamePattern.java
@@ -9,13 +9,16 @@ import java.util.regex.Pattern;
 
 /**
  * GraphiteNamePattern is initialised with a simplified glob pattern that only allows '*' as special
- * character. Examples of valid patterns:
+ * character. Accepts a broad range of metric name patterns including single-level names, names with
+ * underscores, hyphens, and colons. Examples of valid patterns:
  *
  * <ul>
  *   <li>org.test.controller.gather.status.400
  *   <li>org.test.controller.gather.status.*
  *   <li>org.test.controller.*.status.*
  *   <li>*.test.controller.*.status.*
+ *   <li>app_metric_some_count
+ *   <li>io.dropwizard.jetty.MutableServletContextHandler.*-requests
  * </ul>
  *
  * <p>It contains logic to match a metric name and to extract named parameters from it.
@@ -32,6 +35,10 @@ class GraphiteNamePattern {
    * @param pattern The glob style pattern to be used.
    */
   GraphiteNamePattern(String pattern) throws IllegalArgumentException {
+    if (pattern.contains("**")) {
+      throw new IllegalArgumentException(
+          String.format("Provided pattern [%s] must not contain '**' (double-star glob)", pattern));
+    }
     if (!VALIDATION_PATTERN.matcher(pattern).matches()) {
       throw new IllegalArgumentException(
           String.format("Provided pattern [%s] does not matches [%s]", pattern, METRIC_GLOB_REGEX));

--- a/prometheus-metrics-instrumentation-dropwizard5/src/main/java/io/prometheus/metrics/instrumentation/dropwizard5/labels/MapperConfig.java
+++ b/prometheus-metrics-instrumentation-dropwizard5/src/main/java/io/prometheus/metrics/instrumentation/dropwizard5/labels/MapperConfig.java
@@ -16,11 +16,14 @@ import javax.annotation.Nullable;
  * and new labels based on this config.
  */
 public final class MapperConfig {
-  // each part of the metric name between dots
-  private static final String METRIC_PART_REGEX = "[a-zA-Z_0-9](-?[a-zA-Z0-9_])+";
-  // Simplified GLOB: we can have "*." at the beginning and "*" only at the end
+  // Each part of the metric name between dots. Accepts letters, digits, underscores, hyphens,
+  // colons, and glob wildcards (*) to support a broad range of metric naming conventions.
+  private static final String METRIC_PART_REGEX = "[a-zA-Z_0-9*][a-zA-Z0-9_:\\-*]*";
+  // Simplified GLOB: accepts single-level names, dot-separated names, and glob patterns with '*'.
+  // The pattern requires at least one non-empty segment and does not allow empty segments (double
+  // dots) or empty/whitespace-only strings. The '**' glob is rejected separately in validateMatch.
   static final String METRIC_GLOB_REGEX =
-      "^(\\*\\.|" + METRIC_PART_REGEX + "\\.)+(\\*|" + METRIC_PART_REGEX + ")$";
+      "^(" + METRIC_PART_REGEX + ")(\\." + METRIC_PART_REGEX + ")*$";
   // Labels validation.
   private static final String LABEL_REGEX = "^[a-zA-Z_][a-zA-Z0-9_]+$";
   private static final Pattern MATCH_EXPRESSION_PATTERN = Pattern.compile(METRIC_GLOB_REGEX);
@@ -109,6 +112,10 @@ public final class MapperConfig {
   }
 
   private void validateMatch(String match) {
+    if (match.contains("**")) {
+      throw new IllegalArgumentException(
+          String.format("Match expression [%s] must not contain '**' (double-star glob)", match));
+    }
     if (!MATCH_EXPRESSION_PATTERN.matcher(match).matches()) {
       throw new IllegalArgumentException(
           String.format(

--- a/prometheus-metrics-instrumentation-dropwizard5/src/main/java/io/prometheus/metrics/instrumentation/dropwizard5/labels/MapperConfig.java
+++ b/prometheus-metrics-instrumentation-dropwizard5/src/main/java/io/prometheus/metrics/instrumentation/dropwizard5/labels/MapperConfig.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
 public final class MapperConfig {
   // Each part of the metric name between dots. Accepts letters, digits, underscores, hyphens,
   // colons, and glob wildcards (*) to support a broad range of metric naming conventions.
-  private static final String METRIC_PART_REGEX = "[a-zA-Z_0-9*][a-zA-Z0-9_:\\-*]*";
+  private static final String METRIC_PART_REGEX = "[a-zA-Z_0-9*][a-zA-Z0-9_:*-]*";
   // Simplified GLOB: accepts single-level names, dot-separated names, and glob patterns with '*'.
   // The pattern requires at least one non-empty segment and does not allow empty segments (double
   // dots) or empty/whitespace-only strings. The '**' glob is rejected separately in validateMatch.

--- a/prometheus-metrics-instrumentation-dropwizard5/src/test/java/io/prometheus/metrics/instrumentation/dropwizard5/labels/GraphiteNamePatternTest.java
+++ b/prometheus-metrics-instrumentation-dropwizard5/src/test/java/io/prometheus/metrics/instrumentation/dropwizard5/labels/GraphiteNamePatternTest.java
@@ -17,18 +17,12 @@ class GraphiteNamePatternTest {
     List<String> invalidPatterns =
         Arrays.asList(
             "",
-            "a",
-            "1org",
             "1org.",
             "org.",
             "org.**",
-            "org.**",
-            "org.company-",
             "org.company-.",
-            "org.company-*",
             "org.company.**",
             "org.company.**-",
-            "org.com*pany.*",
             "org.test.contr.oller.gather.status..400",
             "org.test.controller.gather.status..400");
     for (String pattern : invalidPatterns) {
@@ -47,7 +41,22 @@ class GraphiteNamePatternTest {
             "org.test.controller.*.status.*",
             "*.test.controller.*.status.*",
             "*.test.controller-1.*.status.*",
-            "*.amazing-test.controller-1.*.status.*");
+            "*.amazing-test.controller-1.*.status.*",
+            // Single-level names (previously rejected, fixes #461)
+            "a",
+            "1org",
+            "app_metric_some_count",
+            // Names with colons (fixes #645)
+            "my:metric:name",
+            "org.company:metric.*",
+            // Names with hyphens at boundaries
+            "org.company-",
+            "org.company-*",
+            // Embedded glob in segment (fixes #518)
+            "org.com*pany.*",
+            "io.dropwizard.jetty.MutableServletContextHandler.*-requests",
+            // Standalone glob
+            "*");
     for (String pattern : validPatterns) {
       new GraphiteNamePattern(pattern);
     }

--- a/prometheus-metrics-instrumentation-dropwizard5/src/test/java/io/prometheus/metrics/instrumentation/dropwizard5/labels/MapperConfigTest.java
+++ b/prometheus-metrics-instrumentation-dropwizard5/src/test/java/io/prometheus/metrics/instrumentation/dropwizard5/labels/MapperConfigTest.java
@@ -42,6 +42,52 @@ class MapperConfigTest {
   }
 
   @Test
+  void setMatch_WHEN_SingleLevelName_AllGood() {
+    final MapperConfig mapperConfig = new MapperConfig();
+    mapperConfig.setMatch("app_metric_some_count");
+    assertThat(mapperConfig.getMatch()).isEqualTo("app_metric_some_count");
+  }
+
+  @Test
+  void setMatch_WHEN_NameWithColons_AllGood() {
+    final MapperConfig mapperConfig = new MapperConfig();
+    mapperConfig.setMatch("my:metric:name");
+    assertThat(mapperConfig.getMatch()).isEqualTo("my:metric:name");
+  }
+
+  @Test
+  void setMatch_WHEN_EmbeddedGlobInSegment_AllGood() {
+    final MapperConfig mapperConfig = new MapperConfig();
+    mapperConfig.setMatch("io.dropwizard.jetty.MutableServletContextHandler.*-requests");
+    assertThat(mapperConfig.getMatch())
+        .isEqualTo("io.dropwizard.jetty.MutableServletContextHandler.*-requests");
+  }
+
+  @Test
+  void setMatch_WHEN_DoubleStarGlob_ThrowException() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new MapperConfig().setMatch("org.**"));
+  }
+
+  @Test
+  void setMatch_WHEN_EmptyString_ThrowException() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new MapperConfig().setMatch(""));
+  }
+
+  @Test
+  void setMatch_WHEN_TrailingDot_ThrowException() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new MapperConfig().setMatch("org.company."));
+  }
+
+  @Test
+  void setMatch_WHEN_DoubleDot_ThrowException() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> new MapperConfig().setMatch("org..company"));
+  }
+
+  @Test
   void toString_WHEN_EmptyConfig_AllGood() {
     final MapperConfig mapperConfig = new MapperConfig();
     assertThat(mapperConfig).hasToString("MapperConfig{match=null, name=null, labels={}}");


### PR DESCRIPTION
Decided to revisit a very old PR of mine that addressed an issue that seems to reoccur periodically for others. 

## Changes
- Relaxes overly strict `METRIC_GLOB_REGEX` in `MapperConfig`/`GraphiteNamePattern` to accept a broader range of metric name patterns
- The `CustomMappingSampleBuilder` can now remap metrics with underscores, colons, hyphens, and single-level names
- Still rejects clearly invalid inputs (empty strings, double-star globs, trailing/double dots)

## Fixes
- #461: Cannot match a Graphite metric with only one level
- #518: Custom metric name remapping fails for non-Graphite-style names
- #645: MapperConfig does not allow `:` in regex

The validation was originally designed for Graphite bridge metrics but is too restrictive for `CustomMappingSampleBuilder` which needs to handle arbitrary Dropwizard metric names.

@fstab @dhoard @zeitlinger @jaydeluca when you have a chance would appreciate your review :) 