### PR TITLE
fix: preserve OM2 info metric names

### DIFF
--- a/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriter.java
+++ b/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriter.java
@@ -41,8 +41,8 @@ import javax.annotation.Nullable;
 
 /**
  * Write the OpenMetrics 2.0 text format. Unlike the OM1 writer, this writer outputs metric names as
- * provided by the user, without appending {@code _total} or unit suffixes. The {@code _info} suffix
- * is enforced per the OM2 spec (MUST). This is experimental and subject to change as the <a
+ * provided by the user, without appending {@code _total}, unit, or {@code _info} suffixes. This is
+ * experimental and subject to change as the <a
  * href="https://github.com/prometheus/docs/blob/main/docs/specs/om/open_metrics_spec_2_0.md">OpenMetrics
  * 2.0 specification</a> evolves.
  */
@@ -550,9 +550,7 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
   private void writeInfo(Writer writer, InfoSnapshot snapshot, EscapingScheme scheme)
       throws IOException {
     MetricMetadata metadata = snapshot.getMetadata();
-    // OM2 spec: Info MetricFamily name MUST end in _info.
-    // In OM2, TYPE/HELP use the same name as the data lines.
-    String infoName = ensureSuffix(getOriginalMetadataName(metadata, scheme), "_info");
+    String infoName = getOriginalMetadataName(metadata, scheme);
     writeMetadataWithName(writer, infoName, "info", metadata);
     for (InfoSnapshot.InfoDataPointSnapshot data : snapshot.getDataPoints()) {
       writeNameAndLabels(writer, infoName, null, data.getLabels(), scheme);
@@ -712,12 +710,5 @@ public class OpenMetrics2TextFormatWriter implements ExpositionFormatWriter {
       writeEscapedString(writer, metadata.getHelp());
       writer.write('\n');
     }
-  }
-
-  private static String ensureSuffix(String name, String suffix) {
-    if (name.endsWith(suffix)) {
-      return name;
-    }
-    return name + suffix;
   }
 }

--- a/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriterTest.java
+++ b/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/OpenMetrics2TextFormatWriterTest.java
@@ -181,7 +181,7 @@ class OpenMetrics2TextFormatWriterTest {
   }
 
   @Test
-  void testInfoHelpNameMatchesMeterName() throws IOException {
+  void testInfoPreservesOriginalName() throws IOException {
     MetricSnapshots snapshots =
         MetricSnapshots.of(
             InfoSnapshot.builder()
@@ -195,12 +195,35 @@ class OpenMetrics2TextFormatWriterTest {
 
     String om2Output = writeWithOM2(snapshots);
 
-    // OM2: TYPE/HELP use the full name including _info (help name == meter name)
+    // OM2: preserve the original metric name without appending _info.
+    assertThat(om2Output)
+        .isEqualTo(
+            "# TYPE my info\n"
+                + "# HELP my Test info\n"
+                + "my{platform=\"linux\",version=\"1.0\"} 1\n"
+                + "# EOF\n");
+  }
+
+  @Test
+  void testInfoKeepsExistingInfoSuffix() throws IOException {
+    MetricSnapshots snapshots =
+        MetricSnapshots.of(
+            InfoSnapshot.builder()
+                .name("my_info")
+                .help("Test info")
+                .dataPoint(
+                    InfoSnapshot.InfoDataPointSnapshot.builder()
+                        .labels(Labels.of("version", "1.0"))
+                        .build())
+                .build());
+
+    String om2Output = writeWithOM2(snapshots);
+
     assertThat(om2Output)
         .isEqualTo(
             "# TYPE my_info info\n"
                 + "# HELP my_info Test info\n"
-                + "my_info{platform=\"linux\",version=\"1.0\"} 1\n"
+                + "my_info{version=\"1.0\"} 1\n"
                 + "# EOF\n");
   }
 


### PR DESCRIPTION
## Summary
- preserve OpenMetrics 2 info metric names instead of appending `_info`
- keep the existing name unchanged when it already includes `_info`
- update OM2 writer tests to cover both cases

## Testing
- `./mvnw test -pl prometheus-metrics-exposition-textformats -Dtest=OpenMetrics2TextFormatWriterTest -Dcoverage.skip=true -Dcheckstyle.skip=true`
- `mise run build`
- `mise run lint:fix`