### PR TITLE
chore: Fix CounterTest created timestamp flake

### DIFF
--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/CounterTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/CounterTest.java
@@ -123,7 +123,7 @@ class CounterTest {
     assertThat(ProtobufUtil.shortDebugString(protobufData))
         .matches(
             "^name: \"my_counter_seconds_total\" type: COUNTER metric \\{ counter \\{ value: 0.0"
-                + " created_timestamp \\{ seconds: \\d+ nanos: \\d+ } } }$");
+                + " created_timestamp \\{ seconds: \\d+( nanos: \\d+)? } } }$");
   }
 
   @Test


### PR DESCRIPTION
## What changed

Relaxed the `CounterTest.testTotalStrippedFromName` protobuf text assertion so `created_timestamp` accepts both forms emitted by protobuf text format:

- `created_timestamp { seconds: ... nanos: ... }`
- `created_timestamp { seconds: ... }`

## Why

This test was flaky when the created timestamp landed exactly on a whole-second boundary. In that case, protobuf text format omits the `nanos` field when it is zero, but the test required `nanos` to always be present.

## Impact

This does not change product behavior. It removes a nondeterministic test failure in CI by matching the actual protobuf output contract more accurately.

## Root cause

The assertion encoded a stronger formatting assumption than protobuf guarantees. `protobuf-java` may omit zero-valued `nanos` in text output.

## Validation

- `./mvnw test -pl prometheus-metrics-core -Dtest=CounterTest#testTotalStrippedFromName -Dcoverage.skip=true -Dcheckstyle.skip=true`
- `mise run build`
