### PR TITLE
test: verify buffer recovery after snapshot failures

### DIFF
--- a/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Buffer.java
+++ b/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Buffer.java
@@ -95,43 +95,47 @@ class Buffer {
         expectedCount += observationCount.getAndAdd(bufferActiveBit);
       }
 
-      while (!complete.apply(expectedCount)) {
-        // Wait until all in-flight threads have added their observations to the histogram /
-        // summary.
-        // we can't use a condition here, because the other thread doesn't have a lock as it's on
-        // the fast path.
-        Thread.yield();
-      }
-      result = createResult.get();
-
-      // Signal that the buffer is inactive.
-      long expectedBufferSize = 0;
-      if (reset) {
-        for (AtomicLong observationCount : stripedObservationCounts) {
-          expectedBufferSize += observationCount.getAndSet(0) & ~bufferActiveBit;
-        }
-        reset = false;
-      } else {
-        for (AtomicLong observationCount : stripedObservationCounts) {
-          expectedBufferSize += observationCount.addAndGet(bufferActiveBit);
-        }
-      }
-      expectedBufferSize -= expectedCount;
-
-      appendLock.lock();
       try {
-        while (bufferPos < expectedBufferSize) {
-          // Wait until all in-flight threads have added their observations to the buffer.
-          bufferFilled.await();
+        while (!complete.apply(expectedCount)) {
+          // Wait until all in-flight threads have added their observations to the histogram /
+          // summary.
+          // we can't use a condition here, because the other thread doesn't have a lock as it's on
+          // the fast path.
+          Thread.yield();
         }
+        result = createResult.get();
       } finally {
-        appendLock.unlock();
-      }
+        // Signal that the buffer is inactive. This has to happen even when the block above throws:
+        // the bit is what makes append() buffer instead of record, so a bit left set sends every
+        // later run() into the wait loop above forever, holding runLock and with it the scrape.
+        long expectedBufferSize = 0;
+        if (reset) {
+          for (AtomicLong observationCount : stripedObservationCounts) {
+            expectedBufferSize += observationCount.getAndSet(0) & ~bufferActiveBit;
+          }
+          reset = false;
+        } else {
+          for (AtomicLong observationCount : stripedObservationCounts) {
+            expectedBufferSize += observationCount.addAndGet(bufferActiveBit);
+          }
+        }
+        expectedBufferSize -= expectedCount;
 
-      buffer = observationBuffer;
-      bufferSize = bufferPos;
-      observationBuffer = new double[0];
-      bufferPos = 0;
+        appendLock.lock();
+        try {
+          while (bufferPos < expectedBufferSize) {
+            // Wait until all in-flight threads have added their observations to the buffer.
+            bufferFilled.await();
+          }
+        } finally {
+          appendLock.unlock();
+        }
+
+        buffer = observationBuffer;
+        bufferSize = bufferPos;
+        observationBuffer = new double[0];
+        bufferPos = 0;
+      }
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     } finally {

--- a/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/BufferTest.java
+++ b/prometheus-metrics-core/src/test/java/io/prometheus/metrics/core/metrics/BufferTest.java
@@ -1,10 +1,32 @@
 package io.prometheus.metrics.core.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
 class BufferTest {
+
+  @Test
+  void bufferIsDeactivatedWhenCreateResultThrows() {
+    Buffer buffer = new Buffer();
+    assertThat(buffer.append(1.0)).isFalse();
+
+    assertThatThrownBy(
+            () ->
+                buffer.run(
+                    count -> true,
+                    () -> {
+                      throw new IllegalStateException("failed to create the snapshot");
+                    },
+                    value -> {}))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("failed to create the snapshot");
+
+    // The buffer has to be inactive again. While it stayed active, append() kept buffering
+    // observations instead of recording them, and the next run() never left its wait loop.
+    assertThat(buffer.append(2.0)).isFalse();
+  }
 
   @Test
   void stripeIndexDoesNotOverflowWhenThreadIdNarrowsToIntegerMinValue() {


### PR DESCRIPTION
## Problem

`Buffer.run()` sets the buffer-active bit on every striped observation counter, waits for
in-flight observations to land, calls `createResult.get()`, and then clears the bit again.
The surrounding `finally` only releases `runLock` — the bit-clearing block sits inside the
`try`, so when `createResult.get()` throws, the bit is left set permanently.

https://github.com/prometheus/client_java/blob/main/prometheus-metrics-core/src/main/java/io/prometheus/metrics/core/metrics/Buffer.java#L90-L139

Two things follow from a bit that stays set:

- `append()` keeps returning `true`, so observations go into the buffer instead of being
  recorded, and are replayed at an arbitrary later point.
- The next `run()` derives `expectedCount` from counters that still carry the sign bit, so
  `complete.apply(expectedCount)` may never be satisfied. The wait loop then spins on
  `Thread.yield()` indefinitely **while holding `runLock`**, which blocks every subsequent
  scrape of that registry.

Whether the second case spins or instead produces a corrupt snapshot depends on the number
of stripes, because `2 * Long.MIN_VALUE == 0`: the sign-bit contributions cancel out for an
even `Runtime.getRuntime().availableProcessors()`. With an even stripe count you get a run
whose buffer semantics are inverted (observations recorded directly rather than buffered,
i.e. a torn snapshot) rather than a hang. With an odd count — including the single
`AtomicLong` this code used before striping — the spin is deterministic.

Nothing clears the bit in-process, so the only recovery is a process restart.

## Fix

Move the wait-and-create block into its own `try`, with the "signal that the buffer is
inactive" step and the buffer drain in the matching `finally`.

The drain has to move with it rather than just the bit flip: leaving `bufferPos` set makes
the next `run()` skip its own wait and replay stale values on top of the new ones. The
arithmetic is unaffected on the exception path — `expectedCount` is computed before the
throw, so `expectedBufferSize -= expectedCount` still holds.

## Test

`BufferTest.bufferIsDeactivatedWhenCreateResultThrows` asserts the invariant rather than the
symptom: after `run()` returns *or* throws, the buffer must be inactive, probed directly via
`append()`. Using `count -> true` for `complete` keeps the test independent of the stripe
count, so it fails deterministically on any machine.

Verified both ways:

| | Result |
|---|---|
| With the fix, `BufferTest` | 2/2 pass |
| With the fix reverted | fails — `Expecting value to be false but was true` |
| With the fix, full `prometheus-metrics-core` suite | 166/166 pass |

## How we hit this

Found in production in Alluxio on `prometheus-metrics-core` 1.0.0. An `OutOfMemoryError`
raised inside `createResult.get()` — snapshot creation allocates several arrays per data
point, so it is a likely place for an allocation to fail — left the bit set and wedged the
`/metrics` endpoint of several workers for 4.5 days, until they were restarted. Three
separate data points were poisoned within 12 seconds of each other, consistent with a single
JVM-wide allocation failure rather than a race.

Note that `Buffer.run()` catches nothing, so an `Error` leaks the bit exactly as an exception
does.

## Relation to #2287

#2287 reports two things about this class: unbounded growth of `observationBuffer` in
`doAppend()`, and the `Thread.yield()` wait loop having no timeout. This PR fixes neither of
those directly — it removes the error path that makes the second one *permanent*. Without a
leaked active bit, the wait loop is a bounded spin over in-flight observations; with one, it
never terminates. So the two changes are complementary rather than overlapping, and I have
deliberately left the loop itself alone here to keep this diff reviewable.

## Notes

- The unbounded `Thread.yield()` wait loop is left as-is; this change only ensures a thrown
  exception cannot turn it into an infinite spin.
- Built and tested locally with JDK 24 (`-Dtest.java.version=24`), since `test.java.version`
  defaults to 25. Main sources are unaffected (`java.version=8`). I was not able to run
  `mise run lint` locally, so please let CI arbitrate formatting.


## Update after merging main

The original production change above is now superseded by the generation-based `Buffer`
implementation merged in #2336. This update merges the original PR with current `main` and
retains the original production rationale for historical context; no production code from this
PR remains in the resulting diff.

The retained regression coverage now exercises both `IllegalStateException` and
`AssertionError` from snapshot creation. Each test appends while the collection generation is
active, verifies the buffered observation is replayed exactly once, verifies a later append takes
the direct path, and completes a subsequent collection successfully. `BufferTest` passes 8/8,
`mise run lint:fix` passes, and `mise run build -- -DskipITs=true` passes (Docker integration
services are unavailable in this environment).
