### PR TITLE
ci: auto-regenerate api-diff on OTel renovate updates

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -73,6 +73,11 @@
         "mise"
       ]
     },
+    ".github/workflows/regenerate-api-diff-otel.yml": {
+      "regex": [
+        "mise"
+      ]
+    },
     ".github/workflows/release.yml": {
       "regex": [
         "mise"

--- a/.github/workflows/regenerate-api-diff-otel.yml
+++ b/.github/workflows/regenerate-api-diff-otel.yml
@@ -1,0 +1,88 @@
+---
+name: Regenerate API Diff (OTel update)
+
+on:
+  push:
+    branches:
+      - "renovate/otel.instrumentation.version"
+
+permissions: {}
+
+jobs:
+  generate:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout + read-only `git fetch origin main` for the verify step
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.ref }}
+          persist-credentials: false
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: v2026.6.10
+          sha256: 656131b5d995493c18b06c2135afda193f94a1848e0a4d1cb07a1161859d0c80
+      - name: Cache local Maven repository
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Verify OTel instrumentation version was updated
+        run: |
+          git fetch origin main
+          DIFF_POM=$(git diff origin/main -- pom.xml)
+          if ! echo "$DIFF_POM" | grep -q 'otel.instrumentation.version'; then
+            echo "::error::otel.instrumentation.version not updated in pom.xml"
+            exit 1
+          fi
+      - name: Regenerate API diff
+        run: mise run api-diff
+      - name: Validate and export apidiff changes as a patch
+        run: |
+          UNEXPECTED=$(git diff --name-only | grep -v '^docs/apidiffs/' || true)
+          if [[ -n "$UNEXPECTED" ]]; then
+            echo "::error::Unexpected files changed:"
+            echo "$UNEXPECTED"
+            exit 1
+          fi
+          git diff --binary -- docs/apidiffs > /tmp/apidiffs.patch
+      - name: Upload generated patch
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: apidiffs-patch
+          path: /tmp/apidiffs.patch
+          retention-days: 5
+
+  publish:
+    runs-on: ubuntu-24.04
+    needs: generate
+    permissions:
+      contents: write # push regenerated apidiffs back to the renovate branch
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.ref }}
+          # zizmor: ignore[artipacked] -- needs credentials to push
+          persist-credentials: true
+      - name: Download generated patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: apidiffs-patch
+          path: /tmp/patch
+      - name: Commit and push regenerated apidiffs
+        run: |
+          PATCH=/tmp/patch/apidiffs.patch
+          if [[ ! -s "$PATCH" ]]; then
+            echo "No apidiff changes to commit"
+            exit 0
+          fi
+          git apply "$PATCH"
+          # Note: GITHUB_TOKEN pushes don't trigger CI re-runs.
+          # Close and reopen the PR to trigger CI after this commit.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/apidiffs
+          git commit -m "chore: regenerate api diff"
+          git push


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/regenerate-api-diff-otel.yml`, mirroring `generate-protobuf.yml`.
- Triggered on push to `renovate/otel.instrumentation.version`: runs `mise run api-diff` and commits the refreshed `docs/apidiffs/` back to the branch.
- Without this, every OTel instrumentation bump fails the `api-diff` check because the shaded package name (e.g. `io_opentelemetry_2_28_1_alpha` → `io_opentelemetry_2_29_0_alpha`) shifts the published API surface. See [#2236](https://github.com/prometheus/client_java/pull/2236).

## Test plan

- [ ] After merge, the next OTel renovate PR should auto-commit the regenerated apidiffs and pass the `api-diff` check (renovate PR must be closed/reopened to retrigger CI after the bot commit, same as protoc).