### PR TITLE
fix: keep PR title check required after rebases

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -6,10 +6,12 @@ on:
     types:
       - opened
       - edited
+      - reopened
+      - synchronize
 permissions: {}
 
 jobs:
-  lint:
+  pr-title:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read # action-semantic-pull-request reads the PR title


### PR DESCRIPTION
## Summary

- rerun the PR title check after PR branch updates and reopen events
- give the title check a unique status context so it cannot be satisfied by the regular lint job

This closes the workflow gap observed on #2410, where Renovate rebased the branch, the failed title check remained attached to the previous SHA, and the successful regular `lint` job satisfied the required `lint` context.

After this PR merges, `pr-title` must be added as a distinct required check in the main-branch ruleset. Adding it before merge would block every existing PR because their merge commits still use the old `lint` job name.

## Validation

- `mise run lint:fix`
- `mise run lint`
- `pr-title` check passed on this PR with the new job name