### PR TITLE
ci: limit release job to Java toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     environment: release
     runs-on: ubuntu-24.04
     env:
+      # Keep artifact releases isolated from unrelated mise tools and caches.
       MISE_ENABLE_TOOLS: java
     permissions:
       actions: write # required to trigger bump-api-diff-baseline.yml via `gh workflow run`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     environment: release
     runs-on: ubuntu-24.04
     env:
-      # Keep artifact releases isolated from unrelated mise tools and caches.
+      # Artifact releases pair a focused tool allowlist with cache: false.
       MISE_ENABLE_TOOLS: java
     permissions:
       actions: write # required to trigger bump-api-diff-baseline.yml via `gh workflow run`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     if: ${{ github.repository == 'prometheus/client_java' }}
     environment: release
     runs-on: ubuntu-24.04
+    env:
+      MISE_ENABLE_TOOLS: java
     permissions:
       actions: write # required to trigger bump-api-diff-baseline.yml via `gh workflow run`
 


### PR DESCRIPTION
## What changed

- Restrict the Maven Central release job to the mise-managed Java toolchain.
- Preserve the existing no-cache release configuration.

## Why

The artifact release should not install unrelated development and linting tools from `mise.toml`. This keeps release execution focused and prevents unrelated tool resolution failures from blocking publication.

## Validation

- `mise run lint:fix`
- `actionlint .github/workflows/release.yml`
- `git diff --check`
