### PR TITLE
fix: prevent buffer stripe index overflow

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Buffer.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Buffer.java
@@ -43,7 +43,7 @@ class Buffer {
   }
 
   boolean append(double value) {
-    int index = Math.abs((int) Thread.currentThread().getId()) % stripedObservationCounts.length;
+    int index = stripeIndex(Thread.currentThread().getId(), stripedObservationCounts.length);
     AtomicLong observationCountForThread = stripedObservationCounts[index];
     long count = observationCountForThread.incrementAndGet();
     if ((count & bufferActiveBit) == 0) {
@@ -52,6 +52,10 @@ class Buffer {
       doAppend(value);
       return true;
     }
+  }
+
+  static int stripeIndex(long threadId, int stripeCount) {
+    return (int) Math.floorMod(threadId, stripeCount);
   }
 
   private void doAppend(double amount) {

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/BufferTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/BufferTest.java
@@ -1,0 +1,15 @@
+package io.prometheus.metrics.core.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class BufferTest {
+
+  @Test
+  void stripeIndexDoesNotOverflowWhenThreadIdNarrowsToIntegerMinValue() {
+    assertThat(Buffer.stripeIndex(2_147_483_648L, 3)).isEqualTo(2);
+    assertThat(Buffer.stripeIndex(2_147_483_648L, 6)).isEqualTo(2);
+    assertThat(Buffer.stripeIndex(2_147_483_648L, 12)).isEqualTo(8);
+  }
+}


### PR DESCRIPTION
## Summary

- compute `Buffer` stripe indexes with `Math.floorMod(long, int)`
- add regression coverage for thread IDs whose low bits previously narrowed to `Integer.MIN_VALUE`

This is the focused replacement for the #2282 portion of #2297.

Fixes #2282

## Ongoing discussion

None. The earlier review did not identify an unresolved design question for this isolated index fix.

## Validation

- `mise run lint:fix`
- `mise run build`
- `./mvnw test -pl prometheus-metrics-core -Dcoverage.skip=true -Dcheckstyle.skip=true`
