### PR TITLE
test: validate Micrometer typed-descriptor compatibility

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -58,7 +58,9 @@
     },
     ".github/workflows/micrometer-compatibility.yml": {
       "regex": [
-        "mise"
+        "micrometer-metrics/micrometer",
+        "mise",
+        "zeitlinger/micrometer"
       ]
     },
     ".github/workflows/native-tests.yml": {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -77,5 +77,21 @@
          "<!-- renovate: datasource=(?<datasource>[a-z-]+?) packageName=(?<packageName>.+?) -->\\s*<api\\.diff\\.baseline\\.version>(?<currentValue>[^<]+)</api\\.diff\\.baseline\\.version>"
        ]
      },
+     {
+       customType: "regex",
+       description: "track the latest Micrometer release for upstream compatibility",
+       managerFilePatterns: ["/^\\.github\\/workflows\\/micrometer-compatibility\\.yml$/"],
+       matchStrings: [
+         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) packageName=(?<packageName>\\S+)\\n\\s*ref:\\s*(?<currentValue>v[0-9][^\\s]*)",
+       ],
+     },
+     {
+       customType: "regex",
+       description: "pin the Micrometer typed-descriptor compatibility ref",
+       managerFilePatterns: ["/^\\.github\\/workflows\\/micrometer-compatibility\\.yml$/"],
+       matchStrings: [
+         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) packageName=(?<packageName>\\S+) currentValue=(?<currentValue>\\S+)\\n\\s*ref:\\s*(?<currentDigest>[a-f0-9]{40})",
+       ],
+     },
   ],
 }

--- a/.github/workflows/micrometer-compatibility.yml
+++ b/.github/workflows/micrometer-compatibility.yml
@@ -20,11 +20,14 @@ jobs:
             # renovate: datasource=github-releases depName=micrometer-metrics/micrometer packageName=micrometer-metrics/micrometer
             ref: v1.16.5
           - name: typed-descriptor
+            # TODO: remove this temporary opt-in leg once Micrometer switches the
+            # Prometheus client integration to typed descriptors by default.
+            # Follow-up: https://github.com/prometheus/client_java/issues/2182
             repository: zeitlinger/micrometer
             # renovate: datasource=git-refs depName=zeitlinger/micrometer packageName=https://github.com/zeitlinger/micrometer currentValue=feat/prometheus-client-opt-in
             ref: 1af1b3185058941eea57dc467bfe0df5a4786fe4
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/.github/workflows/micrometer-compatibility.yml
+++ b/.github/workflows/micrometer-compatibility.yml
@@ -4,18 +4,11 @@ name: Micrometer Compatibility
 on:
   pull_request:
   workflow_dispatch:
-    inputs:
-      micrometer-repository:
-        description: Micrometer repository to test, in owner/name form
-        required: false
-      micrometer-ref:
-        description: Micrometer branch, tag, or commit to test
-        required: false
 
 permissions: {}
 
 jobs:
-  micrometer-compatibility:
+  compat-test:
     name: ${{ matrix.name }}
     runs-on: ubuntu-24.04
     strategy:
@@ -24,13 +17,14 @@ jobs:
         include:
           - name: upstream
             repository: micrometer-metrics/micrometer
-            ref: main
-          - name: opt-in
+            # renovate: datasource=github-releases depName=micrometer-metrics/micrometer packageName=micrometer-metrics/micrometer
+            ref: v1.16.5
+          - name: typed-descriptor
             repository: zeitlinger/micrometer
             # renovate: datasource=git-refs depName=zeitlinger/micrometer packageName=https://github.com/zeitlinger/micrometer currentValue=feat/prometheus-client-opt-in
             ref: 1af1b3185058941eea57dc467bfe0df5a4786fe4
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -46,6 +40,19 @@ jobs:
       - name: Run Micrometer compatibility tests
         working-directory: .mise/envs/micrometer
         env:
-          MICROMETER_REPOSITORY: ${{ inputs.micrometer-repository || matrix.repository }}
-          MICROMETER_REF: ${{ inputs.micrometer-ref || matrix.ref }}
+          MICROMETER_REPOSITORY: ${{ matrix.repository }}
+          MICROMETER_REF: ${{ matrix.ref }}
         run: mise compat-test
+
+  micrometer-compatibility:
+    name: micrometer-compatibility
+    runs-on: ubuntu-24.04
+    needs: compat-test
+    if: always()
+    steps:
+      - name: Aggregate matrix results
+        run: |
+          if [[ "${{ needs.compat-test.result }}" != "success" ]]; then
+            echo "compat-test matrix failed: ${{ needs.compat-test.result }}"
+            exit 1
+          fi

--- a/.github/workflows/micrometer-compatibility.yml
+++ b/.github/workflows/micrometer-compatibility.yml
@@ -8,16 +8,27 @@ on:
       micrometer-repository:
         description: Micrometer repository to test, in owner/name form
         required: false
-        default: micrometer-metrics/micrometer
       micrometer-ref:
         description: Micrometer branch, tag, or commit to test
-        required: true
+        required: false
 
 permissions: {}
 
 jobs:
   micrometer-compatibility:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: upstream
+            repository: micrometer-metrics/micrometer
+            ref: main
+          - name: opt-in
+            repository: zeitlinger/micrometer
+            # renovate: datasource=git-refs depName=zeitlinger/micrometer packageName=https://github.com/zeitlinger/micrometer currentValue=feat/prometheus-client-opt-in
+            ref: 1af1b3185058941eea57dc467bfe0df5a4786fe4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -35,6 +46,6 @@ jobs:
       - name: Run Micrometer compatibility tests
         working-directory: .mise/envs/micrometer
         env:
-          MICROMETER_REPOSITORY: ${{ inputs.micrometer-repository || 'micrometer-metrics/micrometer' }}
-          MICROMETER_REF: ${{ inputs.micrometer-ref }}
+          MICROMETER_REPOSITORY: ${{ inputs.micrometer-repository || matrix.repository }}
+          MICROMETER_REF: ${{ inputs.micrometer-ref || matrix.ref }}
         run: mise compat-test


### PR DESCRIPTION
Draft validation PR for the downstream opt-in path.

Depends on #2114 for the typed descriptor implementation. This branch is stacked on the #2114 head, so once #2114 lands this PR should shrink to only the Micrometer opt-in compatibility tooling.

This validates Micrometer using the new descriptor API, defaulting to:

- `MICROMETER_REPOSITORY=zeitlinger/micrometer`
- `MICROMETER_REF=feat/prometheus-client-opt-in`

That Micrometer branch provides `MetricFamilyDescriptor` metadata from the Prometheus registry without invoking scrape/sample callbacks during registration.

Local validation:

- `mise run lint`
- `MICROMETER_DIR=/tmp/micrometer-compat-optin mise run micrometer:test`
