### PR TITLE
fix: handle multi-type Accept headers in parseOpenMetricsVersion

### DIFF
--- a/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/ExpositionFormats.java
+++ b/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/ExpositionFormats.java
@@ -108,14 +108,19 @@ public class ExpositionFormats {
     if (acceptHeader == null) {
       return null;
     }
-    for (String mediaType : acceptHeader.split(";")) {
-      String[] tokens = mediaType.split("=");
-      if (tokens.length == 2) {
-        String key = tokens[0].trim();
-        String value = tokens[1].trim();
-        if (key.equals("version")) {
-          return value;
+    for (String mediaType : acceptHeader.split(",")) {
+      if (mediaType.contains("application/openmetrics-text")) {
+        for (String param : mediaType.split(";")) {
+          String[] tokens = param.split("=");
+          if (tokens.length == 2) {
+            String key = tokens[0].trim();
+            String value = tokens[1].trim();
+            if (key.equals("version")) {
+              return value;
+            }
+          }
         }
+        return null;
       }
     }
     return null;

--- a/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
+++ b/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
@@ -232,6 +232,37 @@ class ExpositionFormatsTest {
   }
 
   @Test
+  void testOM2ContentNegotiationMultiTypeAcceptHeaderWithoutOMVersion() {
+    // When the Accept header has multiple media types and only text/plain has a version,
+    // the openmetrics type should be treated as having no version (use OM1).
+    PrometheusProperties props =
+        PrometheusProperties.builder()
+            .openMetrics2Properties(
+                OpenMetrics2Properties.builder().enabled(true).contentNegotiation(true).build())
+            .build();
+    ExpositionFormats formats = ExpositionFormats.init(props);
+    ExpositionFormatWriter writer =
+        formats.findWriter("application/openmetrics-text, text/plain; version=0.0.4");
+    assertThat(writer).isInstanceOf(OpenMetricsTextFormatWriter.class);
+  }
+
+  @Test
+  void testOM2ContentNegotiationMultiTypeAcceptHeaderWithOMVersion() {
+    // When the Accept header has multiple media types and openmetrics has version=2.0.0,
+    // the OM2 writer should be selected.
+    PrometheusProperties props =
+        PrometheusProperties.builder()
+            .openMetrics2Properties(
+                OpenMetrics2Properties.builder().enabled(true).contentNegotiation(true).build())
+            .build();
+    ExpositionFormats formats = ExpositionFormats.init(props);
+    ExpositionFormatWriter writer =
+        formats.findWriter(
+            "application/openmetrics-text; version=2.0.0, text/plain; version=0.0.4");
+    assertThat(writer).isInstanceOf(OpenMetrics2TextFormatWriter.class);
+  }
+
+  @Test
   void testCounterComplete() throws IOException {
     String openMetricsText =
         "# TYPE service:time_seconds counter\n"


### PR DESCRIPTION
## Summary
- Fix bug where `parseOpenMetricsVersion` could pick up `version` parameters from unrelated media types in multi-type Accept headers (e.g. `application/openmetrics-text, text/plain; version=0.0.4`)
- Split Accept header by `,` first to isolate individual media types before parsing parameters
- Add two test cases covering multi-type Accept headers with and without an explicit openmetrics version

## Test plan
- [x] All 55 existing `ExpositionFormatsTest` tests pass
- [x] New test: multi-type header where only `text/plain` has version → OM1 writer selected
- [x] New test: multi-type header where openmetrics has `version=2.0.0` → OM2 writer selected