### PR TITLE
fix: disable micrometer compat build cache

### DIFF
--- a/.mise/lib/micrometer_compat.py
+++ b/.mise/lib/micrometer_compat.py
@@ -153,6 +153,9 @@ def run_gradle_test(
     cmd = [
         "./gradlew",
         "--no-daemon",
+        # micrometer wires in a remote build cache into settings.gradle.
+        # compatibility tests have no use for upstream's cache
+        "--no-build-cache",
         "-I",
         str(init_script),
         ":micrometer-registry-prometheus:test",


### PR DESCRIPTION
The micrometer compat tests are failing because micrometer pins a remote build cache in their settings.gradle and the released tags point to a ge.micrometer.io which now 301s, so gradle is failing with "Not in GZIP format"