### PR TITLE
fix: update component-prefixed action tags

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,14 @@
   labels: ["dependencies"],
   packageRules: [
     {
+      description: "Update component-prefixed shared-workflow action tags",
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["grafana/shared-workflows"],
+      matchCurrentValue: "/^.+[-/]v?\\d+\\.\\d+(?:\\.\\d+)?$/",
+      overrideDatasource: "github-tags",
+      versioning: "regex:^(?<compatibility>.*)[-/]v?(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?$",
+    },
+    {
       matchFileNames: ["mise.toml"],
       matchDepNames: ["java"],
       groupName: "java temurin",


### PR DESCRIPTION
## Summary
- add a targeted Renovate package rule for `grafana/shared-workflows` component-prefixed GitHub Action tags
- use GitHub tags and component-aware regex versioning so Renovate can update both the pinned digest and `lint-pr-title/v*` comment

This is the configuration workaround described in [Renovate discussion #45418](https://github.com/renovatebot/renovate/discussions/45418). @fstab

## Validation
- `mise run lint`
- `mise exec -- renovate-config-validator .github/renovate.json5`
- `GITHUB_COM_TOKEN=… LOG_LEVEL=debug mise exec -- renovate --platform=local --dry-run=lookup`
  - proposes `lint-pr-title/v1.2.3` → `lint-pr-title/v1.2.4`
  - proposes digest `823ed150196915a86971ab4beb899b0c80d835fe` → `70c40e5b6522c854a55334124545261cae3d4c73`

## AI assistance
This PR was written with AI assistance for the configuration, validation, and description; the result was reviewed locally.
