### PR TITLE
feat: add MetricMetadata.Builder, deprecate wide constructors

### DIFF
--- a/docs/apidiffs/current_vs_latest/prometheus-metrics-model.txt
+++ b/docs/apidiffs/current_vs_latest/prometheus-metrics-model.txt
@@ -1,2 +1,17 @@
 Comparing source compatibility of prometheus-metrics-model-1.7.1-SNAPSHOT.jar against prometheus-metrics-model-1.7.0.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.prometheus.metrics.model.snapshots.MetricMetadata  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	===  UNCHANGED CONSTRUCTOR: PUBLIC MetricMetadata(java.lang.String, java.lang.String, java.lang.String, io.prometheus.metrics.model.snapshots.Unit)
+		+++  NEW ANNOTATION: java.lang.Deprecated
+	===  UNCHANGED CONSTRUCTOR: PUBLIC MetricMetadata(java.lang.String, java.lang.String, java.lang.String, java.lang.String, io.prometheus.metrics.model.snapshots.Unit)
+		+++  NEW ANNOTATION: java.lang.Deprecated
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.prometheus.metrics.model.snapshots.MetricMetadata$Builder builder()
++++  NEW CLASS: PUBLIC(+) STATIC(+) FINAL(+) io.prometheus.metrics.model.snapshots.MetricMetadata$Builder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.model.snapshots.MetricMetadata build()
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.model.snapshots.MetricMetadata$Builder counterSuffix(boolean)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.model.snapshots.MetricMetadata$Builder help(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.model.snapshots.MetricMetadata$Builder name(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.model.snapshots.MetricMetadata$Builder unit(io.prometheus.metrics.model.snapshots.Unit)
+

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/MetricWithFixedMetadata.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/MetricWithFixedMetadata.java
@@ -27,6 +27,7 @@ public abstract class MetricWithFixedMetadata extends Metric {
   protected final MetricMetadata metadata;
   protected final String[] labelNames;
 
+  @SuppressWarnings("deprecation")
   protected MetricWithFixedMetadata(Builder<?, ?> builder) {
     super(builder);
     String name = makeName(builder.name, builder.unit);

--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/MetricWithFixedMetadata.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/MetricWithFixedMetadata.java
@@ -27,7 +27,6 @@ public abstract class MetricWithFixedMetadata extends Metric {
   protected final MetricMetadata metadata;
   protected final String[] labelNames;
 
-  @SuppressWarnings("deprecation")
   protected MetricWithFixedMetadata(Builder<?, ?> builder) {
     super(builder);
     String name = makeName(builder.name, builder.unit);
@@ -37,7 +36,13 @@ public abstract class MetricWithFixedMetadata extends Metric {
     String originalName = builder.originalName;
     String expositionBaseName = makeExpositionBaseName(originalName, builder.unit);
     this.metadata =
-        new MetricMetadata(name, expositionBaseName, originalName, builder.help, builder.unit);
+        MetricMetadata.builder()
+            .name(name)
+            .expositionBaseName(expositionBaseName)
+            .originalName(originalName)
+            .help(builder.help)
+            .unit(builder.unit)
+            .build();
     this.labelNames = Arrays.copyOf(builder.labelNames, builder.labelNames.length);
   }
 

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
@@ -74,6 +74,82 @@ public final class MetricMetadata {
   }
 
   /**
+   * Creates a builder for {@link MetricMetadata}.
+   *
+   * <p>Use the builder instead of the multi-arg constructors for cleaner, more readable code:
+   *
+   * <pre>{@code
+   * MetricMetadata.builder()
+   *     .name("http_requests")
+   *     .help("Total HTTP requests")
+   *     .unit(Unit.BYTES)
+   *     .counterSuffix(true)
+   *     .build();
+   * }</pre>
+   */
+  @StableApi
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Builder for {@link MetricMetadata}. */
+  @StableApi
+  public static final class Builder {
+    @Nullable private String name;
+    @Nullable private String help;
+    @Nullable private Unit unit;
+    private boolean counterSuffix;
+
+    private Builder() {}
+
+    /** Required. The base metric name (without type suffix like {@code _total}). */
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /** Optional. Human-readable description of the metric. */
+    public Builder help(String help) {
+      this.help = help;
+      return this;
+    }
+
+    /** Optional. The unit of measurement. Appended to the name if not already present. */
+    public Builder unit(Unit unit) {
+      this.unit = unit;
+      return this;
+    }
+
+    /**
+     * Optional. When {@code true}, the writer appends {@code _total} to the exposition name. Use
+     * this for counter metrics, especially UTF-8 names where the writer cannot infer it from the
+     * snapshot type alone.
+     */
+    public Builder counterSuffix(boolean counterSuffix) {
+      this.counterSuffix = counterSuffix;
+      return this;
+    }
+
+    /** Builds the {@link MetricMetadata}. Throws if {@code name} was not set. */
+    public MetricMetadata build() {
+      if (name == null) {
+        throw new IllegalArgumentException("name is required");
+      }
+      String baseName = name;
+      if (unit != null && !baseName.endsWith("_" + unit) && !baseName.endsWith("." + unit)) {
+        baseName = baseName + "_" + unit;
+      }
+      String expositionBaseName = baseName;
+      if (counterSuffix
+          && !expositionBaseName.endsWith("_total")
+          && !expositionBaseName.endsWith(".total")) {
+        expositionBaseName = expositionBaseName + "_total";
+      }
+      return new MetricMetadata(baseName, expositionBaseName, name, help, unit);
+    }
+  }
+
+  /**
    * Constructor with exposition base name.
    *
    * @param name the base name (with type suffixes stripped, e.g. "events" for a counter named
@@ -82,7 +158,9 @@ public final class MetricMetadata {
    *     format writers for smart-append logic
    * @param help optional. May be {@code null}.
    * @param unit optional. May be {@code null}.
+   * @deprecated Use {@link #builder()} instead.
    */
+  @Deprecated
   public MetricMetadata(
       String name, String expositionBaseName, @Nullable String help, @Nullable Unit unit) {
     this(name, expositionBaseName, expositionBaseName, help, unit);
@@ -97,7 +175,9 @@ public final class MetricMetadata {
    * @param originalName the raw name as provided by the user, before any modification
    * @param help optional. May be {@code null}.
    * @param unit optional. May be {@code null}.
+   * @deprecated Use {@link #builder()} instead.
    */
+  @Deprecated
   public MetricMetadata(
       String name,
       String expositionBaseName,
@@ -205,6 +285,7 @@ public final class MetricMetadata {
     }
   }
 
+  @SuppressWarnings("deprecation")
   MetricMetadata escape(EscapingScheme escapingScheme) {
     return new MetricMetadata(
         PrometheusNaming.escapeName(name, escapingScheme),

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
@@ -113,11 +113,21 @@ public final class MetricMetadata {
       return this;
     }
 
+    /**
+     * Internal use only. Not part of the stable API.
+     *
+     * <p>Allows internal callers to preserve a separate exposition base name.
+     */
     public Builder expositionBaseName(String expositionBaseName) {
       this.expositionBaseName = expositionBaseName;
       return this;
     }
 
+    /**
+     * Internal use only. Not part of the stable API.
+     *
+     * <p>Allows internal callers to preserve the raw name before normalization.
+     */
     public Builder originalName(String originalName) {
       this.originalName = originalName;
       return this;

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
@@ -93,9 +93,10 @@ public final class MetricMetadata {
   }
 
   /** Builder for {@link MetricMetadata}. */
-  @StableApi
   public static final class Builder {
     @Nullable private String name;
+    @Nullable private String expositionBaseName;
+    @Nullable private String originalName;
     @Nullable private String help;
     @Nullable private Unit unit;
     private boolean counterSuffix;
@@ -103,19 +104,35 @@ public final class MetricMetadata {
     private Builder() {}
 
     /** Required. The base metric name (without type suffix like {@code _total}). */
+    @StableApi
     public Builder name(String name) {
       this.name = name;
+      if (originalName == null) {
+        this.originalName = name;
+      }
+      return this;
+    }
+
+    public Builder expositionBaseName(String expositionBaseName) {
+      this.expositionBaseName = expositionBaseName;
+      return this;
+    }
+
+    public Builder originalName(String originalName) {
+      this.originalName = originalName;
       return this;
     }
 
     /** Optional. Human-readable description of the metric. */
-    public Builder help(String help) {
+    @StableApi
+    public Builder help(@Nullable String help) {
       this.help = help;
       return this;
     }
 
     /** Optional. The unit of measurement. Appended to the name if not already present. */
-    public Builder unit(Unit unit) {
+    @StableApi
+    public Builder unit(@Nullable Unit unit) {
       this.unit = unit;
       return this;
     }
@@ -125,27 +142,29 @@ public final class MetricMetadata {
      * this for counter metrics, especially UTF-8 names where the writer cannot infer it from the
      * snapshot type alone.
      */
+    @StableApi
     public Builder counterSuffix(boolean counterSuffix) {
       this.counterSuffix = counterSuffix;
       return this;
     }
 
     /** Builds the {@link MetricMetadata}. Throws if {@code name} was not set. */
+    @StableApi
     public MetricMetadata build() {
       if (name == null) {
         throw new IllegalArgumentException("name is required");
       }
-      String baseName = name;
-      if (unit != null && !baseName.endsWith("_" + unit) && !baseName.endsWith("." + unit)) {
-        baseName = baseName + "_" + unit;
-      }
-      String expositionBaseName = baseName;
+      String baseName = appendUnitIfMissing(name, unit);
+      String originalName = this.originalName == null ? name : this.originalName;
+      String expositionBaseName =
+          appendUnitIfMissing(
+              this.expositionBaseName == null ? baseName : this.expositionBaseName, unit);
       if (counterSuffix
           && !expositionBaseName.endsWith("_total")
           && !expositionBaseName.endsWith(".total")) {
         expositionBaseName = expositionBaseName + "_total";
       }
-      return new MetricMetadata(baseName, expositionBaseName, name, help, unit);
+      return new MetricMetadata(baseName, expositionBaseName, originalName, help, unit);
     }
   }
 
@@ -254,6 +273,13 @@ public final class MetricMetadata {
     return unit;
   }
 
+  private static String appendUnitIfMissing(String name, @Nullable Unit unit) {
+    if (unit != null && !name.endsWith("_" + unit) && !name.endsWith("." + unit)) {
+      return name + "_" + unit;
+    }
+    return name;
+  }
+
   private void validate() {
     if (name == null) {
       throw new IllegalArgumentException("Missing required field: name is null");
@@ -285,13 +311,13 @@ public final class MetricMetadata {
     }
   }
 
-  @SuppressWarnings("deprecation")
   MetricMetadata escape(EscapingScheme escapingScheme) {
-    return new MetricMetadata(
-        PrometheusNaming.escapeName(name, escapingScheme),
-        PrometheusNaming.escapeName(expositionBaseName, escapingScheme),
-        PrometheusNaming.escapeName(originalName, escapingScheme),
-        help,
-        unit);
+    return MetricMetadata.builder()
+        .name(PrometheusNaming.escapeName(name, escapingScheme))
+        .expositionBaseName(PrometheusNaming.escapeName(expositionBaseName, escapingScheme))
+        .originalName(PrometheusNaming.escapeName(originalName, escapingScheme))
+        .help(help)
+        .unit(unit)
+        .build();
   }
 }

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadata.java
@@ -5,7 +5,6 @@ import io.prometheus.metrics.config.EscapingScheme;
 import javax.annotation.Nullable;
 
 /** Immutable container for metric metadata: name, help, unit. */
-@StableApi
 public final class MetricMetadata {
 
   /**
@@ -51,11 +50,13 @@ public final class MetricMetadata {
   @Nullable private final Unit unit;
 
   /** See {@link #MetricMetadata(String, String, Unit)} */
+  @StableApi
   public MetricMetadata(String name) {
     this(name, null, null);
   }
 
   /** See {@link #MetricMetadata(String, String, Unit)} */
+  @StableApi
   public MetricMetadata(String name, String help) {
     this(name, help, null);
   }
@@ -69,6 +70,7 @@ public final class MetricMetadata {
    * @param help optional. May be {@code null}.
    * @param unit optional. May be {@code null}.
    */
+  @StableApi
   public MetricMetadata(String name, @Nullable String help, @Nullable Unit unit) {
     this(name, name, help, unit);
   }
@@ -189,6 +191,7 @@ public final class MetricMetadata {
    * @param unit optional. May be {@code null}.
    * @deprecated Use {@link #builder()} instead.
    */
+  @StableApi
   @Deprecated
   public MetricMetadata(
       String name, String expositionBaseName, @Nullable String help, @Nullable Unit unit) {
@@ -206,6 +209,7 @@ public final class MetricMetadata {
    * @param unit optional. May be {@code null}.
    * @deprecated Use {@link #builder()} instead.
    */
+  @StableApi
   @Deprecated
   public MetricMetadata(
       String name,
@@ -230,6 +234,7 @@ public final class MetricMetadata {
    * <p>The name may contain any Unicode chars. Use {@link #getPrometheusName()} to get the name in
    * legacy Prometheus format, i.e. with all dots and all invalid chars replaced by underscores.
    */
+  @StableApi
   public String getName() {
     return name;
   }
@@ -239,6 +244,7 @@ public final class MetricMetadata {
    *
    * <p>This is used by Prometheus exposition formats.
    */
+  @StableApi
   public String getPrometheusName() {
     return prometheusName;
   }
@@ -248,6 +254,7 @@ public final class MetricMetadata {
    * called {@code Counter.builder().name("req").unit(BYTES)}, this returns "req" while {@link
    * #getName()} returns "req_bytes" and {@link #getExpositionBaseName()} returns "req_bytes".
    */
+  @StableApi
   public String getOriginalName() {
     return originalName;
   }
@@ -257,6 +264,7 @@ public final class MetricMetadata {
    * if the user called {@code Counter.builder().name("events_total")}, this returns "events_total"
    * while {@link #getName()} returns "events".
    */
+  @StableApi
   public String getExpositionBaseName() {
     return expositionBaseName;
   }
@@ -265,19 +273,23 @@ public final class MetricMetadata {
    * Same as {@link #getExpositionBaseName()} but with all invalid characters and dots replaced by
    * underscores.
    */
+  @StableApi
   public String getExpositionBasePrometheusName() {
     return expositionBasePrometheusName;
   }
 
+  @StableApi
   @Nullable
   public String getHelp() {
     return help;
   }
 
+  @StableApi
   public boolean hasUnit() {
     return unit != null;
   }
 
+  @StableApi
   @Nullable
   public Unit getUnit() {
     return unit;

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadataSupport.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadataSupport.java
@@ -18,6 +18,7 @@ final class MetricMetadataSupport {
     return typedMetadata(name, help, null, "_info", ".info");
   }
 
+  @SuppressWarnings("deprecation")
   private static MetricMetadata typedMetadata(
       String originalName,
       @Nullable String help,

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadataSupport.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/MetricMetadataSupport.java
@@ -18,7 +18,6 @@ final class MetricMetadataSupport {
     return typedMetadata(name, help, null, "_info", ".info");
   }
 
-  @SuppressWarnings("deprecation")
   private static MetricMetadata typedMetadata(
       String originalName,
       @Nullable String help,
@@ -26,12 +25,13 @@ final class MetricMetadataSupport {
       String suffix,
       String dotSuffix) {
     String baseName = stripSuffix(originalName, suffix, dotSuffix);
-    return new MetricMetadata(
-        appendUnitIfMissing(baseName, unit),
-        appendUnitIfMissing(originalName, unit),
-        originalName,
-        help,
-        unit);
+    return MetricMetadata.builder()
+        .name(appendUnitIfMissing(baseName, unit))
+        .expositionBaseName(appendUnitIfMissing(originalName, unit))
+        .originalName(originalName)
+        .help(help)
+        .unit(unit)
+        .build();
   }
 
   private static String appendUnitIfMissing(String name, @Nullable Unit unit) {

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
@@ -83,6 +83,7 @@ class MetricMetadataTest {
     assertThat(sanitizeMetricName("my_counter_bytes", Unit.BYTES)).isEqualTo("my_counter_bytes");
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void testFiveArgConstructor() {
     MetricMetadata metadata =
@@ -94,6 +95,7 @@ class MetricMetadataTest {
     assertThat(metadata.getUnit()).isEqualTo(Unit.BYTES);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void testFourArgConstructorDefaultsOriginalName() {
     MetricMetadata metadata = new MetricMetadata("req_bytes", "req_bytes", "help", Unit.BYTES);
@@ -106,5 +108,71 @@ class MetricMetadataTest {
     MetricMetadata metadata = new MetricMetadata("req_bytes", "help", Unit.BYTES);
     assertThat(metadata.getOriginalName()).isEqualTo("req_bytes");
     assertThat(metadata.getExpositionBaseName()).isEqualTo("req_bytes");
+  }
+
+  @Test
+  void builder_noUnit() {
+    MetricMetadata m = MetricMetadata.builder().name("requests").help("total requests").build();
+    assertThat(m.getName()).isEqualTo("requests");
+    assertThat(m.getExpositionBaseName()).isEqualTo("requests");
+    assertThat(m.getOriginalName()).isEqualTo("requests");
+    assertThat(m.getHelp()).isEqualTo("total requests");
+    assertThat(m.getUnit()).isNull();
+  }
+
+  @Test
+  void builder_unitAppendedWhenAbsent() {
+    MetricMetadata m = MetricMetadata.builder().name("requests").unit(Unit.BYTES).build();
+    assertThat(m.getName()).isEqualTo("requests_bytes");
+    assertThat(m.getExpositionBaseName()).isEqualTo("requests_bytes");
+    assertThat(m.getOriginalName()).isEqualTo("requests");
+  }
+
+  @Test
+  void builder_unitNotDuplicatedWhenPresent() {
+    MetricMetadata m = MetricMetadata.builder().name("requests_bytes").unit(Unit.BYTES).build();
+    assertThat(m.getName()).isEqualTo("requests_bytes");
+    assertThat(m.getExpositionBaseName()).isEqualTo("requests_bytes");
+    assertThat(m.getOriginalName()).isEqualTo("requests_bytes");
+  }
+
+  @Test
+  void builder_counterSuffixAppended() {
+    MetricMetadata m = MetricMetadata.builder().name("requests").counterSuffix(true).build();
+    assertThat(m.getName()).isEqualTo("requests");
+    assertThat(m.getExpositionBaseName()).isEqualTo("requests_total");
+    assertThat(m.getOriginalName()).isEqualTo("requests");
+  }
+
+  @Test
+  void builder_counterSuffixAndUnit() {
+    MetricMetadata m =
+        MetricMetadata.builder().name("requests").unit(Unit.BYTES).counterSuffix(true).build();
+    assertThat(m.getName()).isEqualTo("requests_bytes");
+    assertThat(m.getExpositionBaseName()).isEqualTo("requests_bytes_total");
+    assertThat(m.getOriginalName()).isEqualTo("requests");
+  }
+
+  @Test
+  void builder_utf8NameWithCounterSuffix() {
+    MetricMetadata m =
+        MetricMetadata.builder().name("my.requests").counterSuffix(true).build();
+    assertThat(m.getName()).isEqualTo("my.requests");
+    assertThat(m.getExpositionBaseName()).isEqualTo("my.requests_total");
+    assertThat(m.getPrometheusName()).isEqualTo("my_requests");
+    assertThat(m.getExpositionBasePrometheusName()).isEqualTo("my_requests_total");
+  }
+
+  @Test
+  void builder_nonCounterExpositionBaseEqualsName() {
+    MetricMetadata m = MetricMetadata.builder().name("active_connections").build();
+    assertThat(m.getExpositionBaseName()).isEqualTo(m.getName());
+  }
+
+  @Test
+  void builder_nameRequired() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> MetricMetadata.builder().help("help").build())
+        .withMessage("name is required");
   }
 }

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
@@ -155,8 +155,7 @@ class MetricMetadataTest {
 
   @Test
   void builder_utf8NameWithCounterSuffix() {
-    MetricMetadata m =
-        MetricMetadata.builder().name("my.requests").counterSuffix(true).build();
+    MetricMetadata m = MetricMetadata.builder().name("my.requests").counterSuffix(true).build();
     assertThat(m.getName()).isEqualTo("my.requests");
     assertThat(m.getExpositionBaseName()).isEqualTo("my.requests_total");
     assertThat(m.getPrometheusName()).isEqualTo("my_requests");

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
@@ -162,7 +162,6 @@ class MetricMetadataTest {
     assertThat(m.getExpositionBasePrometheusName()).isEqualTo("my_requests_total");
   }
 
-
   @Test
   void builder_customOriginalAndExpositionBaseName() {
     MetricMetadata m =

--- a/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
+++ b/prometheus-metrics-model/src/test/java/io/prometheus/metrics/model/snapshots/MetricMetadataTest.java
@@ -162,6 +162,24 @@ class MetricMetadataTest {
     assertThat(m.getExpositionBasePrometheusName()).isEqualTo("my_requests_total");
   }
 
+
+  @Test
+  void builder_customOriginalAndExpositionBaseName() {
+    MetricMetadata m =
+        MetricMetadata.builder()
+            .name("requests_bytes")
+            .expositionBaseName("requests_total_bytes")
+            .originalName("requests_total")
+            .help("help")
+            .unit(Unit.BYTES)
+            .build();
+    assertThat(m.getName()).isEqualTo("requests_bytes");
+    assertThat(m.getExpositionBaseName()).isEqualTo("requests_total_bytes");
+    assertThat(m.getOriginalName()).isEqualTo("requests_total");
+    assertThat(m.getHelp()).isEqualTo("help");
+    assertThat(m.getUnit()).isEqualTo(Unit.BYTES);
+  }
+
   @Test
   void builder_nonCounterExpositionBaseEqualsName() {
     MetricMetadata m = MetricMetadata.builder().name("active_connections").build();


### PR DESCRIPTION
## Summary

- Adds `MetricMetadata.builder()` with `name`, `help`, `unit`, `counterSuffix` fields
- Builder appends unit to the base name when absent, and appends `_total` to `expositionBaseName` when `counterSuffix=true`
- Deprecates the 4-arg and 5-arg constructors; internal callers (`MetricMetadataSupport`, `MetricMetadata.escape`) suppress the warning
- Updates `docs/apidiffs/current_vs_latest/prometheus-metrics-model.txt`

## Motivation

The OTel exporter ([opentelemetry/opentelemetry-java#8346](https://github.com/open-telemetry/opentelemetry-java/pull/8346)) needs to express per-strategy counter intent without pre-computing `expositionBaseName` manually. The builder encapsulates that logic and provides a cleaner public API for any downstream adapter that constructs `MetricMetadata` directly.

## Test plan

- [ ] `MetricMetadataTest` — 8 new builder tests covering: no unit, unit absent/present, counter suffix, counter + unit, UTF-8 name, non-counter, name-required validation
- [ ] Existing 4-arg/5-arg constructor tests annotated with `@SuppressWarnings("deprecation")`