### PR TITLE
docs: Document semantic PR title guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,14 @@ Pre-built instrumentations:
 - **Markdown code blocks**: Always specify language
   (e.g., ` ```java`, ` ```bash`, ` ```text`)
 
+## Pull Requests
+
+- PR titles must use semantic/conventional prefixes, for example
+  `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, or
+  `test: ...`.
+- Do not prefix PR titles with `[codex]`.
+- Match the PR title type to the primary user-facing change.
+
 ## Linting and Validation
 
 **CRITICAL**: These checks MUST be run before creating any


### PR DESCRIPTION
## Summary

Document PR title expectations for AI coding agents working in this repository.

- Require semantic/conventional PR title prefixes such as `feat:`, `fix:`, `docs:`, `chore:`, or `test:`.
- Tell agents not to use `[codex]` in PR titles.
- Ask agents to match the title type to the primary user-facing change.

## Validation

- `mise run lint`
- `git diff --check`
