### PR TITLE
fix: stabilize OpenTelemetry exporter builder API

### DIFF
--- a/docs/apidiffs/current_vs_latest/prometheus-metrics-exporter-opentelemetry-shaded.txt
+++ b/docs/apidiffs/current_vs_latest/prometheus-metrics-exporter-opentelemetry-shaded.txt
@@ -2,5 +2,19 @@ Comparing source compatibility of prometheus-metrics-exporter-opentelemetry-1.8.
 ***! MODIFIED CLASS: PUBLIC io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	---! REMOVED CONSTRUCTOR: PUBLIC(-) OpenTelemetryExporter(io.prometheus.metrics.shaded.io_opentelemetry_2_28_1_alpha.sdk.metrics.export.MetricReader)
-	+++  NEW CONSTRUCTOR: PUBLIC(+) OpenTelemetryExporter(io.prometheus.metrics.shaded.io_opentelemetry_2_29_0_alpha.sdk.metrics.export.MetricReader)
+***  MODIFIED CLASS: PUBLIC STATIC io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter buildAndStart()
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder endpoint(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder header(java.lang.String, java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder intervalSeconds(int)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder preserveNames(boolean)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder protocol(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder registry(io.prometheus.metrics.model.registry.PrometheusRegistry)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder resourceAttribute(java.lang.String, java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder serviceInstanceId(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder serviceName(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder serviceNamespace(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder serviceVersion(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder timeoutSeconds(int)
 

--- a/docs/apidiffs/current_vs_latest/prometheus-metrics-exporter-opentelemetry.txt
+++ b/docs/apidiffs/current_vs_latest/prometheus-metrics-exporter-opentelemetry.txt
@@ -1,2 +1,20 @@
 Comparing source compatibility of prometheus-metrics-exporter-opentelemetry-no-otel-1.8.1-SNAPSHOT.jar against prometheus-metrics-exporter-opentelemetry-no-otel-1.8.0.jar
-No changes.
+***! MODIFIED CLASS: PUBLIC io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	---! REMOVED CONSTRUCTOR: PUBLIC(-) OpenTelemetryExporter(io.opentelemetry.sdk.metrics.export.MetricReader)
+***  MODIFIED CLASS: PUBLIC STATIC io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter buildAndStart()
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder endpoint(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder header(java.lang.String, java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder intervalSeconds(int)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder preserveNames(boolean)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder protocol(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder registry(io.prometheus.metrics.model.registry.PrometheusRegistry)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder resourceAttribute(java.lang.String, java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder serviceInstanceId(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder serviceName(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder serviceNamespace(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder serviceVersion(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter$Builder timeoutSeconds(int)
+

--- a/prometheus-metrics-exporter-opentelemetry/src/main/java/io/prometheus/metrics/exporter/opentelemetry/OpenTelemetryExporter.java
+++ b/prometheus-metrics-exporter-opentelemetry/src/main/java/io/prometheus/metrics/exporter/opentelemetry/OpenTelemetryExporter.java
@@ -8,27 +8,35 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-@StableApi
 public class OpenTelemetryExporter implements AutoCloseable {
   private final MetricReader reader;
 
+  /**
+   * @deprecated This constructor is not part of the stable API. Use {@link #builder()} or {@link
+   *     #builder(PrometheusProperties)} instead.
+   */
+  @Deprecated
   public OpenTelemetryExporter(MetricReader reader) {
     this.reader = reader;
   }
 
+  @StableApi
   @Override
   public void close() {
     reader.shutdown();
   }
 
+  @StableApi
   public static Builder builder() {
     return new Builder(PrometheusProperties.get());
   }
 
+  @StableApi
   public static Builder builder(PrometheusProperties config) {
     return new Builder(config);
   }
 
+  @StableApi
   public static class Builder {
 
     private final PrometheusProperties config;


### PR DESCRIPTION
Blocked by https://github.com/prometheus/client_java/pull/2265 - to make sure that breaking api change is correctly flagged

## Summary
- deprecate the `OpenTelemetryExporter(MetricReader)` constructor instead of treating it as stable API
- make the builder entry points the stable surface for `OpenTelemetryExporter`
- grandfather the already-accepted constructor removal in the API diff workflow so unrelated PRs stop inheriting the failure on `main`

## Testing
- mise run lint:fix
- mise run build
- ./mvnw -B verify -pl prometheus-metrics-exporter-opentelemetry,prometheus-metrics-exporter-opentelemetry-shaded -am -P 'api-diff,!examples-and-integration-tests' -DskipTests -Dcoverage.skip=true -Dcheckstyle.skip=true -Dwarnings=-nowarn
