### PR TITLE
fix: restore legacy suffix compatibility

### DIFF
--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/internal/PrometheusProtobufWriterImpl.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/internal/PrometheusProtobufWriterImpl.java
@@ -21,6 +21,7 @@ import io.prometheus.metrics.model.snapshots.MetricMetadata;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import io.prometheus.metrics.model.snapshots.NativeHistogramBuckets;
+import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import io.prometheus.metrics.model.snapshots.Quantiles;
 import io.prometheus.metrics.model.snapshots.SnapshotEscaper;
 import io.prometheus.metrics.model.snapshots.StateSetSnapshot;
@@ -82,7 +83,7 @@ public class PrometheusProtobufWriterImpl implements ExpositionFormatWriter {
         builder.addMetric(convert(data, scheme));
       }
       setMetadataUnlessEmpty(
-          builder, snapshot.getMetadata(), null, Metrics.MetricType.GAUGE, scheme);
+          builder, snapshot.getMetadata(), null, Metrics.MetricType.GAUGE, scheme, true);
     } else if (snapshot instanceof HistogramSnapshot) {
       HistogramSnapshot histogram = (HistogramSnapshot) snapshot;
       for (HistogramSnapshot.HistogramDataPointSnapshot data : histogram.getDataPoints()) {
@@ -290,23 +291,51 @@ public class PrometheusProtobufWriterImpl implements ExpositionFormatWriter {
       @Nullable String nameSuffix,
       Metrics.MetricType type,
       EscapingScheme scheme) {
+    setMetadataUnlessEmpty(builder, metadata, nameSuffix, type, scheme, false);
+  }
+
+  private void setMetadataUnlessEmpty(
+      Metrics.MetricFamily.Builder builder,
+      MetricMetadata metadata,
+      @Nullable String nameSuffix,
+      Metrics.MetricType type,
+      EscapingScheme scheme,
+      boolean normalizeLegacyGaugeName) {
     if (builder.getMetricCount() == 0) {
       return;
     }
-    if (nameSuffix == null) {
-      builder.setName(SnapshotEscaper.getMetadataName(metadata, scheme));
-    } else {
-      String expositionBaseName = SnapshotEscaper.getExpositionBaseMetadataName(metadata, scheme);
-      if (expositionBaseName.endsWith(nameSuffix)) {
-        builder.setName(expositionBaseName);
-      } else {
-        builder.setName(SnapshotEscaper.getMetadataName(metadata, scheme) + nameSuffix);
-      }
-    }
+    builder.setName(
+        resolveMetricFamilyName(metadata, nameSuffix, scheme, normalizeLegacyGaugeName));
     if (metadata.getHelp() != null) {
       builder.setHelp(metadata.getHelp());
     }
     builder.setType(type);
+  }
+
+  private String resolveMetricFamilyName(
+      MetricMetadata metadata,
+      @Nullable String nameSuffix,
+      EscapingScheme scheme,
+      boolean normalizeLegacyGaugeName) {
+    if (normalizeLegacyGaugeName) {
+      String originalName = metadata.getOriginalName();
+      if (originalName.endsWith(".created")) {
+        return PrometheusNaming.escapeName(
+            originalName.substring(0, originalName.length() - ".created".length()), scheme);
+      }
+      if (originalName.endsWith(".total")) {
+        return PrometheusNaming.escapeName(
+            originalName.substring(0, originalName.length() - ".total".length()), scheme);
+      }
+    }
+    if (nameSuffix == null) {
+      return SnapshotEscaper.getMetadataName(metadata, scheme);
+    }
+    String expositionBaseName = SnapshotEscaper.getExpositionBaseMetadataName(metadata, scheme);
+    if (expositionBaseName.endsWith(nameSuffix)) {
+      return expositionBaseName;
+    }
+    return SnapshotEscaper.getMetadataName(metadata, scheme) + nameSuffix;
   }
 
   private long getNativeCount(HistogramSnapshot.HistogramDataPointSnapshot data) {

--- a/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/internal/PrometheusProtobufWriterImpl.java
+++ b/prometheus-metrics-exposition-formats/src/main/java/io/prometheus/metrics/expositionformats/internal/PrometheusProtobufWriterImpl.java
@@ -21,7 +21,6 @@ import io.prometheus.metrics.model.snapshots.MetricMetadata;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import io.prometheus.metrics.model.snapshots.NativeHistogramBuckets;
-import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import io.prometheus.metrics.model.snapshots.Quantiles;
 import io.prometheus.metrics.model.snapshots.SnapshotEscaper;
 import io.prometheus.metrics.model.snapshots.StateSetSnapshot;
@@ -51,7 +50,10 @@ public class PrometheusProtobufWriterImpl implements ExpositionFormatWriter {
     for (MetricSnapshot s : merged) {
       MetricSnapshot snapshot = SnapshotEscaper.escapeMetricSnapshot(s, escapingScheme);
       if (!snapshot.getDataPoints().isEmpty()) {
-        stringBuilder.append(TextFormat.printer().printToString(convert(snapshot, escapingScheme)));
+        stringBuilder.append(
+            TextFormat.printer()
+                .printToString(
+                    convert(snapshot, s.getMetadata().getOriginalName(), escapingScheme)));
       }
     }
     return stringBuilder.toString();
@@ -65,12 +67,17 @@ public class PrometheusProtobufWriterImpl implements ExpositionFormatWriter {
     for (MetricSnapshot s : merged) {
       MetricSnapshot snapshot = SnapshotEscaper.escapeMetricSnapshot(s, escapingScheme);
       if (!snapshot.getDataPoints().isEmpty()) {
-        convert(snapshot, escapingScheme).writeDelimitedTo(out);
+        convert(snapshot, s.getMetadata().getOriginalName(), escapingScheme).writeDelimitedTo(out);
       }
     }
   }
 
   public Metrics.MetricFamily convert(MetricSnapshot snapshot, EscapingScheme scheme) {
+    return convert(snapshot, snapshot.getMetadata().getOriginalName(), scheme);
+  }
+
+  private Metrics.MetricFamily convert(
+      MetricSnapshot snapshot, String rawOriginalName, EscapingScheme scheme) {
     Metrics.MetricFamily.Builder builder = Metrics.MetricFamily.newBuilder();
     if (snapshot instanceof CounterSnapshot) {
       for (CounterDataPointSnapshot data : ((CounterSnapshot) snapshot).getDataPoints()) {
@@ -83,7 +90,13 @@ public class PrometheusProtobufWriterImpl implements ExpositionFormatWriter {
         builder.addMetric(convert(data, scheme));
       }
       setMetadataUnlessEmpty(
-          builder, snapshot.getMetadata(), null, Metrics.MetricType.GAUGE, scheme, true);
+          builder,
+          snapshot.getMetadata(),
+          rawOriginalName,
+          null,
+          Metrics.MetricType.GAUGE,
+          scheme,
+          true);
     } else if (snapshot instanceof HistogramSnapshot) {
       HistogramSnapshot histogram = (HistogramSnapshot) snapshot;
       for (HistogramSnapshot.HistogramDataPointSnapshot data : histogram.getDataPoints()) {
@@ -291,12 +304,14 @@ public class PrometheusProtobufWriterImpl implements ExpositionFormatWriter {
       @Nullable String nameSuffix,
       Metrics.MetricType type,
       EscapingScheme scheme) {
-    setMetadataUnlessEmpty(builder, metadata, nameSuffix, type, scheme, false);
+    setMetadataUnlessEmpty(
+        builder, metadata, metadata.getOriginalName(), nameSuffix, type, scheme, false);
   }
 
   private void setMetadataUnlessEmpty(
       Metrics.MetricFamily.Builder builder,
       MetricMetadata metadata,
+      String rawOriginalName,
       @Nullable String nameSuffix,
       Metrics.MetricType type,
       EscapingScheme scheme,
@@ -305,7 +320,8 @@ public class PrometheusProtobufWriterImpl implements ExpositionFormatWriter {
       return;
     }
     builder.setName(
-        resolveMetricFamilyName(metadata, nameSuffix, scheme, normalizeLegacyGaugeName));
+        resolveMetricFamilyName(
+            metadata, rawOriginalName, nameSuffix, scheme, normalizeLegacyGaugeName));
     if (metadata.getHelp() != null) {
       builder.setHelp(metadata.getHelp());
     }
@@ -314,19 +330,12 @@ public class PrometheusProtobufWriterImpl implements ExpositionFormatWriter {
 
   private String resolveMetricFamilyName(
       MetricMetadata metadata,
+      String rawOriginalName,
       @Nullable String nameSuffix,
       EscapingScheme scheme,
       boolean normalizeLegacyGaugeName) {
     if (normalizeLegacyGaugeName) {
-      String originalName = metadata.getOriginalName();
-      if (originalName.endsWith(".created")) {
-        return PrometheusNaming.escapeName(
-            originalName.substring(0, originalName.length() - ".created".length()), scheme);
-      }
-      if (originalName.endsWith(".total")) {
-        return PrometheusNaming.escapeName(
-            originalName.substring(0, originalName.length() - ".total".length()), scheme);
-      }
+      return SnapshotEscaper.getLegacyGaugeName(metadata, rawOriginalName, scheme);
     }
     if (nameSuffix == null) {
       return SnapshotEscaper.getMetadataName(metadata, scheme);

--- a/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/DuplicateNamesProtobufTest.java
+++ b/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/DuplicateNamesProtobufTest.java
@@ -239,6 +239,28 @@ class DuplicateNamesProtobufTest {
     assertThat(gaugeFamily.getMetric(0).getGauge().getValue()).isEqualTo(50.0);
   }
 
+  @Test
+  void testLegacyGaugeNameWithDotTotal_usesBaseName() throws IOException {
+    MetricSnapshots snapshots =
+        MetricSnapshots.of(
+            GaugeSnapshot.builder()
+                .name("legacy.total")
+                .dataPoint(GaugeSnapshot.GaugeDataPointSnapshot.builder().value(7).build())
+                .build());
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    PrometheusProtobufWriterImpl writer = new PrometheusProtobufWriterImpl();
+    writer.write(out, snapshots, EscapingScheme.UNDERSCORE_ESCAPING);
+
+    List<Metrics.MetricFamily> metricFamilies = parseProtobufOutput(out);
+
+    assertThat(metricFamilies).hasSize(1);
+    Metrics.MetricFamily family = metricFamilies.get(0);
+    assertThat(family.getName()).isEqualTo("legacy");
+    assertThat(family.getType()).isEqualTo(Metrics.MetricType.GAUGE);
+    assertThat(family.getMetricCount()).isEqualTo(1);
+    assertThat(family.getMetric(0).getGauge().getValue()).isEqualTo(7.0);
+  }
+
   private static MetricSnapshots getMetricSnapshots() {
     PrometheusRegistry registry = new PrometheusRegistry();
 

--- a/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/DuplicateNamesProtobufTest.java
+++ b/prometheus-metrics-exposition-formats/src/test/java/io/prometheus/metrics/expositionformats/DuplicateNamesProtobufTest.java
@@ -240,6 +240,21 @@ class DuplicateNamesProtobufTest {
   }
 
   @Test
+  void testLegacyGaugeNameWithAlternateEscapingSchemes_usesBaseName() throws IOException {
+    MetricSnapshots snapshots =
+        MetricSnapshots.of(
+            GaugeSnapshot.builder()
+                .name("legacy.name.total")
+                .dataPoint(GaugeSnapshot.GaugeDataPointSnapshot.builder().value(7).build())
+                .build());
+
+    assertThat(getSingleMetricFamilyName(snapshots, EscapingScheme.DOTS_ESCAPING))
+        .isEqualTo("legacy_dot_name");
+    assertThat(getSingleMetricFamilyName(snapshots, EscapingScheme.VALUE_ENCODING_ESCAPING))
+        .isEqualTo("U__legacy_2e_name");
+  }
+
+  @Test
   void testLegacyGaugeNameWithDotTotal_usesBaseName() throws IOException {
     MetricSnapshots snapshots =
         MetricSnapshots.of(
@@ -259,6 +274,16 @@ class DuplicateNamesProtobufTest {
     assertThat(family.getType()).isEqualTo(Metrics.MetricType.GAUGE);
     assertThat(family.getMetricCount()).isEqualTo(1);
     assertThat(family.getMetric(0).getGauge().getValue()).isEqualTo(7.0);
+  }
+
+  private static String getSingleMetricFamilyName(
+      MetricSnapshots snapshots, EscapingScheme escapingScheme) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    PrometheusProtobufWriterImpl writer = new PrometheusProtobufWriterImpl();
+    writer.write(out, snapshots, escapingScheme);
+    List<Metrics.MetricFamily> metricFamilies = parseProtobufOutput(out);
+    assertThat(metricFamilies).hasSize(1);
+    return metricFamilies.get(0).getName();
   }
 
   private static MetricSnapshots getMetricSnapshots() {

--- a/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
+++ b/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
@@ -192,10 +192,10 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
   private void writeGauge(Writer writer, GaugeSnapshot snapshot, EscapingScheme scheme)
       throws IOException {
     MetricMetadata metadata = snapshot.getMetadata();
-    writeMetadata(writer, null, "gauge", metadata, scheme);
-    String name = getMetadataName(metadata, scheme);
+    String gaugeName = resolveLegacyGaugeName(metadata, scheme);
+    writeMetadataWithFullName(writer, gaugeName, "gauge", metadata);
     for (GaugeSnapshot.GaugeDataPointSnapshot data : snapshot.getDataPoints()) {
-      writeNameAndLabels(writer, name, null, data.getLabels(), scheme);
+      writeNameAndLabels(writer, gaugeName, null, data.getLabels(), scheme);
       writeDouble(writer, data.getValue());
       writeScrapeTimestampAndNewline(writer, data);
     }
@@ -469,6 +469,19 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
       return fullName.substring(0, fullName.length() - suffix.length());
     }
     return fullName;
+  }
+
+  private static String resolveLegacyGaugeName(MetricMetadata metadata, EscapingScheme scheme) {
+    String originalName = metadata.getOriginalName();
+    if (originalName.endsWith(".created")) {
+      return PrometheusNaming.escapeName(
+          originalName.substring(0, originalName.length() - ".created".length()), scheme);
+    }
+    if (originalName.endsWith(".total")) {
+      return PrometheusNaming.escapeName(
+          originalName.substring(0, originalName.length() - ".total".length()), scheme);
+    }
+    return getMetadataName(metadata, scheme);
   }
 
   private void writeEscapedHelp(Writer writer, String s) throws IOException {

--- a/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
+++ b/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/PrometheusTextFormatWriter.java
@@ -8,6 +8,7 @@ import static io.prometheus.metrics.expositionformats.TextFormatUtil.writeName;
 import static io.prometheus.metrics.expositionformats.TextFormatUtil.writePrometheusTimestamp;
 import static io.prometheus.metrics.model.snapshots.SnapshotEscaper.escapeMetricSnapshot;
 import static io.prometheus.metrics.model.snapshots.SnapshotEscaper.getExpositionBaseMetadataName;
+import static io.prometheus.metrics.model.snapshots.SnapshotEscaper.getLegacyGaugeName;
 import static io.prometheus.metrics.model.snapshots.SnapshotEscaper.getMetadataName;
 import static io.prometheus.metrics.model.snapshots.SnapshotEscaper.getSnapshotLabelName;
 
@@ -123,7 +124,7 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
         if (snapshot instanceof CounterSnapshot) {
           writeCounter(writer, (CounterSnapshot) snapshot, scheme);
         } else if (snapshot instanceof GaugeSnapshot) {
-          writeGauge(writer, (GaugeSnapshot) snapshot, scheme);
+          writeGauge(writer, (GaugeSnapshot) snapshot, s.getMetadata().getOriginalName(), scheme);
         } else if (snapshot instanceof HistogramSnapshot) {
           writeHistogram(writer, (HistogramSnapshot) snapshot, scheme);
         } else if (snapshot instanceof SummarySnapshot) {
@@ -189,10 +190,11 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
     }
   }
 
-  private void writeGauge(Writer writer, GaugeSnapshot snapshot, EscapingScheme scheme)
+  private void writeGauge(
+      Writer writer, GaugeSnapshot snapshot, String rawOriginalName, EscapingScheme scheme)
       throws IOException {
     MetricMetadata metadata = snapshot.getMetadata();
-    String gaugeName = resolveLegacyGaugeName(metadata, scheme);
+    String gaugeName = getLegacyGaugeName(metadata, rawOriginalName, scheme);
     writeMetadataWithFullName(writer, gaugeName, "gauge", metadata);
     for (GaugeSnapshot.GaugeDataPointSnapshot data : snapshot.getDataPoints()) {
       writeNameAndLabels(writer, gaugeName, null, data.getLabels(), scheme);
@@ -469,19 +471,6 @@ public class PrometheusTextFormatWriter implements ExpositionFormatWriter {
       return fullName.substring(0, fullName.length() - suffix.length());
     }
     return fullName;
-  }
-
-  private static String resolveLegacyGaugeName(MetricMetadata metadata, EscapingScheme scheme) {
-    String originalName = metadata.getOriginalName();
-    if (originalName.endsWith(".created")) {
-      return PrometheusNaming.escapeName(
-          originalName.substring(0, originalName.length() - ".created".length()), scheme);
-    }
-    if (originalName.endsWith(".total")) {
-      return PrometheusNaming.escapeName(
-          originalName.substring(0, originalName.length() - ".total".length()), scheme);
-    }
-    return getMetadataName(metadata, scheme);
   }
 
   private void writeEscapedHelp(Writer writer, String s) throws IOException {

--- a/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
+++ b/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
@@ -667,6 +667,29 @@ class ExpositionFormatsTest {
   }
 
   @Test
+  void testGaugeReservedSuffixCompatibilityWithAlternateEscapingSchemes() throws IOException {
+    GaugeSnapshot totalGauge =
+        GaugeSnapshot.builder()
+            .name("legacy.name.total")
+            .dataPoint(GaugeDataPointSnapshot.builder().value(6).build())
+            .build();
+    assertPrometheusText(
+        """
+        # TYPE legacy_dot_name gauge
+        legacy_dot_name 6.0
+        """,
+        totalGauge,
+        EscapingScheme.DOTS_ESCAPING);
+    assertPrometheusText(
+        """
+        # TYPE U__legacy_2e_name gauge
+        U__legacy_2e_name 6.0
+        """,
+        totalGauge,
+        EscapingScheme.VALUE_ENCODING_ESCAPING);
+  }
+
+  @Test
   void testGaugeReservedSuffixCompatibilityOutsideOpenMetrics() throws IOException {
     GaugeSnapshot createdGauge =
         GaugeSnapshot.builder()
@@ -3145,9 +3168,14 @@ class ExpositionFormatsTest {
   }
 
   private void assertPrometheusText(String expected, MetricSnapshot snapshot) throws IOException {
+    assertPrometheusText(expected, snapshot, EscapingScheme.UNDERSCORE_ESCAPING);
+  }
+
+  private void assertPrometheusText(
+      String expected, MetricSnapshot snapshot, EscapingScheme escapingScheme) throws IOException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     getPrometheusWriter(PrometheusTextFormatWriter.builder().setIncludeCreatedTimestamps(true))
-        .write(out, MetricSnapshots.of(snapshot), EscapingScheme.UNDERSCORE_ESCAPING);
+        .write(out, MetricSnapshots.of(snapshot), escapingScheme);
     assertThat(out).hasToString(expected);
   }
 

--- a/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
+++ b/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
@@ -667,6 +667,63 @@ class ExpositionFormatsTest {
   }
 
   @Test
+  void testGaugeReservedSuffixCompatibilityOutsideOpenMetrics() throws IOException {
+    GaugeSnapshot createdGauge =
+        GaugeSnapshot.builder()
+            .name("test3.created")
+            .dataPoint(GaugeDataPointSnapshot.builder().value(3).build())
+            .build();
+    assertOpenMetricsText(
+        """
+        # TYPE U__test3_2e_created gauge
+        U__test3_2e_created 3.0
+        # EOF
+        """,
+        createdGauge);
+    assertPrometheusText(
+        """
+        # TYPE test3 gauge
+        test3 3.0
+        """,
+        createdGauge);
+    assertPrometheusTextWithoutCreated(
+        """
+        # TYPE test3 gauge
+        test3 3.0
+        """,
+        createdGauge);
+    assertPrometheusProtobuf(
+        "name: \"test3\" type: GAUGE metric { gauge { value: 3.0 } }", createdGauge);
+
+    GaugeSnapshot totalGauge =
+        GaugeSnapshot.builder()
+            .name("test6.total")
+            .dataPoint(GaugeDataPointSnapshot.builder().value(6).build())
+            .build();
+    assertOpenMetricsText(
+        """
+        # TYPE U__test6_2e_total gauge
+        U__test6_2e_total 6.0
+        # EOF
+        """,
+        totalGauge);
+    assertPrometheusText(
+        """
+        # TYPE test6 gauge
+        test6 6.0
+        """,
+        totalGauge);
+    assertPrometheusTextWithoutCreated(
+        """
+        # TYPE test6 gauge
+        test6 6.0
+        """,
+        totalGauge);
+    assertPrometheusProtobuf(
+        "name: \"test6\" type: GAUGE metric { gauge { value: 6.0 } }", totalGauge);
+  }
+
+  @Test
   void testGaugeUTF8() throws IOException {
     String prometheusText =
         """

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/SnapshotEscaper.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/SnapshotEscaper.java
@@ -113,6 +113,26 @@ public class SnapshotEscaper {
     }
   }
 
+  public static String getLegacyGaugeName(
+      MetricMetadata metadata, String rawOriginalName, EscapingScheme scheme) {
+    String legacyGaugeBaseName = stripLegacyGaugeSuffix(rawOriginalName);
+    if (legacyGaugeBaseName != null) {
+      return PrometheusNaming.escapeName(legacyGaugeBaseName, scheme);
+    }
+    return getMetadataName(metadata, scheme);
+  }
+
+  @Nullable
+  private static String stripLegacyGaugeSuffix(String rawOriginalName) {
+    if (rawOriginalName.endsWith(".created")) {
+      return rawOriginalName.substring(0, rawOriginalName.length() - ".created".length());
+    }
+    if (rawOriginalName.endsWith(".total")) {
+      return rawOriginalName.substring(0, rawOriginalName.length() - ".total".length());
+    }
+    return null;
+  }
+
   public static Labels escapeLabels(Labels labels, EscapingScheme scheme) {
     Labels.Builder outLabelsBuilder = Labels.builder();
 


### PR DESCRIPTION
Fixes https://github.com/prometheus/client_java/issues/2095

## Summary

Restores OM1/protobuf compatibility for dotted gauge names after
`feat: move suffix handling to scrape time (#1955)`.

The bug was that non-OpenMetrics exposition changed visible output for gauge
names that merely ended in suffix-like dotted strings such as `.created` and
`.total`.

Examples:

- `Gauge("test3.created")` regressed from `test3` to `test3_created`
- `Gauge("test6.total")` regressed from `test6` to `test6_total`

This PR restores the legacy OM1/protobuf behavior while keeping OpenMetrics on
literal-name handling.

This is the extracted prom-side fix from #2093. The Micrometer workflow and
related downstream testing were split into a stacked follow-up PR so this can
merge independently.

## What changed

- Fix OM1 text exposition for dotted gauge names ending in `.created` and
  `.total`
- Fix protobuf exposition for the same compatibility cases
- Add regression tests that cover the restored OM1/protobuf behavior and the
  preserved OpenMetrics behavior
- Clean up protobuf family-name resolution so legacy gauge handling lives in
  one path instead of pre-rewriting metadata objects

## Follow-up stacked PR

- Micrometer workflow/task split: https://github.com/zeitlinger/client_java/pull/1

## Related

- Replaces: https://github.com/prometheus/client_java/pull/2093
- Issue: https://github.com/prometheus/client_java/issues/2095

## Testing

- `mise run build`
- `mise run lint`
- `./mvnw test -pl prometheus-metrics-exposition-textformats,prometheus-metrics-exposition-formats -Dtest=ExpositionFormatsTest,ProtobufExpositionFormatsTest,DuplicateNamesProtobufTest -Dcoverage.skip=true -Dcheckstyle.skip=true`
