### PR TITLE
fix(ci): skip benchmark report for skipped runs

### DIFF
--- a/.github/workflows/pr-benchmark-report.yml
+++ b/.github/workflows/pr-benchmark-report.yml
@@ -16,7 +16,8 @@ jobs:
   comment:
     if: >
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion != 'cancelled'
+      github.event.workflow_run.conclusion != 'cancelled' &&
+      github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-24.04
     permissions:
       actions: read


### PR DESCRIPTION
The benchmark report workflow should comment only when the benchmark workflow actually executed.

This excludes skipped workflow runs, avoiding misleading “artifact was not found” comments while preserving reporting for completed runs.

Validation:
- mise run lint:fix
- git diff --check