### PR TITLE
ci(micrometer): bump typed-descriptor opt-in to PR 7487 head

### DIFF
--- a/.github/workflows/micrometer-compatibility.yml
+++ b/.github/workflows/micrometer-compatibility.yml
@@ -24,8 +24,8 @@ jobs:
             # Prometheus client integration to typed descriptors by default.
             # Follow-up: https://github.com/prometheus/client_java/issues/2182
             repository: zeitlinger/micrometer
-            # renovate: datasource=git-refs depName=zeitlinger/micrometer packageName=https://github.com/zeitlinger/micrometer currentValue=feat/prometheus-client-opt-in
-            ref: 1af1b3185058941eea57dc467bfe0df5a4786fe4
+            # renovate: datasource=git-refs depName=zeitlinger/micrometer packageName=https://github.com/zeitlinger/micrometer currentValue=feat/prom-client-java-typed-family-descriptor
+            ref: 84092837e94d16de4d3bf95a4644498ce2ef49fd
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/micrometer-compatibility.yml
+++ b/.github/workflows/micrometer-compatibility.yml
@@ -25,7 +25,7 @@ jobs:
             # Follow-up: https://github.com/prometheus/client_java/issues/2182
             repository: zeitlinger/micrometer
             # renovate: datasource=git-refs depName=zeitlinger/micrometer packageName=https://github.com/zeitlinger/micrometer currentValue=feat/prom-client-java-typed-family-descriptor
-            ref: 84092837e94d16de4d3bf95a4644498ce2ef49fd
+            ref: 09f32142f06b11a88afe41eab50daaf6c8d08efb
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
## Summary
- Points the `typed-descriptor` compat matrix leg at the latest head of [micrometer-metrics/micrometer#7487](https://github.com/micrometer-metrics/micrometer/pull/7487) (`84092837e`), which now builds against client_java 1.7.0 and uses the typed `MetricFamilyDescriptor` API.
- Updates renovate `currentValue` to match the actual PR branch (`feat/prom-client-java-typed-family-descriptor`).

## Test plan
- [ ] Micrometer Compatibility workflow `typed-descriptor` leg passes