### PR TITLE
test: make Gauge timer test deterministic

### DIFF
--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/GaugeTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/GaugeTest.java
@@ -82,12 +82,11 @@ class GaugeTest {
   }
 
   @Test
-  @SuppressWarnings("try")
-  public void testTimer() throws InterruptedException {
-    try (Timer ignored = noLabels.startTimer()) {
-      Thread.sleep(12);
-    }
-    assertThat(getValue(noLabels)).isGreaterThan(0.01);
+  void testTimer() {
+    Timer timer = noLabels.startTimer();
+    double duration = timer.observeDuration();
+    assertThat(duration).isPositive();
+    assertThat(getValue(noLabels)).isEqualTo(duration);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Make `GaugeTest.testTimer` deterministic by removing the `Thread.sleep(12)` timing dependency.
- Assert that the gauge stores the exact duration returned by `Timer.observeDuration()`.

Fixes #1968

## Test plan

- `.\mvnw.cmd clean test -pl prometheus-metrics-core '-Dtest=GaugeTest' '-Dcoverage.skip=true' '-Dcheckstyle.skip=true'`
- `.\mvnw.cmd install -DskipTests '-Dcoverage.skip=true'`