### PR TITLE
refactor: drop redundant reference check in Labels.isEmpty()

### DIFF
--- a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/Labels.java
+++ b/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/Labels.java
@@ -40,9 +40,8 @@ public final class Labels implements Comparable<Labels>, Iterable<Label> {
     this.values = values;
   }
 
-  @SuppressWarnings("ReferenceEquality")
   public boolean isEmpty() {
-    return this == EMPTY || this.equals(EMPTY);
+    return this.equals(EMPTY);
   }
 
   /**


### PR DESCRIPTION
## What

Simplify `Labels.isEmpty()` by dropping the redundant `this == EMPTY` reference check.

## Why

`Labels.equals()` already begins with `if (this == o) return true;`, so `this.equals(EMPTY)` already returns `true` for the `EMPTY` singleton that the `this == EMPTY` clause guards. Removing the clause is therefore behavior-preserving, and it was the sole reason for the `@SuppressWarnings("ReferenceEquality")` annotation, which is removed as well.

```java
// before
@SuppressWarnings("ReferenceEquality")
public boolean isEmpty() {
  return this == EMPTY || this.equals(EMPTY);
}

// after
public boolean isEmpty() {
  return this.equals(EMPTY);
}
```

This also aligns `isEmpty()` with the rest of `Labels`, which already uses `this.equals(EMPTY)` (e.g. in `toString()`).

This pull request and its description were written by Isaac.