### PR TITLE
ci: auto-label expected OTel api diffs

### DIFF
--- a/.github/workflows/regenerate-api-diff-otel.yml
+++ b/.github/workflows/regenerate-api-diff-otel.yml
@@ -48,11 +48,41 @@ jobs:
             exit 1
           fi
           git diff --binary -- docs/apidiffs > /tmp/apidiffs.patch
+      - name: Detect expected shaded OTel API incompatibility
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import xml.etree.ElementTree as ET
+
+          failures = []
+          for report in sorted(Path('.').glob('**/target/japicmp/api-diff.xml')):
+              parts = report.parts
+              module = '/'.join(parts[: parts.index('target')])
+              tree = ET.parse(report)
+              for change in tree.findall('.//compatibilityChange'):
+                  binary = change.get('binaryCompatible') == 'false'
+                  source = change.get('sourceCompatible') == 'false'
+                  if binary or source:
+                      failures.append((module, change.get('type', 'unknown')))
+
+          expected = {
+              ('prometheus-metrics-exporter-opentelemetry-shaded', 'CONSTRUCTOR_REMOVED')
+          }
+          if failures and set(failures).issubset(expected):
+              Path('/tmp/add-breaking-api-change-accepted-label').write_text('true\n')
+          PY
       - name: Upload generated patch
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: apidiffs-patch
           path: /tmp/apidiffs.patch
+          retention-days: 5
+      - name: Upload label marker
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: add-breaking-api-change-accepted-label
+          path: /tmp/add-breaking-api-change-accepted-label
+          if-no-files-found: ignore
           retention-days: 5
 
   publish:
@@ -60,6 +90,8 @@ jobs:
     needs: generate
     permissions:
       contents: write # push regenerated apidiffs back to the renovate branch
+      issues: write # add the breaking-api-change-accepted label to the PR when needed
+      pull-requests: read # discover the PR for the renovate branch
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -71,6 +103,13 @@ jobs:
         with:
           name: apidiffs-patch
           path: /tmp/patch
+      - name: Download label marker
+        id: download-label-marker
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: add-breaking-api-change-accepted-label
+          path: /tmp/label-marker
       - name: Commit and push regenerated apidiffs
         run: |
           PATCH=/tmp/patch/apidiffs.patch
@@ -80,9 +119,20 @@ jobs:
           fi
           git apply "$PATCH"
           # Note: GITHUB_TOKEN pushes don't trigger CI re-runs.
-          # Close and reopen the PR to trigger CI after this commit.
+          # The label step below triggers a fresh api-diff run on the PR.
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/apidiffs
           git commit -m "chore: regenerate api diff"
           git push
+      - name: Add breaking-api-change-accepted label
+        if: ${{ steps.download-label-marker.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=$(gh pr list             --repo "$GITHUB_REPOSITORY"             --head "$GITHUB_REF_NAME"             --state open             --json number             --jq '.[0].number')
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "::error::No open PR found for branch $GITHUB_REF_NAME"
+            exit 1
+          fi
+          gh pr edit "$PR_NUMBER"             --repo "$GITHUB_REPOSITORY"             --add-label breaking-api-change-accepted


### PR DESCRIPTION
## Summary
- extend the OTel api-diff regeneration workflow to detect the expected shaded OTel incompatibility from generated japicmp reports
- upload a marker artifact only when the incompatible changes are limited to the expected shaded constructor removal
- add `breaking-api-change-accepted` to the open Renovate PR for `renovate/otel.instrumentation.version` after the workflow pushes regenerated apidiffs

## Why
The current workflow only regenerates `docs/apidiffs`. When an OTel bump changes the shaded package version, the PR can still fail the separate incompatible API gate until the acceptance label is added manually.

## Validation
- `mise run lint:fix`
- `actionlint .github/workflows/regenerate-api-diff-otel.yml`
