### PR TITLE
fix: include license files in release source jars

### DIFF
--- a/prometheus-metrics-parent/pom.xml
+++ b/prometheus-metrics-parent/pom.xml
@@ -74,6 +74,32 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.6.1</version>
+            <executions>
+              <execution>
+                <id>add-license-resources</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>add-resource</goal>
+                </goals>
+                <configuration>
+                  <resources>
+                    <resource>
+                      <directory>${maven.multiModuleProjectDirectory}</directory>
+                      <targetPath>META-INF</targetPath>
+                      <includes>
+                        <include>LICENSE</include>
+                        <include>NOTICE</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>3.2.8</version>


### PR DESCRIPTION
## Summary

- Include repo-level `LICENSE` and `NOTICE` files as `META-INF` resources during release builds.
- Ensures generated `*-sources.jar` artifacts contain license information for legal/compliance scanners.

## Verification

- Confirmed affected source jars include:
  - `META-INF/LICENSE`
  - `META-INF/NOTICE`
- Ran targeted module tests:
  - `prometheus-metrics-config`: 59 tests passed

Fixes #2216