### PR TITLE
ci: avoid cache restore keys on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,5 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Run the Maven verify phase
         run: mise run ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-codeql-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-codeql-
-            ${{ runner.os }}-maven-
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:

--- a/.github/workflows/java-version-matrix-tests.yml
+++ b/.github/workflows/java-version-matrix-tests.yml
@@ -41,9 +41,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Build core library artifacts
         run: mise exec -- ./mvnw install -DskipTests -Dcoverage.skip=true -Dcheckstyle.skip=true -Dwarnings=-nowarn -pl '!integration-tests'
 

--- a/.github/workflows/micrometer-compatibility.yml
+++ b/.github/workflows/micrometer-compatibility.yml
@@ -32,8 +32,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Run Micrometer compatibility tests
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then

--- a/.github/workflows/multi-version-test.yml
+++ b/.github/workflows/multi-version-test.yml
@@ -31,9 +31,5 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-java${{ matrix.java }}-
-            ${{ runner.os }}-maven-
-
       - name: Build and test on Java ${{ matrix.java }}
         run: ./mvnw clean install -Dtest.java.version=${{ matrix.java }} -Dcheckstyle.skip=true -Dwarnings=-nowarn -Dcoverage.skip=true

--- a/.github/workflows/test-release-build.yml
+++ b/.github/workflows/test-release-build.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Build GitHub Pages
         run: mise run build-gh-pages
         env:


### PR DESCRIPTION
## Summary

Removes broad Maven cache `restore-keys` from workflows that run on pull requests, while keeping the exact cache key.

This is a canary remediation for the `cache-security.restore-keys-on-pr` finding from the draft security-hardening skill.

## Validation

- `security_hardening.py detect --repo . --repo-name prometheus/client_java --modules cache-security --jsonl /tmp/client-java-cache.jsonl`