### PR TITLE
fix: Preserve original metric names in OM2 output

### DIFF
--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/OpenMetrics2TextFormatWriterTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/OpenMetrics2TextFormatWriterTest.java
@@ -1,0 +1,118 @@
+package io.prometheus.metrics.core.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.prometheus.metrics.config.EscapingScheme;
+import io.prometheus.metrics.config.OpenMetrics2Properties;
+import io.prometheus.metrics.expositionformats.ExpositionFormatWriter;
+import io.prometheus.metrics.expositionformats.OpenMetrics2TextFormatWriter;
+import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.model.snapshots.Unit;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class OpenMetrics2TextFormatWriterTest {
+
+  @Test
+  void counterPreservesOriginalNameWhenUnitIsConfigured() throws IOException {
+    Counter counter =
+        Counter.builder()
+            .name("my_counter")
+            .unit(Unit.SECONDS)
+            .help("Test counter")
+            .labelNames("method")
+            .build();
+    counter.labelValues("GET").inc(42.0);
+    MetricSnapshots snapshots = MetricSnapshots.of(counter.collect());
+
+    String om1Output = writeWithOM1(snapshots);
+    String om2Output = writeWithOM2(snapshots);
+
+    assertThat(om1Output).contains("my_counter_seconds_total{method=\"GET\"} 42.0");
+    assertThat(om2Output)
+        .contains("# TYPE my_counter counter\n")
+        .contains("# UNIT my_counter seconds\n")
+        .contains("# HELP my_counter Test counter\n")
+        .containsPattern("(?m)^my_counter\\{method=\"GET\"} 42\\.0 st@\\d+\\.\\d{3}$")
+        .doesNotContain("my_counter_seconds");
+  }
+
+  @Test
+  void classicHistogramPreservesOriginalNameWhenUnitIsConfigured() throws IOException {
+    Histogram histogram =
+        Histogram.builder()
+            .name("request_duration")
+            .unit(Unit.SECONDS)
+            .help("Request duration in seconds")
+            .labelNames("path")
+            .classicOnly()
+            .classicUpperBounds(10.0)
+            .build();
+    histogram.labelValues("/hello").observe(3.2);
+    MetricSnapshots snapshots = MetricSnapshots.of(histogram.collect());
+
+    String om1Output = writeWithOM1(snapshots);
+    String om2Output = writeWithOM2(snapshots);
+
+    assertThat(om1Output).contains("request_duration_seconds_bucket");
+    assertThat(om2Output)
+        .contains("# TYPE request_duration histogram\n")
+        .contains("# UNIT request_duration seconds\n")
+        .contains("# HELP request_duration Request duration in seconds\n")
+        .contains("request_duration_bucket{path=\"/hello\",le=\"10.0\"} 1\n")
+        .contains("request_duration_bucket{path=\"/hello\",le=\"+Inf\"} 1\n")
+        .contains("request_duration_count{path=\"/hello\"} 1\n")
+        .contains("request_duration_sum{path=\"/hello\"} 3.2\n")
+        .doesNotContain("request_duration_seconds");
+  }
+
+  @Test
+  void nativeHistogramPreservesOriginalNameWhenUnitIsConfigured() throws IOException {
+    Histogram histogram =
+        Histogram.builder()
+            .name("my.request.duration")
+            .unit(Unit.SECONDS)
+            .help("Request duration in seconds")
+            .labelNames("http.path")
+            .nativeOnly()
+            .build();
+    histogram.labelValues("/hello").observe(3.2);
+    MetricSnapshots snapshots = MetricSnapshots.of(histogram.collect());
+
+    String om2Output = writeWithNativeHistograms(snapshots);
+
+    assertThat(om2Output)
+        .contains("# TYPE \"my.request.duration\" histogram\n")
+        .contains("# UNIT \"my.request.duration\" seconds\n")
+        .contains("# HELP \"my.request.duration\" Request duration in seconds\n")
+        .contains("{\"my.request.duration\",\"http.path\"=\"/hello\"} {count:1,sum:3.2,")
+        .doesNotContain("my.request.duration_seconds");
+  }
+
+  private String writeWithOM1(MetricSnapshots snapshots) throws IOException {
+    return write(snapshots, OpenMetricsTextFormatWriter.create());
+  }
+
+  private String writeWithOM2(MetricSnapshots snapshots) throws IOException {
+    return write(snapshots, OpenMetrics2TextFormatWriter.create());
+  }
+
+  private String writeWithNativeHistograms(MetricSnapshots snapshots) throws IOException {
+    OpenMetrics2TextFormatWriter writer =
+        OpenMetrics2TextFormatWriter.builder()
+            .setOpenMetrics2Properties(
+                OpenMetrics2Properties.builder().nativeHistograms(true).build())
+            .build();
+    return write(snapshots, writer);
+  }
+
+  private String write(MetricSnapshots snapshots, ExpositionFormatWriter writer)
+      throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.write(out, snapshots, EscapingScheme.ALLOW_UTF8);
+    return out.toString(StandardCharsets.UTF_8.name());
+  }
+}

--- a/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriter.java
+++ b/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriter.java
@@ -6,7 +6,7 @@ import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeLabels
 import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeLong;
 import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeName;
 import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeOpenMetricsTimestamp;
-import static io.prometheus.metrics.model.snapshots.SnapshotEscaper.getExpositionBaseMetadataName;
+import static io.prometheus.metrics.model.snapshots.SnapshotEscaper.getOriginalMetadataName;
 import static io.prometheus.metrics.model.snapshots.SnapshotEscaper.getSnapshotLabelName;
 
 import io.prometheus.metrics.config.EscapingScheme;
@@ -40,8 +40,8 @@ import javax.annotation.Nullable;
 
 /**
  * Write the OpenMetrics 2.0 text format. Unlike the OM1 writer, this writer outputs metric names as
- * provided by the user — no {@code _total} or unit suffix appending. The {@code _info} suffix is
- * enforced per the OM2 spec (MUST). This is experimental and subject to change as the <a
+ * provided by the user, without appending {@code _total} or unit suffixes. The {@code _info} suffix
+ * is enforced per the OM2 spec (MUST). This is experimental and subject to change as the <a
  * href="https://github.com/prometheus/docs/blob/main/docs/specs/om/open_metrics_spec_2_0.md">OpenMetrics
  * 2.0 specification</a> evolves.
  */
@@ -89,6 +89,7 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
   public static final String CONTENT_TYPE =
       "application/openmetrics-text; version=2.0.0; charset=utf-8";
   private final OpenMetrics2Properties openMetrics2Properties;
+  private final boolean createdTimestampsEnabled;
   private final boolean exemplarsOnAllMetricTypesEnabled;
   private final OpenMetricsTextFormatWriter om1Writer;
 
@@ -102,6 +103,7 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
       boolean createdTimestampsEnabled,
       boolean exemplarsOnAllMetricTypesEnabled) {
     this.openMetrics2Properties = openMetrics2Properties;
+    this.createdTimestampsEnabled = createdTimestampsEnabled;
     this.exemplarsOnAllMetricTypesEnabled = exemplarsOnAllMetricTypesEnabled;
     this.om1Writer =
         new OpenMetricsTextFormatWriter(createdTimestampsEnabled, exemplarsOnAllMetricTypesEnabled);
@@ -170,8 +172,8 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
   private void writeCounter(Writer writer, CounterSnapshot snapshot, EscapingScheme scheme)
       throws IOException {
     MetricMetadata metadata = snapshot.getMetadata();
-    // OM2: use the name as provided by the user, no _total appending
-    String counterName = getExpositionBaseMetadataName(metadata, scheme);
+    // OM2: use the original name, no _total or unit suffix appending.
+    String counterName = getOriginalMetadataName(metadata, scheme);
     writeMetadataWithName(writer, counterName, "counter", metadata);
     for (CounterSnapshot.CounterDataPointSnapshot data : snapshot.getDataPoints()) {
       writeNameAndLabels(writer, counterName, null, data.getLabels(), scheme);
@@ -192,7 +194,7 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
   private void writeGauge(Writer writer, GaugeSnapshot snapshot, EscapingScheme scheme)
       throws IOException {
     MetricMetadata metadata = snapshot.getMetadata();
-    String name = getExpositionBaseMetadataName(metadata, scheme);
+    String name = getOriginalMetadataName(metadata, scheme);
     writeMetadataWithName(writer, name, "gauge", metadata);
     for (GaugeSnapshot.GaugeDataPointSnapshot data : snapshot.getDataPoints()) {
       writeNameAndLabels(writer, name, null, data.getLabels(), scheme);
@@ -209,12 +211,12 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
       throws IOException {
     boolean compositeHistogram =
         openMetrics2Properties.getCompositeValues() || openMetrics2Properties.getNativeHistograms();
+    MetricMetadata metadata = snapshot.getMetadata();
+    String name = getOriginalMetadataName(metadata, scheme);
     if (!compositeHistogram && !openMetrics2Properties.getExemplarCompliance()) {
-      om1Writer.writeHistogram(writer, snapshot, scheme);
+      writeClassicHistogram(writer, name, snapshot, scheme);
       return;
     }
-    MetricMetadata metadata = snapshot.getMetadata();
-    String name = getExpositionBaseMetadataName(metadata, scheme);
     if (snapshot.isGaugeHistogram()) {
       writeMetadataWithName(writer, name, "gaugehistogram", metadata);
       for (HistogramSnapshot.HistogramDataPointSnapshot data : snapshot.getDataPoints()) {
@@ -233,6 +235,88 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
           writeCompositeHistogramDataPoint(writer, name, "count", "sum", data, scheme, true);
         }
       }
+    }
+  }
+
+  private void writeClassicHistogram(
+      Writer writer, String name, HistogramSnapshot snapshot, EscapingScheme scheme)
+      throws IOException {
+    if (snapshot.isGaugeHistogram()) {
+      writeMetadataWithName(writer, name, "gaugehistogram", snapshot.getMetadata());
+      writeClassicHistogramDataPoints(writer, name, "_gcount", "_gsum", snapshot, scheme);
+    } else {
+      writeMetadataWithName(writer, name, "histogram", snapshot.getMetadata());
+      writeClassicHistogramDataPoints(writer, name, "_count", "_sum", snapshot, scheme);
+    }
+  }
+
+  private void writeClassicHistogramDataPoints(
+      Writer writer,
+      String name,
+      String countSuffix,
+      String sumSuffix,
+      HistogramSnapshot snapshot,
+      EscapingScheme scheme)
+      throws IOException {
+    for (HistogramSnapshot.HistogramDataPointSnapshot data : snapshot.getDataPoints()) {
+      ClassicHistogramBuckets buckets = getClassicBuckets(data);
+      Exemplars exemplars = data.getExemplars();
+      long cumulativeCount = 0;
+      for (int i = 0; i < buckets.size(); i++) {
+        cumulativeCount += buckets.getCount(i);
+        writeNameAndLabels(
+            writer, name, "_bucket", data.getLabels(), scheme, "le", buckets.getUpperBound(i));
+        writeLong(writer, cumulativeCount);
+        Exemplar exemplar;
+        if (i == 0) {
+          exemplar = exemplars.get(Double.NEGATIVE_INFINITY, buckets.getUpperBound(i));
+        } else {
+          exemplar = exemplars.get(buckets.getUpperBound(i - 1), buckets.getUpperBound(i));
+        }
+        writeScrapeTimestampAndExemplar(writer, data, exemplar, scheme);
+      }
+      if (data.hasCount() && data.hasSum()) {
+        writeClassicCountAndSum(writer, name, data, countSuffix, sumSuffix, exemplars, scheme);
+      }
+      writeClassicCreated(writer, name, data, scheme);
+    }
+  }
+
+  private void writeClassicCountAndSum(
+      Writer writer,
+      String name,
+      HistogramSnapshot.HistogramDataPointSnapshot data,
+      String countSuffix,
+      String sumSuffix,
+      Exemplars exemplars,
+      EscapingScheme scheme)
+      throws IOException {
+    writeNameAndLabels(writer, name, countSuffix, data.getLabels(), scheme);
+    writeLong(writer, data.getCount());
+    if (exemplarsOnAllMetricTypesEnabled) {
+      writeScrapeTimestampAndExemplar(writer, data, exemplars.getLatest(), scheme);
+    } else {
+      writeScrapeTimestampAndExemplar(writer, data, null, scheme);
+    }
+    writeNameAndLabels(writer, name, sumSuffix, data.getLabels(), scheme);
+    writeDouble(writer, data.getSum());
+    writeScrapeTimestampAndExemplar(writer, data, null, scheme);
+  }
+
+  private void writeClassicCreated(
+      Writer writer,
+      String name,
+      HistogramSnapshot.HistogramDataPointSnapshot data,
+      EscapingScheme scheme)
+      throws IOException {
+    if (createdTimestampsEnabled && data.hasCreatedTimestamp()) {
+      writeNameAndLabels(writer, name, "_created", data.getLabels(), scheme);
+      writeOpenMetricsTimestamp(writer, data.getCreatedTimestampMillis());
+      if (data.hasScrapeTimestamp()) {
+        writer.write(' ');
+        writeOpenMetricsTimestamp(writer, data.getScrapeTimestampMillis());
+      }
+      writer.write('\n');
     }
   }
 
@@ -398,7 +482,7 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
     }
     boolean metadataWritten = false;
     MetricMetadata metadata = snapshot.getMetadata();
-    String name = getExpositionBaseMetadataName(metadata, scheme);
+    String name = getOriginalMetadataName(metadata, scheme);
     for (SummarySnapshot.SummaryDataPointSnapshot data : snapshot.getDataPoints()) {
       if (data.getQuantiles().size() == 0 && !data.hasCount() && !data.hasSum()) {
         continue;
@@ -465,7 +549,7 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
     MetricMetadata metadata = snapshot.getMetadata();
     // OM2 spec: Info MetricFamily name MUST end in _info.
     // In OM2, TYPE/HELP use the same name as the data lines.
-    String infoName = ensureSuffix(getExpositionBaseMetadataName(metadata, scheme), "_info");
+    String infoName = ensureSuffix(getOriginalMetadataName(metadata, scheme), "_info");
     writeMetadataWithName(writer, infoName, "info", metadata);
     for (InfoSnapshot.InfoDataPointSnapshot data : snapshot.getDataPoints()) {
       writeNameAndLabels(writer, infoName, null, data.getLabels(), scheme);
@@ -477,7 +561,7 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
   private void writeStateSet(Writer writer, StateSetSnapshot snapshot, EscapingScheme scheme)
       throws IOException {
     MetricMetadata metadata = snapshot.getMetadata();
-    String name = getExpositionBaseMetadataName(metadata, scheme);
+    String name = getOriginalMetadataName(metadata, scheme);
     writeMetadataWithName(writer, name, "stateset", metadata);
     for (StateSetSnapshot.StateSetDataPointSnapshot data : snapshot.getDataPoints()) {
       for (int i = 0; i < data.size(); i++) {
@@ -513,7 +597,7 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
   private void writeUnknown(Writer writer, UnknownSnapshot snapshot, EscapingScheme scheme)
       throws IOException {
     MetricMetadata metadata = snapshot.getMetadata();
-    String name = getExpositionBaseMetadataName(metadata, scheme);
+    String name = getOriginalMetadataName(metadata, scheme);
     writeMetadataWithName(writer, name, "unknown", metadata);
     for (UnknownSnapshot.UnknownDataPointSnapshot data : snapshot.getDataPoints()) {
       writeNameAndLabels(writer, name, null, data.getLabels(), scheme);

--- a/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriterTest.java
+++ b/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriterTest.java
@@ -17,7 +17,6 @@ import io.prometheus.metrics.model.snapshots.NativeHistogramBuckets;
 import io.prometheus.metrics.model.snapshots.Quantiles;
 import io.prometheus.metrics.model.snapshots.StateSetSnapshot;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
-import io.prometheus.metrics.model.snapshots.Unit;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -86,33 +85,6 @@ class OpenMetrics2TextFormatWriterTest {
     assertThat(writer.getOpenMetrics2Properties()).isEqualTo(props);
     assertThat(writer.getOpenMetrics2Properties().getContentNegotiation()).isTrue();
     assertThat(writer.getOpenMetrics2Properties().getCompositeValues()).isTrue();
-  }
-
-  @Test
-  void testCounterNoTotalSuffix() throws IOException {
-    MetricSnapshots snapshots =
-        MetricSnapshots.of(
-            CounterSnapshot.builder()
-                .name("my_counter_seconds")
-                .help("Test counter")
-                .unit(Unit.SECONDS)
-                .dataPoint(
-                    CounterSnapshot.CounterDataPointSnapshot.builder()
-                        .value(42.0)
-                        .labels(Labels.of("method", "GET"))
-                        .build())
-                .build());
-
-    String om2Output = writeWithOM2(snapshots);
-
-    // OM2: name as provided, no _total appending
-    assertThat(om2Output)
-        .isEqualTo(
-            "# TYPE my_counter_seconds counter\n"
-                + "# UNIT my_counter_seconds seconds\n"
-                + "# HELP my_counter_seconds Test counter\n"
-                + "my_counter_seconds{method=\"GET\"} 42.0\n"
-                + "# EOF\n");
   }
 
   @Test
@@ -685,47 +657,6 @@ class OpenMetrics2TextFormatWriterTest {
   }
 
   @Test
-  void testNativeHistogramWithDots() throws IOException {
-    Exemplar exemplar =
-        Exemplar.builder()
-            .labels(Labels.of("some.exemplar.key", "some value"))
-            .value(3.0)
-            .timestampMillis(1690298864383L)
-            .build();
-
-    MetricSnapshots snapshots =
-        MetricSnapshots.of(
-            HistogramSnapshot.builder()
-                .name("my.request.duration.seconds")
-                .help("Request duration in seconds")
-                .unit(Unit.SECONDS)
-                .dataPoint(
-                    HistogramSnapshot.HistogramDataPointSnapshot.builder()
-                        .labels(Labels.builder().label("http.path", "/hello").build())
-                        .sum(3.2)
-                        .nativeSchema(5)
-                        .nativeZeroCount(1)
-                        .nativeBucketsForPositiveValues(
-                            NativeHistogramBuckets.builder().bucket(2, 3).build())
-                        .exemplars(Exemplars.of(exemplar))
-                        .build())
-                .build());
-
-    String output = writeWithNativeHistograms(snapshots);
-
-    assertThat(output)
-        .isEqualTo(
-            "# TYPE \"my.request.duration.seconds\" histogram\n"
-                + "# UNIT \"my.request.duration.seconds\" seconds\n"
-                + "# HELP \"my.request.duration.seconds\" Request duration in seconds\n"
-                + "{\"my.request.duration.seconds\",\"http.path\"=\"/hello\"}"
-                + " {count:4,sum:3.2,schema:5,zero_threshold:0.0,zero_count:1,"
-                + "positive_spans:[2:1],positive_buckets:[3]}"
-                + " # {\"some.exemplar.key\"=\"some value\"} 3.0 1690298864.383\n"
-                + "# EOF\n");
-  }
-
-  @Test
   void testCompositeSummary() throws IOException {
     MetricSnapshots snapshots =
         MetricSnapshots.of(
@@ -911,6 +842,6 @@ class OpenMetrics2TextFormatWriterTest {
       throws IOException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     writer.write(out, snapshots, EscapingScheme.ALLOW_UTF8);
-    return out.toString(StandardCharsets.UTF_8);
+    return out.toString(StandardCharsets.UTF_8.name());
   }
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/SnapshotEscaper.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/SnapshotEscaper.java
@@ -105,6 +105,14 @@ public class SnapshotEscaper {
     }
   }
 
+  public static String getOriginalMetadataName(MetricMetadata metadata, EscapingScheme scheme) {
+    if (scheme == EscapingScheme.UNDERSCORE_ESCAPING) {
+      return PrometheusNaming.prometheusName(metadata.getOriginalName());
+    } else {
+      return metadata.getOriginalName();
+    }
+  }
+
   public static Labels escapeLabels(Labels labels, EscapingScheme scheme) {
     Labels.Builder outLabelsBuilder = Labels.builder();
 


### PR DESCRIPTION
Refs #1954.

## Summary

This fixes OM2 name preservation in the text writer.

- Use original metric metadata names in OM2 output instead of OM1 exposition base names.
- Preserve original names for default classic histogram output instead of delegating that path to OM1.
- Keep the OM2 `_info` exception for info metrics.
- Add builder-based regression coverage for counters and classic/native histograms with `.unit(...)`.

## Why

`openmetrics2.enabled=true` is documented as preserving metric names as written by the application. The writer still used OM1-derived names in several paths, and classic histograms delegated to the OM1 writer, so `.unit(...)` could still leak unit-suffixed names into OM2 output.

## Smoking gun

`prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/OpenMetrics2TextFormatWriterTest.java`
adds `counterPreservesOriginalNameWhenUnitIsConfigured()`.

That test builds a real counter through the public builder API:

```java
Counter.builder().name("my_counter").unit(Unit.SECONDS)
```

It then asserts that OM1 still emits the legacy name `my_counter_seconds_total`, while OM2 emits
`my_counter` and does not contain `my_counter_seconds`.

I verified this test fails against pre-fix `origin/main` when only the test is applied:

```text
OpenMetrics2TextFormatWriterTest.counterPreservesOriginalNameWhenUnitIsConfigured

Expecting actual:
  "# TYPE my_counter_seconds counter
# UNIT my_counter_seconds seconds
# HELP my_counter_seconds Test counter
my_counter_seconds{method="GET"} 42.0 st@...
# EOF
"
to contain:
  "# TYPE my_counter counter
"
```

That is the bug this PR fixes: OM2 was still using the OM1 unit-suffixed metric name.

## Validation

- `./mvnw test -pl prometheus-metrics-core,prometheus-metrics-exposition-textformats -am -Dtest=OpenMetrics2TextFormatWriterTest -Dcoverage.skip=true -Dcheckstyle.skip=true -Dsurefire.failIfNoSpecifiedTests=false`
- `mise run build`
- `mise run lint`
- `git diff --check`
