### PR TITLE
chore: ignore internal Prometheus BOM in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,7 @@
     {
       enabled: false,
       description: "Ignore internal project modules",
-      matchPackageNames: ["/^io\\.prometheus:(examples|example-.+|integration-tests|it-.+)$/"],
+      matchPackageNames: ["/^io\\.prometheus:(prometheus-metrics-bom|examples|example-.+|integration-tests|it-.+)$/"],
     },
     {
       description: "Group protobuf-java and protoc together so generated code can be updated in one PR",


### PR DESCRIPTION
## Summary
- add `io.prometheus:prometheus-metrics-bom` to the existing Renovate ignore rule for internal project modules
- prevent Renovate PRs that update examples to consume the repo's own just-released BOM while release-please is already moving the repo to the next snapshot

## Testing
- `mise exec -- renovate-config-validator .github/renovate.json5`