### PR TITLE
ci: resolve PR number from head SHA in benchmark report

### DIFF
--- a/.github/workflows/pr-benchmark-report.yml
+++ b/.github/workflows/pr-benchmark-report.yml
@@ -31,8 +31,19 @@ jobs:
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
-          PR_NUMBER=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.pull_requests[0].number')
           HEAD_SHA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_sha')
+          PR_NUMBER=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.pull_requests[0].number')
+          # workflow_run.pull_requests is empty when the triggering run's head branch
+          # is not on the default branch (or the PR is from a fork). Fall back to
+          # resolving the PR from the head SHA.
+          if [[ -z "${PR_NUMBER}" || "${PR_NUMBER}" == "null" ]]; then
+            PR_NUMBER=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+              --jq '.[] | select(.state == "open") | .number' | head -1)
+          fi
+          if [[ -z "${PR_NUMBER}" ]]; then
+            echo "Could not determine PR number for run ${RUN_ID} (head ${HEAD_SHA})." >&2
+            exit 1
+          fi
 
           COMMENT_ARTIFACT_ID=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" \
             --jq '.artifacts[] | select(.name == "pr-benchmark-comment-pr-'"${PR_NUMBER}"'-'"${HEAD_SHA}"'") | .id' \


### PR DESCRIPTION
## Summary

The `PR Benchmark Report` workflow failed to comment on [#2252](https://github.com/prometheus/client_java/pull/2252) after a successful benchmark run ([run 28865892835](https://github.com/prometheus/client_java/actions/runs/28865892835)):

```
gh: Not Found (HTTP 404)
parse "https://api.github.com/repos/prometheus/client_java/issues/comments/{\r": net/url: invalid control character in URL
```

Root cause: `workflow_run.pull_requests` is empty when the triggering run's head branch is not on the default branch (or the PR is from a fork). With `PR_NUMBER` empty, the subsequent `repos/${REPO}/issues//comments` API call 404s and the paginator emits a malformed URL, so no comment gets posted.

## Changes

- Fall back to `repos/{owner}/{repo}/commits/{sha}/pulls` to resolve the PR from the head SHA when `workflow_run.pull_requests` is empty.
- Fail fast with an explicit error if the PR still can't be resolved, so future regressions don't cascade into cryptic URL-parse errors.

## Test plan

- [ ] Re-run the report workflow against run 28861406560 (or a fresh push to #2252) and confirm a benchmark comment lands on the PR.