### PR TITLE
fix: redact invalid configuration values

### DIFF
--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/ExporterPushgatewayProperties.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/ExporterPushgatewayProperties.java
@@ -94,9 +94,8 @@ public class ExporterPushgatewayProperties {
     if (scheme != null) {
       if (!scheme.equals("http") && !scheme.equals("https")) {
         throw new PrometheusPropertiesException(
-            String.format(
-                "%s.%s: Illegal value. Expecting 'http' or 'https'. Found: %s",
-                PREFIX, SCHEME, scheme));
+            Util.invalidValueMessage(
+                PREFIX + "." + SCHEME, "Illegal value. Expecting 'http' or 'https'."));
       }
     }
 
@@ -119,10 +118,9 @@ public class ExporterPushgatewayProperties {
         return EscapingScheme.DOTS_ESCAPING;
       default:
         throw new PrometheusPropertiesException(
-            String.format(
-                "%s.%s: Illegal value. Expecting 'allow-utf-8', 'values', 'underscores', "
-                    + "or 'dots'. Found: %s",
-                PREFIX, ESCAPING_SCHEME, scheme));
+            Util.invalidValueMessage(
+                PREFIX + "." + ESCAPING_SCHEME,
+                "Illegal value. Expecting 'allow-utf-8', 'values', 'underscores', or 'dots'."));
     }
   }
 

--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusPropertiesLoader.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/PrometheusPropertiesLoader.java
@@ -169,8 +169,7 @@ public class PrometheusPropertiesLoader {
       try (InputStream stream = Files.newInputStream(Paths.get(path))) {
         properties.load(stream);
       } catch (IOException e) {
-        throw new PrometheusPropertiesException(
-            "Failed to read Prometheus properties from " + path + ": " + e.getMessage(), e);
+        throw new PrometheusPropertiesException("Failed to read Prometheus properties file.", e);
       }
     }
     return properties;

--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/Util.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/Util.java
@@ -24,7 +24,7 @@ class Util {
       String fullKey = prefix.isEmpty() ? propertyName : prefix + "." + propertyName;
       if (!"true".equalsIgnoreCase(property) && !"false".equalsIgnoreCase(property)) {
         throw new PrometheusPropertiesException(
-            String.format("%s: Expecting 'true' or 'false'. Found: %s", fullKey, property));
+            invalidValueMessage(fullKey, "Expecting 'true' or 'false'."));
       }
       return Boolean.parseBoolean(property);
     }
@@ -88,7 +88,7 @@ class Util {
           }
         } catch (NumberFormatException e) {
           throw new PrometheusPropertiesException(
-              fullKey + "=" + property + ": Expecting comma separated list of double values");
+              invalidValueMessage(fullKey, "Expecting comma separated list of double values"));
         }
       }
       return Arrays.asList(result);
@@ -130,7 +130,7 @@ class Util {
         return Integer.parseInt(property);
       } catch (NumberFormatException e) {
         throw new PrometheusPropertiesException(
-            fullKey + "=" + property + ": Expecting integer value");
+            invalidValueMessage(fullKey, "Expecting integer value"));
       }
     }
     return null;
@@ -146,7 +146,7 @@ class Util {
         return Double.parseDouble(property);
       } catch (NumberFormatException e) {
         throw new PrometheusPropertiesException(
-            fullKey + "=" + property + ": Expecting double value");
+            invalidValueMessage(fullKey, "Expecting double value"));
       }
     }
     return null;
@@ -162,7 +162,7 @@ class Util {
         return Long.parseLong(property);
       } catch (NumberFormatException e) {
         throw new PrometheusPropertiesException(
-            fullKey + "=" + property + ": Expecting long value");
+            invalidValueMessage(fullKey, "Expecting long value"));
       }
     }
     return null;
@@ -196,5 +196,9 @@ class Util {
       String fullMessage = String.format("%s: %s Found: %s", fullKey, message, number);
       throw new PrometheusPropertiesException(fullMessage);
     }
+  }
+
+  static String invalidValueMessage(String fullKey, String message) {
+    return fullKey + ": " + message;
   }
 }

--- a/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/ExporterPropertiesTest.java
+++ b/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/ExporterPropertiesTest.java
@@ -27,8 +27,7 @@ class ExporterPropertiesTest {
                     new HashMap<>(
                         Map.of("io.prometheus.exporter.include_created_timestamps", "invalid"))))
         .withMessage(
-            "io.prometheus.exporter.include_created_timestamps: Expecting 'true' or 'false'. Found:"
-                + " invalid");
+            "io.prometheus.exporter.include_created_timestamps: Expecting 'true' or 'false'.");
     assertThatExceptionOfType(PrometheusPropertiesException.class)
         .isThrownBy(
             () ->
@@ -36,8 +35,7 @@ class ExporterPropertiesTest {
                     new HashMap<>(
                         Map.of("io.prometheus.exporter.exemplars_on_all_metric_types", "invalid"))))
         .withMessage(
-            "io.prometheus.exporter.exemplars_on_all_metric_types: Expecting 'true' or 'false'."
-                + " Found: invalid");
+            "io.prometheus.exporter.exemplars_on_all_metric_types: Expecting 'true' or 'false'.");
   }
 
   private static ExporterProperties load(Map<String, String> map) {
@@ -84,7 +82,6 @@ class ExporterPropertiesTest {
                     new HashMap<>(
                         Map.of("io.prometheus.exporter.prometheus_timestamps_in_ms", "invalid"))))
         .withMessage(
-            "io.prometheus.exporter.prometheus_timestamps_in_ms: Expecting 'true' or 'false'."
-                + " Found: invalid");
+            "io.prometheus.exporter.prometheus_timestamps_in_ms: Expecting 'true' or 'false'.");
   }
 }

--- a/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/ExporterPushgatewayPropertiesTest.java
+++ b/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/ExporterPushgatewayPropertiesTest.java
@@ -27,7 +27,7 @@ class ExporterPushgatewayPropertiesTest {
         .isThrownBy(() -> load(Map.of("io.prometheus.exporter.pushgateway.scheme", "foo")))
         .withMessage(
             "io.prometheus.exporter.pushgateway.scheme: Illegal value. Expecting 'http' or 'https'."
-                + " Found: foo");
+                + "");
   }
 
   @Test
@@ -60,7 +60,7 @@ class ExporterPushgatewayPropertiesTest {
             () -> load(Map.of("io.prometheus.exporter.pushgateway.escaping_scheme", "invalid")))
         .withMessage(
             "io.prometheus.exporter.pushgateway.escaping_scheme: Illegal value. Expecting"
-                + " 'allow-utf-8', 'values', 'underscores', or 'dots'. Found: invalid");
+                + " 'allow-utf-8', 'values', 'underscores', or 'dots'.");
   }
 
   @Test

--- a/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/OpenMetrics2PropertiesTest.java
+++ b/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/OpenMetrics2PropertiesTest.java
@@ -37,8 +37,7 @@ class OpenMetrics2PropertiesTest {
     assertThatExceptionOfType(PrometheusPropertiesException.class)
         .isThrownBy(
             () -> load(new HashMap<>(Map.of("io.prometheus.openmetrics2.enabled", "invalid"))))
-        .withMessage(
-            "io.prometheus.openmetrics2.enabled: Expecting 'true' or 'false'. Found: invalid");
+        .withMessage("io.prometheus.openmetrics2.enabled: Expecting 'true' or 'false'.");
     assertThatExceptionOfType(PrometheusPropertiesException.class)
         .isThrownBy(
             () ->
@@ -46,17 +45,14 @@ class OpenMetrics2PropertiesTest {
                     new HashMap<>(
                         Map.of("io.prometheus.openmetrics2.content_negotiation", "invalid"))))
         .withMessage(
-            "io.prometheus.openmetrics2.content_negotiation: Expecting 'true' or 'false'. Found:"
-                + " invalid");
+            "io.prometheus.openmetrics2.content_negotiation: Expecting 'true' or 'false'.");
     assertThatExceptionOfType(PrometheusPropertiesException.class)
         .isThrownBy(
             () ->
                 load(
                     new HashMap<>(
                         Map.of("io.prometheus.openmetrics2.composite_values", "invalid"))))
-        .withMessage(
-            "io.prometheus.openmetrics2.composite_values: Expecting 'true' or 'false'. Found:"
-                + " invalid");
+        .withMessage("io.prometheus.openmetrics2.composite_values: Expecting 'true' or 'false'.");
     assertThatExceptionOfType(PrometheusPropertiesException.class)
         .isThrownBy(
             () ->
@@ -64,17 +60,14 @@ class OpenMetrics2PropertiesTest {
                     new HashMap<>(
                         Map.of("io.prometheus.openmetrics2.exemplar_compliance", "invalid"))))
         .withMessage(
-            "io.prometheus.openmetrics2.exemplar_compliance: Expecting 'true' or 'false'. Found:"
-                + " invalid");
+            "io.prometheus.openmetrics2.exemplar_compliance: Expecting 'true' or 'false'.");
     assertThatExceptionOfType(PrometheusPropertiesException.class)
         .isThrownBy(
             () ->
                 load(
                     new HashMap<>(
                         Map.of("io.prometheus.openmetrics2.native_histograms", "invalid"))))
-        .withMessage(
-            "io.prometheus.openmetrics2.native_histograms: Expecting 'true' or 'false'. Found:"
-                + " invalid");
+        .withMessage("io.prometheus.openmetrics2.native_histograms: Expecting 'true' or 'false'.");
   }
 
   private static OpenMetrics2Properties load(Map<String, String> map) {

--- a/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/PrometheusPropertiesLoaderTest.java
+++ b/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/PrometheusPropertiesLoaderTest.java
@@ -31,9 +31,8 @@ class PrometheusPropertiesLoaderTest {
   void cantLoadPropertiesFile() {
     assertThatExceptionOfType(PrometheusPropertiesException.class)
         .isThrownBy(() -> PrometheusPropertiesLoader.load(new Properties()))
-        .withMessage(
-            "Failed to read Prometheus properties from nonexistent.properties:"
-                + " nonexistent.properties");
+        .withMessage("Failed to read Prometheus properties file.")
+        .withMessageNotContaining("nonexistent.properties");
   }
 
   @Test

--- a/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/UtilTest.java
+++ b/prometheus-metrics-config/src/test/java/io/prometheus/metrics/config/UtilTest.java
@@ -51,6 +51,18 @@ class UtilTest {
 
     assertThatExceptionOfType(PrometheusPropertiesException.class)
         .isThrownBy(() -> Util.loadOptionalDuration("", "foo", propertySource))
-        .withMessage("foo=abc: Expecting long value");
+        .withMessage("foo: Expecting long value");
+  }
+
+  @Test
+  void invalidValueMessageRedactsRawValue() {
+    String secret = "bad\n\"secret-value";
+    Map<Object, Object> regularProperties = new HashMap<>(Map.of("foo", secret));
+    PropertySource propertySource = new PropertySource(regularProperties);
+
+    assertThatExceptionOfType(PrometheusPropertiesException.class)
+        .isThrownBy(() -> Util.loadBoolean("", "foo", propertySource))
+        .withMessage("foo: Expecting 'true' or 'false'.")
+        .withMessageNotContaining(secret);
   }
 }

--- a/prometheus-metrics-exporter-pushgateway/src/main/java/io/prometheus/metrics/exporter/pushgateway/PushGateway.java
+++ b/prometheus-metrics-exporter-pushgateway/src/main/java/io/prometheus/metrics/exporter/pushgateway/PushGateway.java
@@ -554,9 +554,9 @@ public class PushGateway {
             getEscapingScheme(properties),
             getConnectionTimeout(properties),
             getReadTimeout(properties));
-      } catch (MalformedURLException e) {
+      } catch (MalformedURLException | IllegalArgumentException e) {
         throw new PrometheusPropertiesException(
-            address + ": Invalid address. Expecting <host>:<port>");
+            "Invalid Pushgateway address. Expecting <host>:<port>");
       } catch (UnsupportedEncodingException e) {
         throw new RuntimeException(e); // cannot happen, UTF-8 is always supported
       }

--- a/prometheus-metrics-exporter-pushgateway/src/test/java/io/prometheus/metrics/exporter/pushgateway/PushGatewayTest.java
+++ b/prometheus-metrics-exporter-pushgateway/src/test/java/io/prometheus/metrics/exporter/pushgateway/PushGatewayTest.java
@@ -6,6 +6,7 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 import io.prometheus.metrics.config.EscapingScheme;
+import io.prometheus.metrics.config.PrometheusPropertiesException;
 import io.prometheus.metrics.core.metrics.Gauge;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.IOException;
@@ -46,6 +47,15 @@ class PushGatewayTest {
                   .address("::")
                   .build(); // ":" is interpreted as port number, so parsing fails
             });
+  }
+
+  @Test
+  void testInvalidURLDoesNotExposeCredentials() {
+    String secretAddress = "user:secret@[::";
+    assertThatExceptionOfType(PrometheusPropertiesException.class)
+        .isThrownBy(() -> PushGateway.builder().address(secretAddress).build())
+        .withMessage("Invalid Pushgateway address. Expecting <host>:<port>")
+        .withMessageNotContaining("secret");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- remove raw invalid configuration values from exception messages
- avoid exposing configured properties-file paths
- apply the same redaction to PushGateway validation paths

This is the focused replacement for the #2286 portion of #2297.

Fixes #2286

## Ongoing discussion

None currently. The earlier escape-versus-redact question is resolved in favor of full redaction because servlet containers can expose exception messages.

## Validation

- `mise run lint:fix`
- `mise run build`
- `./mvnw test -pl prometheus-metrics-config,prometheus-metrics-exporter-pushgateway -Dcoverage.skip=true -Dcheckstyle.skip=true`
