### PR TITLE
chore: Add java 8 to test matrix

### DIFF
--- a/.github/workflows/java-version-matrix-tests.yml
+++ b/.github/workflows/java-version-matrix-tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [11, 17, 21, 25]
+        java-version: [8, 11, 17, 21, 25]
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -56,8 +56,8 @@ jobs:
       - name: Rebuild sample apps targeting Java ${{ matrix.java-version }}
         run: |
           cd integration-tests
-          # Note: Jetty 12 and Tomcat 11 require Java 17+, so servlet samples are skipped for Java 11
-          if [ "${{ matrix.java-version }}" = "11" ]; then
+          # Note: Jetty 12 and Tomcat 11 require Java 17+, so servlet samples are skipped for Java 8 & 11
+          if [[ "${{ matrix.java-version }}" == "11" || "${{ matrix.java-version }}" == "8" ]]; then
             MODULES="it-common,it-exporter/it-exporter-httpserver-sample,it-exporter/it-exporter-no-protobuf,it-pushgateway"
           else
             MODULES="it-common,it-exporter/it-exporter-httpserver-sample,it-exporter/it-exporter-servlet-tomcat-sample,it-exporter/it-exporter-servlet-jetty-sample,it-exporter/it-exporter-no-protobuf,it-pushgateway"
@@ -73,7 +73,7 @@ jobs:
         run: |
           cd integration-tests
           # Note: Servlet tests require Java 17+ (due to Jetty 12 and Tomcat 11)
-          if [ "${{ matrix.java-version }}" = "11" ]; then
+          if [[ "${{ matrix.java-version }}" == "11" || "${{ matrix.java-version }}" == "8" ]]; then
             TEST_MODULES="it-exporter/it-no-protobuf-test,it-pushgateway"
           else
             TEST_MODULES="it-exporter/it-exporter-test,it-exporter/it-no-protobuf-test,it-pushgateway"


### PR DESCRIPTION
migrating to flint allows us to get around some limitations we had due to the dependency on spotless, so now we can run our java compatibility integration tests on java 8 🎉 