### PR TITLE
test: run Spring smoke tests against shaded artifact

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -17,7 +17,5 @@ jobs:
         with:
           version: v2026.8.6
           sha256: 96f6f1f416d868b78addd22746eefc7f4bf7820c6a3afa392a9f653f708c1644
-          working_directory: .mise/envs/native
       - name: Run native tests
-        working-directory: .mise/envs/native
-        run: mise native-test
+        run: mise //.mise/envs/native:native-test

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -17,5 +17,6 @@ jobs:
         with:
           version: v2026.8.6
           sha256: 96f6f1f416d868b78addd22746eefc7f4bf7820c6a3afa392a9f653f708c1644
+          working_directory: .mise/envs/native
       - name: Run native tests
         run: mise //.mise/envs/native:native-test

--- a/.mise/envs/native/mise.toml
+++ b/.mise/envs/native/mise.toml
@@ -2,10 +2,9 @@
 java = "oracle-graalvm-25.0.1"
 
 [tasks.native-test]
-depends = "build"
+depends = "//:build"
 # Native Test uses Surefire, so explicitly select the Failsafe-named test class.
 run = '''
-repo_root="$MISE_PROJECT_ROOT/../../.."
-cd "$repo_root/integration-tests/it-spring-boot-smoke-test"
-"$repo_root/mvnw" test -PnativeTest -Dtest=ApplicationIT
+cd "$MISE_MONOREPO_ROOT/integration-tests/it-spring-boot-smoke-test"
+"$MISE_MONOREPO_ROOT/mvnw" test -PnativeTest -Dtest=ApplicationIT
 '''

--- a/.mise/envs/native/mise.toml
+++ b/.mise/envs/native/mise.toml
@@ -4,5 +4,8 @@ java = "oracle-graalvm-25.0.1"
 [tasks.native-test]
 depends = "build"
 # Native Test uses Surefire, so explicitly select the Failsafe-named test class.
-run = "../../mvnw test -PnativeTest -Dtest=ApplicationIT"
-dir = "../../../integration-tests/it-spring-boot-smoke-test"
+run = '''
+repo_root="$MISE_PROJECT_ROOT/../../.."
+cd "$repo_root/integration-tests/it-spring-boot-smoke-test"
+"$repo_root/mvnw" test -PnativeTest -Dtest=ApplicationIT
+'''

--- a/.mise/envs/native/mise.toml
+++ b/.mise/envs/native/mise.toml
@@ -3,5 +3,6 @@ java = "oracle-graalvm-25.0.1"
 
 [tasks.native-test]
 depends = "build"
-run = "../../mvnw test -PnativeTest"
+# Native Test uses Surefire, so explicitly select the Failsafe-named test class.
+run = "../../mvnw test -PnativeTest -Dtest=ApplicationIT"
 dir = "../../../integration-tests/it-spring-boot-smoke-test"

--- a/integration-tests/it-spring-boot-smoke-test/pom.xml
+++ b/integration-tests/it-spring-boot-smoke-test/pom.xml
@@ -21,17 +21,10 @@
   <properties>
     <java.version>25</java.version>
     <junit-jupiter.version>6.1.3</junit-jupiter.version>
-    <protobuf-java.version>4.35.1</protobuf-java.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-      <!-- Align Spring Boot's managed runtime with the generated classes used by reactor tests. -->
-      <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-java</artifactId>
-        <version>${protobuf-java.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
@@ -97,6 +90,19 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <!-- Run after package so reactor dependencies resolve to their shaded artifacts. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/integration-tests/it-spring-boot-smoke-test/pom.xml
+++ b/integration-tests/it-spring-boot-smoke-test/pom.xml
@@ -21,10 +21,17 @@
   <properties>
     <java.version>25</java.version>
     <junit-jupiter.version>6.1.3</junit-jupiter.version>
+    <!-- Keep aligned with generated sources when reactor dependencies use target/classes. -->
+    <protobuf-java.version>4.35.1</protobuf-java.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf-java.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>

--- a/integration-tests/it-spring-boot-smoke-test/pom.xml
+++ b/integration-tests/it-spring-boot-smoke-test/pom.xml
@@ -21,12 +21,12 @@
   <properties>
     <java.version>25</java.version>
     <junit-jupiter.version>6.1.3</junit-jupiter.version>
-    <!-- Keep aligned with generated sources when reactor dependencies use target/classes. -->
     <protobuf-java.version>4.35.1</protobuf-java.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <!-- Align Spring Boot's managed runtime with the generated classes used by reactor tests. -->
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>

--- a/integration-tests/it-spring-boot-smoke-test/src/test/java/io/prometheus/metrics/it/springboot/ApplicationIT.java
+++ b/integration-tests/it-spring-boot-smoke-test/src/test/java/io/prometheus/metrics/it/springboot/ApplicationIT.java
@@ -17,7 +17,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-class ApplicationTest {
+class ApplicationIT {
+  @Test
+  void testUsesShadedProtobufRuntime() {
+    assertThat(Metrics.MetricFamily.class.getSuperclass().getName())
+        .startsWith("io.prometheus.metrics.shaded.com_google_protobuf_");
+  }
+
   @Test
   void testPrometheusProtobufFormat() throws IOException {
     ExporterTest.Response response =

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 monorepo_root = true
 
 [monorepo]
-config_roots = [".mise/envs/native"]
+config_roots = [".mise/envs/*"]
 
 [tools]
 "aqua:grafana/gcx" = "v1.1.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,8 @@
+monorepo_root = true
+
+[monorepo]
+config_roots = [".mise/envs/native"]
+
 [tools]
 "aqua:grafana/gcx" = "v1.1.0"
 "aqua:grafana/oats" = "0.10.0"


### PR DESCRIPTION
## Summary

- run the Spring Boot smoke tests with Failsafe after the package phase
- test the packaged, shaded exposition-format artifact instead of reactor `target/classes`
- verify that generated messages use the relocated Protobuf runtime
- explicitly select the Failsafe-named test for the Surefire-based native test task
- register `.mise/envs/*` as mise monorepo projects and invoke the native task directly
- derive native-task repository paths from `MISE_MONOREPO_ROOT`

## Root cause

The smoke test previously ran with Surefire during the test phase. Maven therefore used the
exposition module's unshaded `target/classes`. The generated Protobuf 4.35.1 classes then loaded
against Spring Boot's managed Protobuf 4.34.2 runtime and failed the runtime compatibility check.

Moving this consumer-style smoke test to Failsafe runs it after packaging, when Maven resolves the
shaded artifact that users receive. This avoids an artificial reactor-only version conflict without
overriding Spring Boot's Protobuf version.

The native test task still invokes the Maven `test` phase because GraalVM Native Test consumes
Surefire's test configuration. It now selects `ApplicationIT` explicitly; an inline comment records
why that exception is necessary. The workflow invokes it as
`mise //.mise/envs/native:native-test` from the repository root.

## Impact

There is no production code or published dependency change. The smoke test now more accurately
represents a Spring Boot application consuming the packaged client library.

## Validation

- reproduced the original failure on `main`
- `mise run lint:fix`
- `./mvnw verify -pl integration-tests/it-spring-boot-smoke-test -am -Dcoverage.skip=true -Dwarnings=-nowarn`
- `mise run build`
- `mise run --skip-deps //.mise/envs/native:native-test -- -DskipTests`
- native-image generation passed the previous missing-test-configuration failure locally; final
  linking could not run because the local environment does not provide the static zlib artifact


