### PR TITLE
revert: restore OTel exporter API compatibility

### DIFF
--- a/docs/apidiffs/current_vs_latest/prometheus-metrics-exporter-opentelemetry-shaded.txt
+++ b/docs/apidiffs/current_vs_latest/prometheus-metrics-exporter-opentelemetry-shaded.txt
@@ -1,6 +1,2 @@
 Comparing source compatibility of prometheus-metrics-exporter-opentelemetry-1.8.1-SNAPSHOT.jar against prometheus-metrics-exporter-opentelemetry-1.8.0.jar
-***! MODIFIED CLASS: PUBLIC io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter  (not serializable)
-	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
-	---! REMOVED CONSTRUCTOR: PUBLIC(-) OpenTelemetryExporter(io.prometheus.metrics.shaded.io_opentelemetry_2_28_1_alpha.sdk.metrics.export.MetricReader)
-	+++  NEW CONSTRUCTOR: PUBLIC(+) OpenTelemetryExporter(io.prometheus.metrics.shaded.io_opentelemetry_2_29_0_alpha.sdk.metrics.export.MetricReader)
-
+No changes.

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <awaitility.version>4.3.0</awaitility.version>
     <wiremock.version>3.13.2</wiremock.version>
     <junit-jupiter.version>6.1.0</junit-jupiter.version>
-    <otel.instrumentation.version>2.29.0-alpha</otel.instrumentation.version>
+    <otel.instrumentation.version>2.28.1-alpha</otel.instrumentation.version>
     <java.version>8</java.version>
     <test.java.version>25</test.java.version>
     <!-- Bumped by .github/workflows/bump-api-diff-baseline.yml after each release. -->


### PR DESCRIPTION
## Summary
- revert `otel.instrumentation.version` from `2.29.0-alpha` to `2.28.1-alpha`
- restore `docs/apidiffs/current_vs_latest/prometheus-metrics-exporter-opentelemetry-shaded.txt` to `No changes.`

## Why
PR #2236 updated the shaded OpenTelemetry dependency and changed the public constructor type of `OpenTelemetryExporter` in the shaded exporter module.

That introduced a real `@StableApi` incompatibility on `main`:
- `prometheus-metrics-exporter-opentelemetry-shaded: CONSTRUCTOR_REMOVED`

Because the compatibility gate compares every PR against the pinned release baseline, once that breaking change landed on `main`, unrelated PRs started inheriting the same `api-diff` failure.

`main` should not require per-PR acceptance labels for an already-merged patch/minor-line change, so this PR restores compatibility on `main` by reverting the dependency bump.

## Validation
- `mise run lint:fix`
- `mise run api-diff` (interrupted after the affected modules completed)
- verified module-level japicmp output for both exporter variants:
  - `prometheus-metrics-exporter-opentelemetry/target/japicmp/api-diff.diff` → `No changes.`
  - `prometheus-metrics-exporter-opentelemetry-shaded/target/japicmp/api-diff.diff` → `No changes.`
