### PR TITLE
chore: fix release workflow dispatch repo resolution

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,5 +29,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >
-          gh workflow run release.yml
+          gh workflow run release.yml --repo "${GITHUB_REPOSITORY}"
           -f tag=${{ steps.release-please.outputs.tag_name }}


### PR DESCRIPTION
## What changed
Pass `--repo "${GITHUB_REPOSITORY}"` to the `gh workflow run release.yml` call in `release-please.yml`.

## Why
The `Release Please` workflow dispatch step runs without a checkout, so `gh` cannot infer the repository from `.git`. The failed run for `v1.6.0` stopped with `fatal: not a git repository` before `release.yml` was dispatched.

## Impact
This allows the existing release workflow to be triggered from the `Release Please` job without adding an unnecessary checkout step.

## Validation
- Inspected the failing Actions job `73146303246` and confirmed the dispatch step was the failure point.
- Verified comparable repositories commonly pass `--repo` explicitly when dispatching workflows from Actions.
- Ran `mise run lint` locally.

## Follow-up
After this lands, `release.yml` can be manually dispatched with `tag=v1.6.0` to publish the existing tag.
