### PR TITLE
fix: bound scrape query parameter parsing (#2285)

### DIFF
--- a/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusHttpRequest.java
+++ b/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusHttpRequest.java
@@ -49,15 +49,42 @@ public interface PrometheusHttpRequest extends PrometheusScrapeRequest {
   @SuppressWarnings("JdkObsolete")
   default String[] getParameterValues(String name) {
     try {
+      int maxQueryStringLength = 64 * 1024;
+      int maxQueryParameterCount = 1024;
       ArrayList<String> result = new ArrayList<>();
       String queryString = getQueryString();
       if (queryString != null) {
-        String[] pairs = queryString.split("&");
-        for (String pair : pairs) {
+        if (queryString.length() > maxQueryStringLength) {
+          throw new IllegalArgumentException(
+              "Query string too long: "
+                  + queryString.length()
+                  + " characters (max "
+                  + maxQueryStringLength
+                  + ")");
+        }
+        int start = 0;
+        int parameterCount = 0;
+        for (int end = queryString.indexOf('&'); start <= queryString.length(); ) {
+          parameterCount++;
+          if (parameterCount > maxQueryParameterCount) {
+            throw new IllegalArgumentException(
+                "Too many query parameters: "
+                    + parameterCount
+                    + " (max "
+                    + maxQueryParameterCount
+                    + ")");
+          }
+          String pair =
+              end == -1 ? queryString.substring(start) : queryString.substring(start, end);
           int idx = pair.indexOf("=");
           if (idx != -1 && URLDecoder.decode(pair.substring(0, idx), "UTF-8").equals(name)) {
             result.add(URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
           }
+          if (end == -1) {
+            break;
+          }
+          start = end + 1;
+          end = queryString.indexOf('&', start);
         }
       }
       if (result.isEmpty()) {

--- a/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusScrapeHandler.java
+++ b/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusScrapeHandler.java
@@ -96,6 +96,14 @@ public class PrometheusScrapeHandler {
           }
         }
       }
+    } catch (IllegalArgumentException e) {
+      PrometheusHttpResponse response = exchange.getResponse();
+      response.setHeader("Content-Type", "text/plain; charset=utf-8");
+      String errorMessage = e.getMessage() == null ? "Invalid query parameters" : e.getMessage();
+      byte[] message = errorMessage.getBytes(StandardCharsets.UTF_8);
+      try (OutputStream outputStream = response.sendHeadersAndGetBody(400, message.length)) {
+        outputStream.write(message);
+      }
     } catch (IOException e) {
       exchange.handleException(e);
     } catch (RuntimeException e) {

--- a/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusScrapeHandler.java
+++ b/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusScrapeHandler.java
@@ -99,8 +99,7 @@ public class PrometheusScrapeHandler {
     } catch (IllegalArgumentException e) {
       PrometheusHttpResponse response = exchange.getResponse();
       response.setHeader("Content-Type", "text/plain; charset=utf-8");
-      String errorMessage = e.getMessage() == null ? "Invalid query parameters" : e.getMessage();
-      byte[] message = errorMessage.getBytes(StandardCharsets.UTF_8);
+      byte[] message = "Invalid query parameters".getBytes(StandardCharsets.UTF_8);
       try (OutputStream outputStream = response.sendHeadersAndGetBody(400, message.length)) {
         outputStream.write(message);
       }

--- a/prometheus-metrics-exporter-common/src/test/java/io/prometheus/metrics/exporter/common/PrometheusScrapeHandlerTest.java
+++ b/prometheus-metrics-exporter-common/src/test/java/io/prometheus/metrics/exporter/common/PrometheusScrapeHandlerTest.java
@@ -164,6 +164,36 @@ class PrometheusScrapeHandlerTest {
     assertThat(body).doesNotContain("metric_three");
   }
 
+  @Test
+  void testRejectsTooManyQueryParameters() throws IOException {
+    StringBuilder queryString = new StringBuilder("name[]=test_counter");
+    for (int i = 0; i < 1024; i++) {
+      queryString.append("&name[]=metric_").append(i);
+    }
+
+    TestHttpExchange exchange = new TestHttpExchange("GET", queryString.toString());
+    handler.handleRequest(exchange);
+
+    assertThat(exchange.getResponseCode()).isEqualTo(400);
+    assertThat(exchange.getResponseHeaders().get("Content-Type"))
+        .isEqualTo("text/plain; charset=utf-8");
+    assertThat(exchange.getResponseBody()).contains("Too many query parameters");
+  }
+
+  @Test
+  void testRejectsTooLongQueryString() throws IOException {
+    StringBuilder queryString = new StringBuilder("name[]=");
+    for (int i = 0; i < 64 * 1024; i++) {
+      queryString.append("a");
+    }
+
+    TestHttpExchange exchange = new TestHttpExchange("GET", queryString.toString());
+    handler.handleRequest(exchange);
+
+    assertThat(exchange.getResponseCode()).isEqualTo(400);
+    assertThat(exchange.getResponseBody()).contains("Query string too long");
+  }
+
   /** Test implementation of PrometheusHttpExchange for testing. */
   private static class TestHttpExchange implements PrometheusHttpExchange {
     private final TestHttpRequest request;
@@ -216,7 +246,7 @@ class PrometheusScrapeHandlerTest {
     }
 
     public String getResponseBody() {
-      return rawResponseBody.toString(StandardCharsets.UTF_8);
+      return new String(rawResponseBody.toByteArray(), StandardCharsets.UTF_8);
     }
 
     public boolean isGzipCompressed() {

--- a/prometheus-metrics-exporter-common/src/test/java/io/prometheus/metrics/exporter/common/PrometheusScrapeHandlerTest.java
+++ b/prometheus-metrics-exporter-common/src/test/java/io/prometheus/metrics/exporter/common/PrometheusScrapeHandlerTest.java
@@ -177,7 +177,7 @@ class PrometheusScrapeHandlerTest {
     assertThat(exchange.getResponseCode()).isEqualTo(400);
     assertThat(exchange.getResponseHeaders().get("Content-Type"))
         .isEqualTo("text/plain; charset=utf-8");
-    assertThat(exchange.getResponseBody()).contains("Too many query parameters");
+    assertThat(exchange.getResponseBody()).isEqualTo("Invalid query parameters");
   }
 
   @Test
@@ -191,7 +191,7 @@ class PrometheusScrapeHandlerTest {
     handler.handleRequest(exchange);
 
     assertThat(exchange.getResponseCode()).isEqualTo(400);
-    assertThat(exchange.getResponseBody()).contains("Query string too long");
+    assertThat(exchange.getResponseBody()).isEqualTo("Invalid query parameters");
   }
 
   /** Test implementation of PrometheusHttpExchange for testing. */

--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/MetricNameFilter.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/registry/MetricNameFilter.java
@@ -6,6 +6,7 @@ import io.prometheus.metrics.annotations.StableApi;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -26,10 +27,10 @@ public class MetricNameFilter implements Predicate<String> {
       Collection<String> nameIsNotEqualTo,
       Collection<String> nameStartsWith,
       Collection<String> nameDoesNotStartWith) {
-    this.nameIsEqualTo = unmodifiableCollection(new ArrayList<>(nameIsEqualTo));
-    this.nameIsNotEqualTo = unmodifiableCollection(new ArrayList<>(nameIsNotEqualTo));
-    this.nameStartsWith = unmodifiableCollection(new ArrayList<>(nameStartsWith));
-    this.nameDoesNotStartWith = unmodifiableCollection(new ArrayList<>(nameDoesNotStartWith));
+    this.nameIsEqualTo = unmodifiableCollection(new LinkedHashSet<>(nameIsEqualTo));
+    this.nameIsNotEqualTo = unmodifiableCollection(new LinkedHashSet<>(nameIsNotEqualTo));
+    this.nameStartsWith = unmodifiableCollection(new LinkedHashSet<>(nameStartsWith));
+    this.nameDoesNotStartWith = unmodifiableCollection(new LinkedHashSet<>(nameDoesNotStartWith));
   }
 
   @Override
@@ -42,6 +43,9 @@ public class MetricNameFilter implements Predicate<String> {
 
   private boolean matchesNameEqualTo(String metricName) {
     if (nameIsEqualTo.isEmpty()) {
+      return true;
+    }
+    if (nameIsEqualTo.contains(metricName)) {
       return true;
     }
     for (String name : nameIsEqualTo) {
@@ -57,6 +61,9 @@ public class MetricNameFilter implements Predicate<String> {
   private boolean matchesNameNotEqualTo(String metricName) {
     if (nameIsNotEqualTo.isEmpty()) {
       return false;
+    }
+    if (nameIsNotEqualTo.contains(metricName)) {
+      return true;
     }
     for (String name : nameIsNotEqualTo) {
       // The following ignores suffixes like _total.


### PR DESCRIPTION
## Summary

Fixes #2285.

- Add bounds to default scrape query parsing:
  - max query string length: 64 KiB
  - max query parameter count: 1024
- Avoid unbounded `queryString.split("&")` allocation by scanning the query string incrementally.
- Return HTTP 400 for invalid/excessive query parameters instead of surfacing an internal error.
- Deduplicate metric name filter collections with `LinkedHashSet`.
- Add exact-match fast paths in `MetricNameFilter` while preserving existing suffix-tolerant matching behavior.
- Add regression tests for excessive query length and parameter count.

## Testing

- `mise run lint:fix`
- `./mvnw.cmd test -pl prometheus-metrics-exporter-common -Dtest=PrometheusScrapeHandlerTest '-Dcoverage.skip=true' '-Dcheckstyle.skip=true'`
- `./mvnw.cmd test -pl prometheus-metrics-model -Dtest=MetricNameFilterTest '-Dcoverage.skip=true' '-Dcheckstyle.skip=true'`
- `./mvnw.cmd install -DskipTests '-Dcoverage.skip=true' -rf :prometheus-metrics-model`

Note: `mise run build` fails on Windows because the task invokes `./mvnw`; the equivalent `mvnw.cmd` command was run instead.