### PR TITLE
chore: move narrowly-used test deps out of root pom

### DIFF
--- a/integration-tests/it-exporter/it-exporter-test/pom.xml
+++ b/integration-tests/it-exporter/it-exporter-test/pom.xml
@@ -23,5 +23,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
     <automatic.module.name>--module-name-need-to-be-overridden--</automatic.module.name>
     <protobuf-java.version>4.35.0</protobuf-java.version>
     <guava.version>33.6.0-jre</guava.version>
+    <junit-pioneer.version>2.3.0</junit-pioneer.version>
+    <awaitility.version>4.3.0</awaitility.version>
+    <wiremock.version>3.13.2</wiremock.version>
     <junit-jupiter.version>6.0.3</junit-jupiter.version>
     <otel.instrumentation.version>2.28.1-alpha</otel.instrumentation.version>
     <java.version>8</java.version>
@@ -93,40 +96,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>2.0.18</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit-pioneer</groupId>
-      <artifactId>junit-pioneer</artifactId>
-      <version>2.3.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>4.3.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
-      <version>3.13.2</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/prometheus-metrics-config/pom.xml
+++ b/prometheus-metrics-config/pom.xml
@@ -20,4 +20,13 @@
     <automatic.module.name>io.prometheus.metrics.config</automatic.module.name>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>${junit-pioneer.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/prometheus-metrics-core/pom.xml
+++ b/prometheus-metrics-core/pom.xml
@@ -50,5 +50,17 @@
       <version>3.6.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/prometheus-metrics-exporter-opentelemetry-shaded/pom.xml
+++ b/prometheus-metrics-exporter-opentelemetry-shaded/pom.xml
@@ -94,6 +94,30 @@
           <artifactId>opentelemetry-sdk-testing</artifactId>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.wiremock</groupId>
+          <artifactId>wiremock</artifactId>
+          <version>${wiremock.version}</version>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.hamcrest</groupId>
+              <artifactId>hamcrest-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.awaitility</groupId>
+          <artifactId>awaitility</artifactId>
+          <version>${awaitility.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>${guava.version}</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/prometheus-metrics-exporter-opentelemetry/pom.xml
+++ b/prometheus-metrics-exporter-opentelemetry/pom.xml
@@ -95,6 +95,30 @@
           <artifactId>opentelemetry-sdk-testing</artifactId>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.wiremock</groupId>
+          <artifactId>wiremock</artifactId>
+          <version>${wiremock.version}</version>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.hamcrest</groupId>
+              <artifactId>hamcrest-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.awaitility</groupId>
+          <artifactId>awaitility</artifactId>
+          <version>${awaitility.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>${guava.version}</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>


### PR DESCRIPTION
The root `pom.xml` was declaring `junit-pioneer`, `awaitility`, `wiremock`, and `guava` (test scope) as global test dependencies, adding them to the classpath of all 24 core modules. Each is only actually needed by 1–3 modules.