### PR TITLE
docs: document scrape query limits in request API

### DIFF
--- a/docs/content/exporters/filter.md
+++ b/docs/content/exporters/filter.md
@@ -23,7 +23,8 @@ params:
 
 For safety, exporters limit the query string to 65,536 characters and accept at most 1,024
 query parameters. The parameter limit counts every `&`-separated pair, including repeated
-parameters and empty pairs.
+parameters and empty pairs. These are fixed implementation limits and cannot be changed through
+runtime configuration.
 
 If a request exceeds either limit or contains invalid percent-encoding, the `/metrics` endpoint
 returns HTTP `400 Bad Request` with the plain-text response `Invalid query parameters`.

--- a/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusHttpRequest.java
+++ b/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusHttpRequest.java
@@ -44,11 +44,11 @@ public interface PrometheusHttpRequest extends PrometheusScrapeRequest {
   /**
    * See {@code jakarta.servlet.ServletRequest.getParameterValues(String)}.
    *
-   * <p>For safety, the default implementation applies two fixed limits: {@code
-   * maxQueryStringLength = 64 * 1024} (65,536 characters) and {@code maxQueryParameterCount =
-   * 1024} ({@code &}-separated parameter pairs). These implementation values are not exposed as
-   * runtime configuration. Requests that exceed either limit or contain invalid percent-encoding
-   * are rejected by the scrape handler with HTTP {@code 400 Bad Request}.
+   * <p>For safety, the default implementation applies two fixed limits: {@code maxQueryStringLength
+   * = 64 * 1024} (65,536 characters) and {@code maxQueryParameterCount = 1024} ({@code &}-separated
+   * parameter pairs). These implementation values are not exposed as runtime configuration.
+   * Requests that exceed either limit or contain invalid percent-encoding are rejected by the
+   * scrape handler with HTTP {@code 400 Bad Request}.
    */
   @Override
   @Nullable

--- a/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusHttpRequest.java
+++ b/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusHttpRequest.java
@@ -41,7 +41,13 @@ public interface PrometheusHttpRequest extends PrometheusScrapeRequest {
     }
   }
 
-  /** See {@code jakarta.servlet.ServletRequest.getParameterValues(String)} */
+  /**
+   * See {@code jakarta.servlet.ServletRequest.getParameterValues(String)}.
+   *
+   * <p>For safety, query strings are limited to 65,536 characters and 1,024 {@code &}-separated
+   * parameter pairs. Requests that exceed either limit or contain invalid percent-encoding are
+   * rejected by the scrape handler with HTTP {@code 400 Bad Request}.
+   */
   @Override
   @Nullable
   // decode with Charset is only available in Java 10+, but we want to support Java 8

--- a/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusHttpRequest.java
+++ b/prometheus-metrics-exporter-common/src/main/java/io/prometheus/metrics/exporter/common/PrometheusHttpRequest.java
@@ -44,9 +44,11 @@ public interface PrometheusHttpRequest extends PrometheusScrapeRequest {
   /**
    * See {@code jakarta.servlet.ServletRequest.getParameterValues(String)}.
    *
-   * <p>For safety, query strings are limited to 65,536 characters and 1,024 {@code &}-separated
-   * parameter pairs. Requests that exceed either limit or contain invalid percent-encoding are
-   * rejected by the scrape handler with HTTP {@code 400 Bad Request}.
+   * <p>For safety, the default implementation applies two fixed limits: {@code
+   * maxQueryStringLength = 64 * 1024} (65,536 characters) and {@code maxQueryParameterCount =
+   * 1024} ({@code &}-separated parameter pairs). These implementation values are not exposed as
+   * runtime configuration. Requests that exceed either limit or contain invalid percent-encoding
+   * are rejected by the scrape handler with HTTP {@code 400 Bad Request}.
    */
   @Override
   @Nullable


### PR DESCRIPTION
## Summary

- document the default implementation values `maxQueryStringLength = 64 * 1024` and `maxQueryParameterCount = 1024` in `PrometheusHttpRequest` JavaDoc
- clarify that these values are fixed implementation limits, not runtime configuration
- clarify that invalid or excessive query parameters produce HTTP 400

Follow-up to [prometheus/client_java#2334](https://github.com/prometheus/client_java/pull/2334) and [discussion_r3752169308](https://github.com/prometheus/client_java/pull/2334#discussion_r3752169308).

## Validation

- `mise run lint:fix` *(blocked by the pre-existing 403 response for the README CNCF Slack link; the push hook passed using a temporary local-only README substitution, restored before completion)*
- `mise run build`
- `./mvnw -pl prometheus-metrics-exporter-common test -Dcoverage.skip=true`
