### PR TITLE
test: run JMX Exporter quick test configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,6 +24,13 @@
       additionalBranchPrefix: "graalvm-",
     },
     {
+      description: "Compat tests pin an LTS JDK the upstream release supports; block major JDK bumps that would break those builds",
+      matchFileNames: [".mise/envs/jmx-exporter/mise.toml", ".mise/envs/micrometer/mise.toml"],
+      matchDepNames: ["java"],
+      matchUpdateTypes: ["major"],
+      enabled: false,
+    },
+    {
       matchPackageNames: ["io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha"],
       ignoreUnstable: false,
     },

--- a/.mise/lib/jmx_exporter_compat.py
+++ b/.mise/lib/jmx_exporter_compat.py
@@ -17,11 +17,10 @@ DEFAULT_JMX_EXPORTER_REPOSITORY = os.environ.get(
     "JMX_EXPORTER_REPOSITORY", "prometheus/jmx_exporter"
 )
 DEFAULT_JMX_EXPORTER_REMOTE = os.environ.get("JMX_EXPORTER_REMOTE", "origin")
-DEFAULT_JMX_EXPORTER_REF = (
-    os.environ.get("JMX_EXPORTER_REF")
-    or os.environ.get("DEFAULT_JMX_EXPORTER_VERSION")
-    or "main"
-)
+# Test jmx_exporter main rather than the latest release: the integration_test_suite
+# only compiles against client_java once a release adopts the stable Metrics class
+# (see the tracking issue referenced in mise.toml's DEFAULT_JMX_EXPORTER_VERSION).
+DEFAULT_JMX_EXPORTER_REF = os.environ.get("JMX_EXPORTER_REF") or "main"
 DEFAULT_PROM_VERSION = os.environ.get("PROM_VERSION")
 
 # Quick test configuration: the integration_test_suite runs one matrix cell

--- a/.mise/lib/jmx_exporter_compat.py
+++ b/.mise/lib/jmx_exporter_compat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -21,15 +22,22 @@ DEFAULT_JMX_EXPORTER_REF = (
     or os.environ.get("DEFAULT_JMX_EXPORTER_VERSION")
     or "main"
 )
-DEFAULT_MAVEN_MODULES = os.environ.get(
-    "JMX_EXPORTER_MAVEN_MODULES",
-    "jmx_prometheus_common,jmx_prometheus_javaagent,jmx_prometheus_standalone",
-)
 DEFAULT_PROM_VERSION = os.environ.get("PROM_VERSION")
 
+# Quick test configuration: the integration_test_suite runs one matrix cell
+# (single Java + Prometheus distribution) instead of the full smoke-test matrix.
+# The distributions are read from the checked-out jmx_exporter's run-quick-test.sh
+# so they stay aligned with upstream rather than drifting from a hardcoded copy.
+QUICK_TEST_SCRIPT = "run-quick-test.sh"
+QUICK_TEST_IMAGE_VARS = ("JAVA_DOCKER_IMAGES", "PROMETHEUS_DOCKER_IMAGES")
 
-def run_cmd(cmd: list[str], cwd: Optional[Path] = None) -> None:
-    subprocess.run(cmd, cwd=cwd, check=True)
+
+def run_cmd(
+    cmd: list[str],
+    cwd: Optional[Path] = None,
+    env: Optional[dict[str, str]] = None,
+) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, env=env)
 
 
 def jmx_exporter_repository_url(repository: str) -> str:
@@ -105,24 +113,44 @@ def install_local_artifacts(root_dir: Path = Path.cwd()) -> None:
     )
 
 
-def run_maven_test(
-    test_selector: Optional[str] = None,
+def quick_test_images(
     jmx_exporter_dir: Path = DEFAULT_JMX_EXPORTER_DIR,
-    maven_modules: str = DEFAULT_MAVEN_MODULES,
+) -> dict[str, str]:
+    """Read the quick test docker image pins from the checked-out jmx_exporter's
+    run-quick-test.sh. An explicit env var overrides the script value."""
+    script_path = jmx_exporter_dir / QUICK_TEST_SCRIPT
+    script = script_path.read_text()
+    images: dict[str, str] = {}
+    for var in QUICK_TEST_IMAGE_VARS:
+        override = os.environ.get(var)
+        if override:
+            images[var] = override
+            continue
+        match = re.search(rf'^\s*export\s+{var}="([^"]+)"', script, re.MULTILINE)
+        if not match:
+            raise RuntimeError(f"could not find {var} in {script_path}")
+        images[var] = match.group(1)
+    return images
+
+
+def run_maven_test(
+    jmx_exporter_dir: Path = DEFAULT_JMX_EXPORTER_DIR,
     prom_version: Optional[str] = None,
 ) -> None:
     if prom_version is None:
         prom_version = get_prom_version()
+    # Build the full reactor (including the integration_test_suite) the same way
+    # run-quick-test.sh does, but against our locally installed io.prometheus
+    # artifacts. The pinned distribution env vars keep this to the quick (single
+    # cell) matrix rather than the full smoke-test matrix.
+    env = {**os.environ, **quick_test_images(jmx_exporter_dir)}
     cmd = [
         "./mvnw",
         "-B",
-        "-pl",
-        maven_modules,
-        "-am",
+        "clean",
+        "install",
         f"-Dprometheus.metrics.version={prom_version}",
+        f"-Dparamixel.parallelism={os.cpu_count() or 1}",
         "-Djacoco.skip=true",
     ]
-    if test_selector:
-        cmd.append(f"-Dtest={test_selector}")
-    cmd.append("test")
-    run_cmd(cmd, cwd=jmx_exporter_dir)
+    run_cmd(cmd, cwd=jmx_exporter_dir, env=env)

--- a/mise.toml
+++ b/mise.toml
@@ -27,6 +27,11 @@ zizmor = "1.25.2"
 FLINT_CONFIG_DIR = ".github/config"
 # renovate: datasource=github-releases depName=grafana/docker-otel-lgtm
 LGTM_VERSION = "0.28.0"
+# Latest JMX Exporter release. The compatibility job currently tests `main`
+# instead (see #2179): release 1.5.0 imports client_java's version-stamped
+# protobuf package directly, which breaks when we bump protobuf; main uses the
+# stable Metrics class. Kept renovate-tracked so the target is current when we
+# switch the ref back to this release.
 # renovate: datasource=github-tags depName=prometheus/jmx_exporter versioning=semver-coerced
 DEFAULT_JMX_EXPORTER_VERSION = "1.5.0"
 # renovate: datasource=github-tags depName=micrometer-metrics/micrometer versioning=semver-coerced


### PR DESCRIPTION
Follow-up to #2167 ([review comment](https://github.com/prometheus/client_java/pull/2167#issuecomment-4593772792)): switches the JMX Exporter compatibility job to the **quick test** configuration and fixes the gaps that surfaced.

**Changes**

- **Quick test config** (`jmx_exporter_compat.py`): build the full reactor (`clean install`) so `integration_test_suite` actually runs, pinned to a single Java + Prometheus distribution. The pins are read from the checked-out jmx_exporter's `run-quick-test.sh` so they stay aligned with upstream; `-Dparamixel.parallelism` set to CPU count.
- **Test `main`, not the release**: the integration suite only compiles against current `client_java` when jmx_exporter imports the stable `expositionformats.generated.Metrics` class (#1873). Release 1.5.0 imports the version-stamped `com_google_protobuf_4_32_0` package directly, which breaks on protobuf bumps (now 4.35.0); `main` uses the stable class. Tracked by #2179 — switch the ref back to a pinned release once one ships the fix.
- **Renovate guard** (`renovate.json5`): block major JDK bumps for the jmx-exporter and micrometer compat env files (they pin an LTS JDK the upstream release supports). This supersedes #2173-style bumps.

**Local validation**: `mise run lint:fix`; image-pin regex verified against `prometheus/jmx_exporter@main`. Full integration run is validated by CI (needs Docker + JDK 21).