### PR TITLE
chore: remove deprecated setting

### DIFF
--- a/.github/config/flint.toml
+++ b/.github/config/flint.toml
@@ -1,7 +1,6 @@
 [settings]
 # These paths are generated, vendored, or handled by other checks.
 exclude = ["CHANGELOG.md", "**/src/main/generated/**", "docs/themes/**", "mvnw", "simpleclient-archive/**", "mise.lock"]
-setup_migration_version = 2
 
 [checks.renovate-deps]
 exclude_managers = ["github-actions", "github-runners", "maven"]


### PR DESCRIPTION
Removed setup_migration_version setting from config.