### PR TITLE
test: pin JMX Exporter compat job to release

### DIFF
--- a/.mise/lib/jmx_exporter_compat.py
+++ b/.mise/lib/jmx_exporter_compat.py
@@ -17,10 +17,11 @@ DEFAULT_JMX_EXPORTER_REPOSITORY = os.environ.get(
     "JMX_EXPORTER_REPOSITORY", "prometheus/jmx_exporter"
 )
 DEFAULT_JMX_EXPORTER_REMOTE = os.environ.get("JMX_EXPORTER_REMOTE", "origin")
-# Test jmx_exporter main rather than the latest release: the integration_test_suite
-# only compiles against client_java once a release adopts the stable Metrics class
-# (see the tracking issue referenced in mise.toml's DEFAULT_JMX_EXPORTER_VERSION).
-DEFAULT_JMX_EXPORTER_REF = os.environ.get("JMX_EXPORTER_REF") or "main"
+DEFAULT_JMX_EXPORTER_REF = (
+    os.environ.get("JMX_EXPORTER_REF")
+    or os.environ.get("DEFAULT_JMX_EXPORTER_VERSION")
+    or "main"
+)
 DEFAULT_PROM_VERSION = os.environ.get("PROM_VERSION")
 
 # Quick test configuration: the integration_test_suite runs one matrix cell

--- a/mise.toml
+++ b/mise.toml
@@ -27,11 +27,7 @@ zizmor = "1.25.2"
 FLINT_CONFIG_DIR = ".github/config"
 # renovate: datasource=github-releases depName=grafana/docker-otel-lgtm
 LGTM_VERSION = "0.28.0"
-# Latest JMX Exporter release. The compatibility job currently tests `main`
-# instead (see #2179): release 1.5.0 imports client_java's version-stamped
-# protobuf package directly, which breaks when we bump protobuf; main uses the
-# stable Metrics class. Kept renovate-tracked so the target is current when we
-# switch the ref back to this release.
+# Latest JMX Exporter release; used as the default ref for the compatibility job.
 # renovate: datasource=github-tags depName=prometheus/jmx_exporter versioning=semver-coerced
 DEFAULT_JMX_EXPORTER_VERSION = "v1.6.0"
 # renovate: datasource=github-tags depName=micrometer-metrics/micrometer versioning=semver-coerced


### PR DESCRIPTION
## Summary

- v1.6.0 of jmx_exporter ships the stable `io.prometheus.metrics.expositionformats.generated.Metrics` class (verified in `integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MetricsParser.java` on the v1.6.0 tag).
- Restore `DEFAULT_JMX_EXPORTER_VERSION` (currently `v1.6.0`, renovate-tracked) as the default ref so the compatibility job pins to a release again. `workflow_dispatch`'s `JMX_EXPORTER_REF` still overrides.
- Drops the stale comment in `mise.toml` that explained why we tracked `main`.

Closes #2179. Follow-up to #2178.

## Test plan

- [ ] CI `JMX Exporter Compatibility` job runs against `v1.6.0` and passes.