### PR TITLE
fix: correct native histogram bucket merge on scale-down

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Histogram.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Histogram.java
@@ -614,7 +614,7 @@ public class Histogram extends StatefulMetric<DistributionDataPoint, Histogram.D
       }
       buckets.clear();
       for (i = 0; i < keys.length; i++) {
-        int index = (keys[i] + 1) / 2;
+        int index = (keys[i] > 0 ? keys[i] + 1 : keys[i]) / 2;
         LongAdder count = buckets.computeIfAbsent(index, k -> new LongAdder());
         count.add(values[i]);
       }

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/HistogramTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/HistogramTest.java
@@ -28,7 +28,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.CountDownLatch;
@@ -39,6 +41,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -833,6 +836,36 @@ class HistogramTest {
       assertThat(result)
           .as("index=" + indexes[i] + ", schema=" + schemas[i])
           .isCloseTo(expectedUpperBounds[i], offset(0.0000000000001));
+    }
+  }
+
+  @Test
+  void testDoubleBucketWidthMergesNegativeIndexesCorrectly()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Histogram histogram = Histogram.builder().name("test").nativeOnly().build();
+    Histogram.DataPoint dataPoint = histogram.newDataPoint();
+
+    Method doubleBucketWidth =
+        Histogram.DataPoint.class.getDeclaredMethod("doubleBucketWidth", Map.class);
+    doubleBucketWidth.setAccessible(true);
+
+    int[] keys = {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5};
+    int[] expectedMergedIndexes = {-2, -2, -1, -1, 0, 0, 1, 1, 2, 2, 3};
+
+    for (int i = 0; i < keys.length; i++) {
+      Map<Integer, LongAdder> buckets = new HashMap<>();
+      LongAdder adder = new LongAdder();
+      adder.add(7);
+      buckets.put(keys[i], adder);
+
+      doubleBucketWidth.invoke(dataPoint, buckets);
+
+      assertThat(buckets.keySet())
+          .as("merged index for original key " + keys[i])
+          .containsExactly(expectedMergedIndexes[i]);
+      assertThat(buckets.get(expectedMergedIndexes[i]).sum())
+          .as("count preserved for original key " + keys[i])
+          .isEqualTo(7);
     }
   }
 


### PR DESCRIPTION
## Summary

Fix native histogram bucket remapping when the bucket width is doubled during schema scale-down.

The previous merge formula used:

```
(keys[i] + 1) / 2
```

That works for positive bucket indexes, but not for negative even indexes. Java integer division truncates toward zero, so negative even buckets were merged into the bucket immediately to the right of the correct target.

This matches the behaviour described in #2270 and aligns the merge formula with client_golang:

```
(keys[i] > 0 ? keys[i] + 1 : keys[i]) / 2
```

## Why

When `doubleBucketWidth()` runs, counts from some negative native histogram buckets could be shifted into neighbouring buckets. That can make Prometheus interpret the reshuffled bucket counters as resets, causing spikes in queries such as:

```
histogram_count(rate(my_native_histogram[1m]))
```

## Tests

Added a focused regression test for negative, zero, and positive bucket index remapping during `doubleBucketWidth(Map)`.

Verified locally:

```
./mvnw test -pl prometheus-metrics-core -am \
  -Dtest=HistogramTest#testDoubleBucketWidthMergesNegativeIndexesCorrectly \
  -Dcoverage.skip=true \
  -Dcheckstyle.skip=true \
  -Dsurefire.failIfNoSpecifiedTests=false
```

Also verified:

```bash
./mvnw install -DskipTests -Dcoverage.skip=true
```

Fixes #2270