### PR TITLE
ci: add PR benchmark workflows

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -73,6 +73,11 @@
         "mise"
       ]
     },
+    ".github/workflows/pr-benchmarks.yml": {
+      "regex": [
+        "mise"
+      ]
+    },
     ".github/workflows/regenerate-api-diff-otel.yml": {
       "regex": [
         "mise"

--- a/.github/workflows/pr-benchmark-report.yml
+++ b/.github/workflows/pr-benchmark-report.yml
@@ -1,0 +1,81 @@
+---
+name: PR Benchmark Report
+
+on:
+  # zizmor: ignore[dangerous-triggers] -- this workflow never checks out or executes PR code;
+  # it only reads artifacts produced by the benchmark run and posts a PR comment.
+  workflow_run:
+    workflows:
+      - PR Benchmarks
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  comment:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Comment on PR with benchmark results
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          PR_NUMBER=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.pull_requests[0].number')
+          HEAD_SHA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_sha')
+
+          COMMENT_ARTIFACT_ID=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '.artifacts[] | select(.name == "pr-benchmark-comment-pr-'"${PR_NUMBER}"'-'"${HEAD_SHA}"'") | .id' \
+            | head -1)
+
+          RESULTS_ARTIFACT_NAME="pr-benchmark-results-pr-${PR_NUMBER}-${HEAD_SHA}"
+          MARKER="<!-- pr-benchmark-report -->"
+
+          if [[ -n "${COMMENT_ARTIFACT_ID}" ]]; then
+            gh api \
+              -H "Accept: application/octet-stream" \
+              "repos/${REPO}/actions/artifacts/${COMMENT_ARTIFACT_ID}/zip" > /tmp/pr-benchmark-comment.zip
+            unzip -p /tmp/pr-benchmark-comment.zip pr-benchmark-comment.md > /tmp/pr-benchmark-comment.md
+            SUMMARY_BODY=$(cat /tmp/pr-benchmark-comment.md)
+          else
+            SUMMARY_BODY="_Benchmark summary artifact was not found; see the workflow run for details._"
+          fi
+
+          if [[ "${CONCLUSION}" == "success" ]]; then
+            STATUS_LINE="Benchmark run succeeded for \`${HEAD_SHA}\`."
+          else
+            STATUS_LINE="Benchmark run finished with conclusion \`${CONCLUSION}\` for \`${HEAD_SHA}\`."
+          fi
+
+          body=$(cat <<EOF
+          ${MARKER}
+          ## Benchmark results
+
+          ${STATUS_LINE}
+
+          - Workflow run: ${RUN_URL}
+          - Artifact: \`${RESULTS_ARTIFACT_NAME}\`
+
+          ${SUMMARY_BODY}
+          EOF
+          )
+
+          comment_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+
+          if [[ -n "${comment_id}" ]]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${comment_id}" \
+              --field body="$body"
+          else
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$body"
+          fi

--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -1,0 +1,76 @@
+---
+name: PR Benchmarks
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+permissions: {}
+
+concurrency:
+  group: pr-benchmarks-${{ github.event.pull_request.number }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  benchmark:
+    if: github.event.label.name == 'benchmark'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout only
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          version: v2026.6.14
+          sha256: 96ae1ef7b00a6ebbbec23ba1016d6e722f5e904966272f621d15326429e90d53
+
+      - name: Cache local Maven repository
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-pr-bench-maven-${{ github.event.pull_request.head.sha }}
+          restore-keys: |
+            ${{ runner.os }}-pr-bench-maven-
+            ${{ runner.os }}-maven-
+
+      - name: Run JMH benchmarks
+        run: mise run benchmark:ci-json
+
+      - name: Generate benchmark summary
+        run: |
+          mise run benchmark:generate-summary \
+            --input benchmark-results.json \
+            --output-dir benchmark-results \
+            --commit-sha "${{ github.event.pull_request.head.sha }}"
+        env:
+          GITHUB_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Prepare PR comment summary
+        run: |
+          cp benchmark-results/README.md pr-benchmark-comment.md
+
+      - name: Upload PR benchmark results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-benchmark-results-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: benchmark-results
+          retention-days: 5
+
+      - name: Upload PR benchmark comment
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-benchmark-comment-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: pr-benchmark-comment.md
+          retention-days: 5


### PR DESCRIPTION
## Summary

Extract the PR benchmark workflows from #2252 into a standalone PR so they can land on `main` first.

## Why

The benchmark job uploads a Markdown artifact with the PR comment contents, but the actual PR comment is posted by a separate `workflow_run` workflow. GitHub only triggers `workflow_run` workflows when the workflow file already exists on the default branch, so keeping the reporter in the same PR prevents it from commenting on that PR's benchmark run.

Splitting these workflows out first lets subsequent benchmark PRs use the comment-reporting flow as intended.

## Changes

- add `PR Benchmarks` workflow triggered by the `benchmark` label on pull requests
- add `PR Benchmark Report` workflow triggered by `workflow_run`
- keep the benchmark summary as an uploaded artifact consumed by the reporter workflow

## Testing

- `mise run lint:fix`
