### PR TITLE
fix: pin grafana/otel-lgtm to 0.7.2 in OATs acceptance test

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -139,7 +139,7 @@
       "protoc",
       "ubi:google/google-java-format"
     ],
-    "regex": ["ghcr.io/super-linter/super-linter", "grafana/flint"]
+    "regex": ["ghcr.io/super-linter/super-linter", "grafana/docker-otel-lgtm", "grafana/flint"]
   },
   "mvnw": {
     "maven-wrapper": ["maven-wrapper"]

--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,8 @@ protoc = "34.0"
 RENOVATE_TRACKED_DEPS_EXCLUDE="github-actions,github-runners"
 # renovate: datasource=docker depName=ghcr.io/super-linter/super-linter
 SUPER_LINTER_VERSION="slim-v8.5.0@sha256:857dcc3f0bf5dd065fdeed1ace63394bb2004238a5ef02910ea23d9bcd8fd2b8"
+# renovate: datasource=github-releases depName=grafana/docker-otel-lgtm
+LGTM_VERSION="0.7.2"
 
 [tasks.ci]
 description = "CI Build"
@@ -107,7 +109,7 @@ run = "mise generate git-pre-commit --write --task=pre-commit"
 [tasks.acceptance-test]
 description = "Run OATs acceptance tests"
 depends = "build"
-run = "oats -timeout 5m examples/"
+run = "oats -lgtm-version $LGTM_VERSION -timeout 5m examples/"
 
 [tasks.javadoc]
 description = "Generate Javadoc"


### PR DESCRIPTION
`grafana/otel-lgtm:latest` pointed to `0.7.3` which breaks the
`service_instance_id_check` in the OTel acceptance test. `0.7.2` is
confirmed working.

Pin to `0.7.2` for reproducible builds and add a renovate annotation
so the pin is kept up to date automatically.