### PR TITLE
feat: add normalizeMetricName helper

### DIFF
--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
@@ -180,6 +180,9 @@ public class PrometheusNaming {
    * bridge) which relied on {@code sanitizeMetricName} to strip these suffixes before passing names
    * to the snapshot builders.
    *
+   * <p>If you want permissive normalization that keeps reserved suffixes intact, use {@link
+   * #normalizeMetricName(String)} instead.
+   *
    * @throws IllegalArgumentException if the input is empty
    */
   public static String sanitizeMetricName(String metricName) {

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java
@@ -46,7 +46,9 @@ public class PrometheusNaming {
    * format, this will be represented as two values: {@code processing_time_seconds_total} for the
    * counter value, and the optional {@code processing_time_seconds_created} timestamp.
    *
-   * <p>Use {@link #sanitizeMetricName(String)} to convert arbitrary Strings to valid metric names.
+   * <p>Use {@link #sanitizeMetricName(String)} for compatibility-preserving sanitization that
+   * strips reserved suffixes, or {@link #normalizeMetricName(String)} for permissive normalization
+   * that keeps the original suffixes intact.
    */
   public static boolean isValidMetricName(String name) {
     return validateMetricName(name) == null;
@@ -213,6 +215,37 @@ public class PrometheusNaming {
    */
   public static String sanitizeMetricName(String metricName, Unit unit) {
     String result = sanitizeMetricName(metricName);
+    if (unit != null) {
+      if (!result.endsWith("_" + unit) && !result.endsWith("." + unit)) {
+        result += "_" + unit;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Convert an arbitrary string to a valid metric name without stripping reserved suffixes.
+   *
+   * <p>Any non-empty valid UTF-8 string is accepted and returned unchanged. This is the permissive
+   * normalization behavior introduced in 1.6.0. Use this method for new integrations that want to
+   * preserve the original metric name and rely on registration-time collision detection instead of
+   * suffix stripping.
+   *
+   * @throws IllegalArgumentException if the input is empty
+   */
+  public static String normalizeMetricName(String metricName) {
+    if (metricName.isEmpty()) {
+      throw new IllegalArgumentException("Cannot convert an empty string to a valid metric name.");
+    }
+    return metricName;
+  }
+
+  /**
+   * Like {@link #normalizeMetricName(String)}, but also makes sure that the unit is appended as a
+   * suffix if the unit is not {@code null}.
+   */
+  public static String normalizeMetricName(String metricName, Unit unit) {
+    String result = normalizeMetricName(metricName);
     if (unit != null) {
       if (!result.endsWith("_" + unit) && !result.endsWith("." + unit)) {
         result += "_" + unit;

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/PrometheusNamingTest.java
@@ -2,6 +2,7 @@ package io.prometheus.metrics.model.snapshots;
 
 import static io.prometheus.metrics.model.snapshots.PrometheusNaming.escapeName;
 import static io.prometheus.metrics.model.snapshots.PrometheusNaming.isValidLabelName;
+import static io.prometheus.metrics.model.snapshots.PrometheusNaming.normalizeMetricName;
 import static io.prometheus.metrics.model.snapshots.PrometheusNaming.prometheusName;
 import static io.prometheus.metrics.model.snapshots.PrometheusNaming.sanitizeLabelName;
 import static io.prometheus.metrics.model.snapshots.PrometheusNaming.sanitizeMetricName;
@@ -70,6 +71,29 @@ class PrometheusNamingTest {
     assertThat(sanitizeMetricName("jvm.info", Unit.RATIO)).isEqualTo("jvm_" + Unit.RATIO);
     assertThat(sanitizeMetricName("_total", Unit.RATIO)).isEqualTo("total_" + Unit.RATIO);
     assertThat(sanitizeMetricName("total", Unit.RATIO)).isEqualTo("total_" + Unit.RATIO);
+  }
+
+  @Test
+  void testNormalizeMetricName() {
+    assertThat(normalizeMetricName("my_counter_total")).isEqualTo("my_counter_total");
+    assertThat(normalizeMetricName("jvm.info")).isEqualTo("jvm.info");
+    assertThat(normalizeMetricName("jvm_info")).isEqualTo("jvm_info");
+    assertThat(normalizeMetricName("a.b")).isEqualTo("a.b");
+    assertThat(normalizeMetricName("_total")).isEqualTo("_total");
+    assertThat(normalizeMetricName(".total")).isEqualTo(".total");
+    assertThat(normalizeMetricName("my_events_created")).isEqualTo("my_events_created");
+    assertThat(normalizeMetricName("my_histogram_bucket")).isEqualTo("my_histogram_bucket");
+  }
+
+  @Test
+  void testNormalizeMetricNameWithUnit() {
+    assertThat(prometheusName(normalizeMetricName("def", Unit.RATIO)))
+        .isEqualTo("def_" + Unit.RATIO);
+    assertThat(prometheusName(normalizeMetricName("my_counter_total", Unit.RATIO)))
+        .isEqualTo("my_counter_total_" + Unit.RATIO);
+    assertThat(normalizeMetricName("jvm.info", Unit.RATIO)).isEqualTo("jvm.info_" + Unit.RATIO);
+    assertThat(normalizeMetricName("_total", Unit.RATIO)).isEqualTo("_total_" + Unit.RATIO);
+    assertThat(normalizeMetricName("total", Unit.RATIO)).isEqualTo("total_" + Unit.RATIO);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds a new permissive normalization API on top of #2094.

`sanitizeMetricName()` keeps the restored compatibility behavior from that PR:
it strips reserved suffixes such as `_total`, `_created`, `_bucket`, and
`_info` (plus dot variants).

This PR adds `normalizeMetricName()` as the explicit opt-in for the newer
1.6.x-style permissive behavior:

- keep the original metric name unchanged
- allow reserved suffixes to remain in the normalized name
- still append units when requested

That gives downstream integrations a clear API split:

- `sanitizeMetricName(...)` for compatibility-preserving suffix stripping
- `normalizeMetricName(...)` for permissive normalization

## Changes

- add `PrometheusNaming.normalizeMetricName(String)`
- add `PrometheusNaming.normalizeMetricName(String, Unit)`
- extend `PrometheusNamingTest` to cover the new helper and its unit overload
- clarify the class-level Javadoc around when to use `sanitizeMetricName()`
  vs `normalizeMetricName()`

## Why stacked

This is intended to sit on top of #2094.

- #2094 restores the old `sanitizeMetricName()` behavior for downstreams that
  relied on suffix stripping
- this PR preserves access to the newer permissive semantics under a separate,
  explicit method name

## Test plan

- `mise run build`
- `./mvnw test -pl prometheus-metrics-model -am -Dtest=PrometheusNamingTest,MetricMetadataTest -Dsurefire.failIfNoSpecifiedTests=false -Dcoverage.skip=true -Dcheckstyle.skip=true`
